### PR TITLE
tools/add_font.py Include *-ext subsets if any support

### DIFF
--- a/tools/add_font.py
+++ b/tools/add_font.py
@@ -58,8 +58,16 @@ def _MakeMetadata(fontdir):
   """
   file_family_style_weights = _FileFamilyStyleWeights(fontdir)
 
+  # include subset keys when the first font in a family has at least 
+  # 50% of the characters in a subset
   first_file = file_family_style_weights[0].file
   subsets = ['menu'] + [s[0] for s in fonts.SubsetsInFont(first_file, 50)]
+  # make an exception for -ext subsets, include them if any support exists
+  for s in fonts.SubsetsInFont(first_file, 0):
+      if s[0].endswith("-ext"):
+          subsets.append(s[0])
+  # sort and uniq the subsets list
+  subsets = sorted(set(subsets))
 
   font_license = fonts.LicenseFromPath(fontdir)
 

--- a/tools/what_subsets.py
+++ b/tools/what_subsets.py
@@ -18,8 +18,8 @@ flags.DEFINE_integer('min_pct', 0,
 def main(argv):
   for arg in argv[1:]:
     for (subset, available, total) in fonts.SubsetsInFont(arg, FLAGS.min_pct):
-      print '%s %s %d/%d' % (os.path.basename(arg), subset, available, total)
-
+      percent = 100 * float(available) / float(total)
+      print '%s %s %03d/%d %02d%%' % (os.path.basename(arg), subset, available, total, percent)
 
 if __name__ == '__main__':
   app.run()


### PR DESCRIPTION
>> @davelab6: I also noticed that it doesn't automatically add latin-ext subsets when I would do so; since latin-ext, greek-ext, and cyrillic-ext are 'catch all' subsets defined much larger than most fonts that have characters outside their regular subsets, perhaps a special case for this subset would be good, where if any characters in these 3 -ext subsets are found, the METADATA enables this subset. 
>
> @rsheeter: Today add_font uses 50% coverage as the mark for supporting a subset. We could do per-subset limits but that sounds potentially surprising. What if we just said 25% is the mark or something like that?

I checked and I've used a very low bar for `-ext` subsets. 

    python add_font.py ../apache/calligraffitti/
    Calligraffitti-Regular.ttf latin 212/219
    Calligraffitti-Regular.ttf latin-ext 7/810 

Also this supersedes https://github.com/google/fonts/pull/200 that follows up on #191 to prevent further regressions
