### PR TITLE
comfortaa: Fixed METADATA.pb.

### DIFF
--- a/ofl/comfortaa/METADATA.pb
+++ b/ofl/comfortaa/METADATA.pb
@@ -32,6 +32,7 @@ fonts {
 }
 subsets: "cyrillic"
 subsets: "cyrillic-ext"
+subsets: "greek"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"


### PR DESCRIPTION
Greek subset was unintentionally removed by add_font.py on last generation.