### PR TITLE
heptaslab: update METADATA.pb

### DIFF
--- a/ofl/heptaslab/METADATA.pb
+++ b/ofl/heptaslab/METADATA.pb
@@ -6,7 +6,7 @@ date_added: "2018-09-19"
 fonts {
   name: "Hepta Slab"
   style: "normal"
-  weight: 400
+  weight: 200
   filename: "HeptaSlab[wght].ttf"
   post_script_name: "HeptaSlab-ExtraLight"
   full_name: "Hepta Slab ExtraLight"


### PR DESCRIPTION
This is currently set incorrectly. The default VF instance is the ExtraLight so the weight has been changed to 200.

cc @nathan-williams 