### PR TITLE
tools/sanity_check.py: Add Unicode escaper

### DIFF
--- a/tools/sanity_check.py
+++ b/tools/sanity_check.py
@@ -14,6 +14,17 @@ import gflags as flags
 
 from util import google_fonts as fonts
 
+# make a unicode escaper
+if sys.version < '3':
+    import codecs
+    def u(x):
+        if not x:
+            return ''
+        return codecs.unicode_escape_decode(x)[0]
+else:
+    def u(x):
+        return x
+
 FLAGS = flags.FLAGS
 
 flags.DEFINE_boolean('suppress_pass', True, 'Whether to print pass: results')
@@ -341,6 +352,7 @@ def _CheckFontNameValues(path, name, font, ttf):
     # If you have lots of name records they should ALL have the right value
     actuals = fonts.ExtractNames(ttf, name_id)
     for (idx, actual) in enumerate(actuals):
+      actual = u(actual)
       results.append(ResultMessageTuple(
           expected == actual,
           '%s %s/%d \'name\' %s[%d] expected %s, got %s' %


### PR DESCRIPTION
@rsheeter There's a problem with the `sanity_check.py` in dealing with name IDs that have non-ascii unicode text:

```
$ cd ~/fonts/ofl/eczar; python ../../tools/sanity_check.py . ;
../../tools/sanity_check.py:345: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  expected == actual,
Traceback (most recent call last):
  File "../../tools/sanity_check.py", line 467, in <module>
    app.run()
  File "/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/google/apputils/app.py", line 238, in run
    return _actual_start()
  File "/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/google/apputils/app.py", line 267, in _actual_start
    really_start()
  File "/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/google/apputils/app.py", line 220, in really_start
    sys.exit(main(argv))
  File "../../tools/sanity_check.py", line 450, in main
    results = _SanityCheck(font_dir)
  File "../../tools/sanity_check.py", line 77, in _SanityCheck
    results.extend(_CheckFontInternalValues(path))
  File "../../tools/sanity_check.py", line 380, in _CheckFontInternalValues
    results.extend(_CheckFontNameValues(path, name, font, ttf))
  File "../../tools/sanity_check.py", line 347, in _CheckFontNameValues
    (name, style, weight, friendly_name, idx, expected, actual),
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe0 in position 0: ordinal not in range(128)
$
```

This pull request makes a workaround for this which is not ideal, as the unicode characters are still not correctly read, but doesn't raise an exception. 

```
$ cd ~/fonts/ofl/eczar; python ../../tools/sanity_check.py . ;
FAIL: Dir license != METADATA license:  != OFL (.)
FAIL: Eczar normal/400 'name' family[1] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° (.)
FAIL: Eczar normal/400 'name' family[2] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° (.)
FAIL: Eczar normal/400 'name' family[3] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° (.)
FAIL: Eczar normal/400 'name' fullName[1] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° (.)
FAIL: Eczar normal/400 'name' fullName[2] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° (.)
FAIL: Eczar normal/400 'name' fullName[3] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° (.)
FAIL: Eczar normal/500 'name' family[0] expected Eczar, got Eczar Medium (.)
FAIL: Eczar normal/500 'name' family[1] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° Medium (.)
FAIL: Eczar normal/500 'name' family[2] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° Me (.)
FAIL: Eczar normal/500 'name' family[3] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° Medium (.)
FAIL: Eczar normal/500 'name' fullName[1] expected Eczar Medium, got à¤à¤à¥à¤à¤¼à¤° Medium (.)
FAIL: Eczar normal/500 'name' fullName[2] expected Eczar Medium, got à¤à¤à¥à¤à¤¼à¤° Medium (.)
FAIL: Eczar normal/500 'name' fullName[3] expected Eczar Medium, got à¤à¤à¥à¤à¤¼à¤° Medium (.)
FAIL: Eczar normal/600 'name' family[0] expected Eczar, got Eczar SemiBold (.)
FAIL: Eczar normal/600 'name' family[1] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° SemiBold (.)
FAIL: Eczar normal/600 'name' family[2] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° SemiBold (.)
FAIL: Eczar normal/600 'name' family[3] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° SemiBold (.)
FAIL: Eczar normal/600 'name' fullName[1] expected Eczar SemiBold, got à¤à¤à¥à¤à¤¼à¤° SemiBold (.)
FAIL: Eczar normal/600 'name' fullName[2] expected Eczar SemiBold, got à¤à¤à¥à¤à¤¼à¤° SemiBold (.)
FAIL: Eczar normal/600 'name' fullName[3] expected Eczar SemiBold, got à¤à¤à¥à¤à¤¼à¤° SemiBold (.)
FAIL: Eczar normal/700 'name' family[1] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° (.)
FAIL: Eczar normal/700 'name' family[2] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° (.)
FAIL: Eczar normal/700 'name' family[3] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° (.)
FAIL: Eczar normal/700 'name' fullName[1] expected Eczar Bold, got à¤à¤à¥à¤à¤¼à¤° Bold (.)
FAIL: Eczar normal/700 'name' fullName[2] expected Eczar Bold, got à¤à¤à¥à¤à¤¼à¤° Bold (.)
FAIL: Eczar normal/700 'name' fullName[3] expected Eczar Bold, got à¤à¤à¥à¤à¤¼à¤° Bold (.)
FAIL: Eczar normal/800 'name' family[0] expected Eczar, got Eczar ExtraBold (.)
FAIL: Eczar normal/800 'name' family[1] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° ExtraBold (.)
FAIL: Eczar normal/800 'name' family[2] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° ExtraBold (.)
FAIL: Eczar normal/800 'name' family[3] expected Eczar, got à¤à¤à¥à¤à¤¼à¤° ExtraBold (.)
FAIL: Eczar normal/800 'name' fullName[1] expected Eczar ExtraBold, got à¤à¤à¥à¤à¤¼à¤° ExtraBold (.)
FAIL: Eczar normal/800 'name' fullName[2] expected Eczar ExtraBold, got à¤à¤à¥à¤à¤¼à¤° ExtraBold (.)
FAIL: Eczar normal/800 'name' fullName[3] expected Eczar ExtraBold, got à¤à¤à¥à¤à¤¼à¤° ExtraBold
$
```

There may be a better way to do this, though...