### PR TITLE
Fira Mono: Correct category in METADATA.json

### DIFF
--- a/ofl/firamono/METADATA.json
+++ b/ofl/firamono/METADATA.json
@@ -3,7 +3,7 @@
   "designer": "Carrois and Edenspiekermann",
   "license": "OFL",
   "visibility": "Sandbox",
-  "category": "Sans Serif",
+  "category": "Monospace",
   "size": 64822,
   "fonts": [
     {


### PR DESCRIPTION
I guess that Fira Mono font category is Monospace.