### PR TITLE
tools/README.md mention tools depend on submodule GlyphsInfo

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -34,7 +34,8 @@ These can be installed with pip:
     sudo easy_install pip;
     pip install --user google-apputils protobuf git+git://github.com/behdad/fonttools.git;
 
-These tools depend on the submodule [GlyphsInfo](https://github.com/schriftgestalt/GlyphsInfo). Make sure the submodule is up to date by running:
+These tools depend on the submodule [GlyphsInfo](https://github.com/schriftgestalt/GlyphsInfo).
+Make sure the submodule is up to date by running:
 
     git submodule update --init --recursive
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -34,6 +34,10 @@ These can be installed with pip:
     sudo easy_install pip;
     pip install --user google-apputils protobuf git+git://github.com/behdad/fonttools.git;
 
+These tools depend on the submodule [GlyphsInfo](https://github.com/schriftgestalt/GlyphsInfo). Make sure the submodule is up to date by running:
+
+    git submodule update --init --recursive
+
 ## License
 
 The tools and files under this directory are available under the Apache License v2.0, for details see [LICENSE.txt](LICENSE.txt)


### PR DESCRIPTION
When users clone the repository, they may not be aware that it depends on the submodule [GlyphsInfo](https://github.com/schriftgestalt/GlyphsInfo), #1174. In order for users to run the tools in this repository, this submodule must always be kept up to date.