### PR TITLE
add_font.py: --update metadata option

### DIFF
--- a/tools/add_font.py
+++ b/tools/add_font.py
@@ -1,4 +1,28 @@
+"""
+add_font.py:
+~~~~~~~~~~~~
 
+Generate METADATA.pb files for font families.
+
+METADATA.pb files are used to serve the families on http://fonts.google.com.
+
+Font families are stored in this repo by license type. The following
+directories contain font families:
+
+../fonts/ofl
+../fonts/apache
+../fonts/ufl
+
+
+Generating a METADATA.pb file for a new family:
+
+1. Determine the family's license type, ofl, ufl or apache
+2. Create a new folder under the license type directory
+3. Name the folder so it's the family name, all lowercase and no spaces.
+4. Run the following: python add_font.py /path/to/new/family
+5. Update the category field in the generated METADATA.pb file.
+
+"""
 import errno
 import glob
 import os
@@ -134,7 +158,7 @@ def _WriteTextFile(filename, text):
 
 
 def main(args=None):
-  parser = ArgumentParser()
+  parser = ArgumentParser(description=__doc__)
   parser.add_argument('fontdir',
                       help='path to font family')
   args = parser.parse_args()

--- a/tools/add_font.py
+++ b/tools/add_font.py
@@ -22,6 +22,11 @@ Generating a METADATA.pb file for a new family:
 4. Run the following: python add_font.py /path/to/new/family
 5. Update the category field in the generated METADATA.pb file.
 
+
+Generating a METADATA.pb file for an existing family:
+
+1. run the following: python add_font.py /path/to/existing/family --update
+
 """
 import errno
 import glob

--- a/tools/add_font.py
+++ b/tools/add_font.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 import time
+from argparse import ArgumentParser
 
 import fonts_public_pb2 as fonts_pb2
 from google.protobuf import text_format
@@ -132,21 +133,22 @@ def _WriteTextFile(filename, text):
 
 
 
-def main(argv):
-  if len(argv) != 2:
-    sys.exit('One argument, a directory containing a font family')
-  fontdir = argv[1]
+def main(args=None):
+  parser = ArgumentParser()
+  parser.add_argument('fontdir',
+                      help='path to font family')
+  args = parser.parse_args()
 
-  metadata = _MakeMetadata(fontdir)
+  metadata = _MakeMetadata(args.fontdir)
   text_proto = text_format.MessageToString(metadata)
 
-  desc = os.path.join(fontdir, 'DESCRIPTION.en_us.html')
+  desc = os.path.join(args.fontdir, 'DESCRIPTION.en_us.html')
   if os.path.isfile(desc):
     print 'DESCRIPTION.en_us.html exists'
   else:
     _WriteTextFile(desc, 'N/A')
 
-  _WriteTextFile(os.path.join(fontdir, 'METADATA.pb'), text_proto)
+  _WriteTextFile(os.path.join(args.fontdir, 'METADATA.pb'), text_proto)
 
 
 


### PR DESCRIPTION
Currently, when you run [add_font.py](https://github.com/google/fonts/blob/master/tools/add_font.py) It will add placeholders for 'designer', 'category' and 'date added' fields. 
https://github.com/google/fonts/blob/master/tools/add_font.py#L82-L83

I've been upgrading a lot of families so I need to retain these from the previous release. To do this, I've used the metadata api end point.