### PR TITLE
latin_unique-glyphs.nam: Add 0x2026 ellipsis

### DIFF
--- a/tools/encodings/latin_unique-glyphs.nam
+++ b/tools/encodings/latin_unique-glyphs.nam
@@ -206,6 +206,7 @@
 0x201D quotedblright
 0x201E quotedblbase
 0x2022 bullet
+0x2026 ellipsis
 0x2039 guilsinglleft
 0x203A guilsinglright
 0x2044 fraction


### PR DESCRIPTION
Users report problems with our fonts as wordpress and other rich text systems automatically replace 3 `.` with the unicode character `…`, so I propose to add this to the latin subsets where available, and in time add it to all the fonts