### PR TITLE
remove dead link to designers' G+ pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Subdirectories are named according to the family name of the fonts within.
 
 Each family subdirectory contains the  `.ttf` font files served by Google Fonts, plus a `METADATA.pb` file with metadata for the family, and a `DESCRIPTION.en_us.html` with a description of the family in US English.
 
-Also, [/designers](designers) contains a list of the Google+ pages for the fonts' designers.
-
 ## Bug reports and improvement requests
 
 If you find a problem with a font file or have a request for future development of a font project, please [create a new issue in this project's issue tracker](https://github.com/google/fonts/issues).


### PR DESCRIPTION
There's a link in the README that results in a 404 because the file/folder it used to link to got removed at some point.

I was specifically looking for info on designers as the API doesn't provide that, and then was extra disappointed when I found out the advertised file didn't exist. (;

I submitted a CLA btw.