### PR TITLE
cinzel: added Latin-ext codepage.

### DIFF
--- a/ofl/cinzel/METADATA.pb
+++ b/ofl/cinzel/METADATA.pb
@@ -31,4 +31,5 @@ fonts {
   copyright: "Copyright  2012 Natanael Gama (info@ndiscovered.com), with Reserved Font Name \'Cinzel\'"
 }
 subsets: "latin"
+subsets: "latin-ext"
 subsets: "menu"


### PR DESCRIPTION
#722 reported that the family has latin-ext characters.

I reran the family through add_font.py and it found there were suffcieint glyphs to enable the codepage