### PR TITLE
Fix incorrectly-classified Protobuf files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pb linguist-language=protobuf


### PR DESCRIPTION
GitHub currently classifies this repository as a PureBasic codebase, due to the abundance of [`METADATA.pb` files](https://github.com/google/fonts/search?l=purebasic):

<img src="https://user-images.githubusercontent.com/2346707/28498934-42288cc2-6fed-11e7-96a3-2264fea2175b.png" width="572" alt="Figure 1" />

Setting a `linguist-language` attribute will fix both miscategorised files and syntax highlighting [currently missing](https://github.com/google/fonts/blob/480630de320cc119f8fc516ea6a55fbfd5232db0/apache/aclonica/METADATA.pb) from every `METADATA.pb` file:

~~~console
λ Google-Fonts (fix-misclassification): ~/Forks/GitHub-Linguist/bin/linguist .
55.31%  Protocol Buffer
44.69%  HTML
λ Google-Fonts (fix-misclassification):
~~~

More information about overriding auto-detected languages [can be found here](https://github.com/github/linguist#overrides). =)