### PR TITLE
Add instructions for installing on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ You can also sync the collection with git, so that you can update by only fetchi
 To learn how to use git, Github provides [illustrated guides](https://guides.github.com) and a [youtube channel](https://www.youtube.com/user/GitHubGuides), and a [learning game that takes just 15 minutes](https://try.github.io). 
 Free, open source git applications are available for [Windows](https://msysgit.github.io) and [Mac OS X](http://gitx.laullon.com).
 
+### Install on Windows
+
+You can install all of the fonts using power shell. Change directories to the root folder where you downloaded the package, and run the following command:
+```
+$fonts = (New-Object -ComObject Shell.Application).Namespace(0x14)
+dir ofl/*/*.ttf | %{ $fonts.CopyHere($_.fullname) }
+```
+
 ## Licensing
 
 It is important to always read the license for every font that you use.


### PR DESCRIPTION
I added instructions for installing all the fonts on Windows. Not sure if this fits within the repo or is necessary, but I figured it might be helpful and allow people to use these fonts easier.