### PR TITLE
unicode_names.py Fix arg parsing

### DIFF
--- a/tools/unicode_names.py
+++ b/tools/unicode_names.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import unicodedata
+import unicodedata, sys
 
 from google.apputils import app
 import gflags as flags
 
 FLAGS = flags.FLAGS
 
-flags.DEFINE_string('nam_file', '', 'Location of file containing the codepoints')
+flags.DEFINE_string('nam_file', sys.argv[1], 'Location of file containing the codepoints')
 
 
 def main(_):


### PR DESCRIPTION
@nyshadhr9 please review :)

https://github.com/google/fonts/blob/master/tools/unicode_names.py didn't work for me, it seemed the arg parsing wasn't working; this is a rudimentary fix but there may be a better solution :)

```py
$ cd fonts/tools ;
$ python unicode_names.py encodings/cyrillic_unique-glyphs.nam ;
Traceback (most recent call last):
  File "unicode_names.py", line 28, in <module>
    app.run()
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/google/apputils/app.py", line 238, in run
    return _actual_start()
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/google/apputils/app.py", line 267, in _actual_start
    really_start()
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/google/apputils/app.py", line 220, in really_start
    sys.exit(main(argv))
  File "unicode_names.py", line 14, in main
    with open(FLAGS.nam_file, 'r') as f:
IOError: [Errno 2] No such file or directory: ''
```