### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can download all Google Fonts in a simple ZIP snapshot (over 300MB) from <ht
 
 You can also sync the collection with git so that you can update by only fetching what has changed.
 To learn how to use git, Github provides [illustrated guides](https://guides.github.com) and a [youtube channel](https://www.youtube.com/user/GitHubGuides), and a [learning game that takes just 15 minutes](https://try.github.io). 
-Free, open source git applications are available for [Windows](https://msysgit.github.io) and [Mac OS X](http://gitx.laullon.com).
+Free, open source git applications are available for [Windows](https://git-scm.com/download/gui/windows) and [Mac OS X](https://git-scm.com/download/gui/mac).
 
 ## Licensing
 


### PR DESCRIPTION
**GitX** hasn't been in active development for 10 years, and the **Laullon** fork died five years ago. **MSYSGIT** also ceased development around the same time.

However, `git-scm.com` provides a comprehensive list of user-friendly and intuitive Git GUIs for those who don't want to use the command line or might not be as savvy with it. It's probably best to send users there.

Either way, these links need to be updated, because they're both out of date.