### PR TITLE
Fix METADATA.json for Istok Web font

### DIFF
--- a/ofl/istokweb/METADATA.json
+++ b/ofl/istokweb/METADATA.json
@@ -18,7 +18,7 @@
     {
       "name": "Istok Web",
       "style": "italic",
-      "weight": 500,
+      "weight": 700,
       "filename": "IstokWeb-BoldItalic.ttf",
       "postScriptName": "IstokWeb-BoldItalic",
       "fullName": "Istok Web Bold Italic",


### PR DESCRIPTION
Fix of METADATA.json for `Istok Web` font.
BoldItalic font weight is 700 not 500.

Below comment is just a report. Sorry, i am not sure that report it here or other place.

--

By the way, IstokWeb-BoldItalic.ttf looks similar with IstokWeb-Italic.ttf.
From https://code.google.com/p/istok/, i can download a bold-italic font which is not similar with IstokWeb-BoldItalic.ttf.
I guess that IstokWeb-BoldItalic.ttf is wrong file?

And https://www.google.com/fonts#QuickUsePlace:quickUse/Family:Istok+Web also looks strange, because bold-italic font looks similiar with italic font.
I am not sure that github has consistent with google.com/fonts, or not, in google.com/fonts has weight 400 and 700, but in github has weight 500 and 700.