### PR TITLE
tools/add_font.py Fix bug with directory path

### DIFF
--- a/tools/add_font.py
+++ b/tools/add_font.py
@@ -143,7 +143,7 @@ def main(argv):
   if os.path.isfile(desc):
     print 'DESCRIPTION.en_us.html exists'
   else:
-    _WriteTextFile(os.path.join(fontdir, desc), 'N/A')
+    _WriteTextFile(desc, 'N/A')
 
   _WriteTextFile(os.path.join(fontdir, 'METADATA.pb'), text_proto)
 


### PR DESCRIPTION
https://github.com/google/fonts/commit/fda31f226a0cac029ce29f5b61a538c6ce8efda5 introduced a bug where `os.path.join()` was being called twice when the DESCRIPTION file did not already exist. 

This fixes it.