### PR TITLE
Add Aref Ruqaa designers

### DIFF
--- a/ofl/arefruqaa/METADATA.pb
+++ b/ofl/arefruqaa/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Aref Ruqaa"
-designer: "Multiple Designers"
+designer: "Abdullah Aref, Khaled Hosny, Hermann Zapf"
 license: "OFL"
 category: "SERIF"
 date_added: "2016-06-20"


### PR DESCRIPTION
The Arabic is done by Abdullah Aref and Khaled Hosny, while the Latin is based on Hermann Zapf’s AMS Euler.