### PR TITLE
Update size for download all google fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you find a problem with a font file, or have a request for future development
 
 ## Download All Google Fonts
 
-You can download all Google Fonts in a simple ZIP snapshot (over 250Mb) from <https://github.com/google/fonts/archive/master.zip>
+You can download all Google Fonts in a simple ZIP snapshot (over 300Mb) from <https://github.com/google/fonts/archive/master.zip>
 
 #### Sync With Git
 


### PR DESCRIPTION
the size 250Mb is false, because m4rc1e have added the fonts, me i download as tar.gz (not zip).