### PR TITLE
Improve metadata description

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Subdirectories are named according to the family name of the fonts within.
 
 Each family subdirectory contains the  `.ttf` font files served by Google Fonts, plus a `METADATA.pb` file with metadata for the family, and a `DESCRIPTION.en_us.html` with a description of the family in US English.
 
-Also, [/designers](designers) contains a list of the Google+ pages for the fonts' designers.
-
 ## Bug reports and improvement requests
 
 If you find a problem with a font file or have a request for future development of a font project, please [create a new issue in this project's issue tracker](https://github.com/google/fonts/issues).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project contains the binary font files served by Google Fonts: https://font
 The top level directories indicate the license of all files found within them.
 Subdirectories are named according to the family name of the fonts within. 
 
-Each family subdirectory contains the  `.ttf` font files served by Google Fonts, plus a `METADATA.pb` file with metadata for the family, and a `DESCRIPTION.en_us.html` with a description of the family in US English. The `METADATA.pb` file also contains information on a font's designer(s) and license.
+Each family subdirectory contains the  `.ttf` font files served by Google Fonts, plus a `METADATA.pb` file with metadata for the family (such as information on the project designer(s), genre category, and license - [learn more](https://github.com/googlefonts/gf-docs/tree/master/METADATA)) and a `DESCRIPTION.en_us.html` with a description of the family in US English.
 
 ## Bug reports and improvement requests
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project contains the binary font files served by Google Fonts: https://font
 The top level directories indicate the license of all files found within them.
 Subdirectories are named according to the family name of the fonts within. 
 
-Each family subdirectory contains the  `.ttf` font files served by Google Fonts, plus a `METADATA.pb` file with metadata for the family, and a `DESCRIPTION.en_us.html` with a description of the family in US English.
+Each family subdirectory contains the  `.ttf` font files served by Google Fonts, plus a `METADATA.pb` file with metadata for the family, and a `DESCRIPTION.en_us.html` with a description of the family in US English. The `METADATA.pb` file also contains information on a font's designer(s) and license.
 
 ## Bug reports and improvement requests
 


### PR DESCRIPTION
This builds on #1745, but is more a suggestion for a slight content improvement than a fix, so I thought it might be better to separate it out.

It adds a little more context to the description of `METADATA.pb` files for anyone looking to find out more about individual font designers.