### PR TITLE
Add visibility field in tools/fonts_public.proto

### DIFF
--- a/tools/fonts_public.proto
+++ b/tools/fonts_public.proto
@@ -13,10 +13,11 @@ message FamilyProto {
   required string designer = 2;
   required string license = 3;
   required string category = 4;
-  required string date_added = 5;
-  repeated FontProto fonts = 6;
-  repeated string aliases = 7;
-  repeated string subsets = 8;
+  optional string visibility = 5;
+  required string date_added = 6;
+  repeated FontProto fonts = 7;
+  repeated string aliases = 8;
+  repeated string subsets = 9;
 };
 
 message FontProto {


### PR DESCRIPTION
Currently, `visibility` field exists in [ofl/ekmukta/METADATA.pb](https://github.com/google/fonts/blob/master/ofl/ekmukta/METADATA.pb#L5), but, `visibility` field is not defined in `FamilyProto` in tools/fonts_public.proto.

This PR add visibility field in tools/fonts_public.proto.