### PR TITLE
Descriptions updated for 6 families 

### DIFF
--- a/ofl/almendra/DESCRIPTION.en_us.html
+++ b/ofl/almendra/DESCRIPTION.en_us.html
@@ -7,7 +7,7 @@ dialectic elements, especially balancing legibility and formal identity.
 Almendra was selected to be exhibited at the Bienal Iberoamericana de Diseo
 in 2010 and was part of the German editorial project Typodarium 2012.</p>
 
-<p>This is the Regular family, and there are sister
+<p>The two other siblings are the:
 <a href="http://www.google.com/fonts/specimen/Almendra+SC">Small Cap</a> and 
 <a href="http://www.google.com/fonts/specimen/Almendra+Display">Display</a>
 families.</p>

--- a/ofl/almendradisplay/DESCRIPTION.en_us.html
+++ b/ofl/almendradisplay/DESCRIPTION.en_us.html
@@ -1,4 +1,5 @@
-<p>Almendra is a typeface design based on calligraphy. Its style is related to
+<p>Almendra Display is an elegant type with thin strokes that belongs to the Almendra family. 
+Almendra is a typeface design based on calligraphy. Its style is related to
 the chancery and gothic hands. It is intended to be used in long texts,
 especially young children's literature. Almendra's black and white forms
 generate a nice texture in small sizes, while its many details appear when
@@ -7,7 +8,7 @@ dialectic elements, especially balancing legibility and formal identity.
 Almendra was selected to be exhibited at the Bienal Iberoamericana de Diseno
 in 2010 and was part of the German editorial project Typodarium 2012.</p>
 
-<p>This is the Display family, and there are sister
+<p>The two other siblings are the:
 <a href="http://www.google.com/fonts/specimen/Almendra">Regular</a> and 
 <a href="http://www.google.com/fonts/specimen/Almendra+SC">Small Cap</a>
 families.</p>

--- a/ofl/almendrasc/DESCRIPTION.en_us.html
+++ b/ofl/almendrasc/DESCRIPTION.en_us.html
@@ -1,4 +1,5 @@
-<p>Almendra is a typeface design based on calligraphy. Its style is related to
+<p>Almendra SC is the evenly spaced-out small cap version of the Almendra family - 
+a typeface design based on calligraphy. Its style is related to
 the chancery and gothic hands. It is intended to be used in long texts,
 especially young children's literature. Almendra's black and white forms
 generate a nice texture in small sizes, while its many details appear when
@@ -7,7 +8,7 @@ dialectic elements, especially balancing legibility and formal identity.
 Almendra was selected to be exhibited at the Bienal Iberoamericana de Diseo
 in 2010 and was part of the German editorial project Typodarium 2012.</p>
 
-<p>This is the Small Cap family, and there are sister
+<p>The two other siblings are the: 
 <a href="http://www.google.com/fonts/specimen/Almendra">Regular</a> and 
 <a href="http://www.google.com/fonts/specimen/Almendra+Display">Display</a>
 families.</p>

--- a/ofl/baloo/DESCRIPTION.en_us.html
+++ b/ofl/baloo/DESCRIPTION.en_us.html
@@ -24,7 +24,7 @@ Each font supports one Indic subset plus Latin, Latin Extended, and Vietnamese.
 <li><a href="https://fonts.google.com/specimen/Baloo+Thambi">Baloo Thambi</a> for Tamil</li>
 </ul></p>
 <p>
-Baloo Devanagari is designed by Sarang Kulkarni.Type design assistance and font engineering by Girish Dalvi.
+Baloo Devanagari is designed by Sarang Kulkarni. Type design assistance and font engineering by Girish Dalvi.
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/EkType/Baloo">github.com/EkType/Baloo</a>

--- a/ofl/baloo/DESCRIPTION.en_us.html
+++ b/ofl/baloo/DESCRIPTION.en_us.html
@@ -24,13 +24,7 @@ Each font supports one Indic subset plus Latin, Latin Extended, and Vietnamese.
 <li><a href="https://fonts.google.com/specimen/Baloo+Thambi">Baloo Thambi</a> for Tamil</li>
 </ul></p>
 <p>
-Well fed and thoroughly nourished across every script, it took a team of committed type designers to rear Baloo and raise it to be the typeface we love. 
-Baloo Devanagari is designed by Sarang Kulkarni, Gurmukhi by Shuchita Grover, Bangla by Noopur Datye, Oriya by Manish Minz and Shuchita Grover, Gujarati by Supriya Tembe and Noopur Datye, Kannada by Divya Kowshik, Telugu by Omkar Shende, Malayalam by Maithili Shingre, Urdu by Devika Bhansali and Tamil by Aadarsh Rajan.
-Baloo Latin is collaboratively designed by Ek Type. 
-Type design assistance and font engineering by Girish Dalvi.
-</p>
-<p>
-Baloo is grateful to Sulekha Rajkumar, Vaishnavi Murthy, Gangadharan Menon, Vinay Saynekar, Dave Crossland and others for their involvement, suggestions and feedback. 
+Baloo Devanagari is designed by Sarang Kulkarni.Type design assistance and font engineering by Girish Dalvi.
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/EkType/Baloo">github.com/EkType/Baloo</a>

--- a/ofl/baloobhai/DESCRIPTION.en_us.html
+++ b/ofl/baloobhai/DESCRIPTION.en_us.html
@@ -24,13 +24,7 @@ Each font supports one Indic subset plus Latin, Latin Extended, and Vietnamese.
 <li><a href="https://fonts.google.com/specimen/Baloo+Thambi">Baloo Thambi</a> for Tamil</li>
 </ul></p>
 <p>
-Well fed and thoroughly nourished across every script, it took a team of committed type designers to rear Baloo and raise it to be the typeface we love. 
-Baloo Devanagari is designed by Sarang Kulkarni, Gurmukhi by Shuchita Grover, Bangla by Noopur Datye, Oriya by Manish Minz and Shuchita Grover, Gujarati by Supriya Tembe and Noopur Datye, Kannada by Divya Kowshik, Telugu by Omkar Shende, Malayalam by Maithili Shingre, Urdu by Devika Bhansali and Tamil by Aadarsh Rajan.
-Baloo Latin is collaboratively designed by Ek Type. 
-Type design assistance and font engineering by Girish Dalvi.
-</p>
-<p>
-Baloo is grateful to Sulekha Rajkumar, Vaishnavi Murthy, Gangadharan Menon, Vinay Saynekar, Dave Crossland and others for their involvement, suggestions and feedback. 
+Baloo Bhai for Gujarati is designed by Supriya Tembe and Noopur Datye. Type design assistance and font engineering by Girish Dalvi.
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/EkType/Baloo">github.com/EkType/Baloo</a>

--- a/ofl/baloobhaijaan/DESCRIPTION.en_us.html
+++ b/ofl/baloobhaijaan/DESCRIPTION.en_us.html
@@ -24,13 +24,7 @@ Each font supports one Indic subset plus Latin, Latin Extended, and Vietnamese.
 <li><a href="https://fonts.google.com/specimen/Baloo+Thambi">Baloo Thambi</a> for Tamil</li>
 </ul></p>
 <p>
-Well fed and thoroughly nourished across every script, it took a team of committed type designers to rear Baloo and raise it to be the typeface we love.
-Baloo Devanagari is designed by Sarang Kulkarni, Gurmukhi by Shuchita Grover, Bangla by Noopur Datye, Oriya by Manish Minz and Shuchita Grover, Gujarati by Supriya Tembe and Noopur Datye, Kannada by Divya Kowshik, Telugu by Omkar Shende, Malayalam by Maithili Shingre, Urdu by Devika Bhansali and Tamil by Aadarsh Rajan.
-Baloo Latin is collaboratively designed by Ek Type.
-Type design assistance and font engineering by Girish Dalvi.
-</p>
-<p>
-Baloo is grateful to Sulekha Rajkumar, Vaishnavi Murthy, Gangadharan Menon, Vinay Saynekar, Dave Crossland and others for their involvement, suggestions and feedback.
+Baloo Bhaijaan for Urdu is designed by Devika Bhansali. Type design assistance and font engineering by Girish Dalvi.
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/EkType/Baloo">github.com/EkType/Baloo</a>

--- a/ofl/baloobhaina/DESCRIPTION.en_us.html
+++ b/ofl/baloobhaina/DESCRIPTION.en_us.html
@@ -24,13 +24,7 @@ Each font supports one Indic subset plus Latin, Latin Extended, and Vietnamese.
 <li><a href="https://fonts.google.com/specimen/Baloo+Thambi">Baloo Thambi</a> for Tamil</li>
 </ul></p>
 <p>
-Well fed and thoroughly nourished across every script, it took a team of committed type designers to rear Baloo and raise it to be the typeface we love. 
-Baloo Devanagari is designed by Sarang Kulkarni, Gurmukhi by Shuchita Grover, Bangla by Noopur Datye, Oriya by Manish Minz and Shuchita Grover, Gujarati by Supriya Tembe and Noopur Datye, Kannada by Divya Kowshik, Telugu by Omkar Shende, Malayalam by Maithili Shingre, Urdu by Devika Bhansali and Tamil by Aadarsh Rajan.
-Baloo Latin is collaboratively designed by Ek Type. 
-Type design assistance and font engineering by Girish Dalvi.
-</p>
-<p>
-Baloo is grateful to Sulekha Rajkumar, Vaishnavi Murthy, Gangadharan Menon, Vinay Saynekar, Dave Crossland and others for their involvement, suggestions and feedback. 
+Baloo Bhaina for Oriya is designed by Manish Minz and Shuchita Grover. Type design assistance and font engineering by Girish Dalvi.
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/EkType/Baloo">github.com/EkType/Baloo</a>

--- a/ofl/baloochettan/DESCRIPTION.en_us.html
+++ b/ofl/baloochettan/DESCRIPTION.en_us.html
@@ -24,13 +24,7 @@ Each font supports one Indic subset plus Latin, Latin Extended, and Vietnamese.
 <li><a href="https://fonts.google.com/specimen/Baloo+Thambi">Baloo Thambi</a> for Tamil</li>
 </ul></p>
 <p>
-Well fed and thoroughly nourished across every script, it took a team of committed type designers to rear Baloo and raise it to be the typeface we love. 
-Baloo Devanagari is designed by Sarang Kulkarni, Gurmukhi by Shuchita Grover, Bangla by Noopur Datye, Oriya by Manish Minz and Shuchita Grover, Gujarati by Supriya Tembe and Noopur Datye, Kannada by Divya Kowshik, Telugu by Omkar Shende, Malayalam by Maithili Shingre, Urdu by Devika Bhansali and Tamil by Aadarsh Rajan.
-Baloo Latin is collaboratively designed by Ek Type. 
-Type design assistance and font engineering by Girish Dalvi.
-</p>
-<p>
-Baloo is grateful to Sulekha Rajkumar, Vaishnavi Murthy, Gangadharan Menon, Vinay Saynekar, Dave Crossland and others for their involvement, suggestions and feedback. 
+Baloo Chettan for Malayalam is designed by Maithili Shingre. Type design assistance and font engineering by Girish Dalvi.
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/EkType/Baloo">github.com/EkType/Baloo</a>

--- a/ofl/balooda/DESCRIPTION.en_us.html
+++ b/ofl/balooda/DESCRIPTION.en_us.html
@@ -24,13 +24,7 @@ Each font supports one Indic subset plus Latin, Latin Extended, and Vietnamese.
 <li><a href="https://fonts.google.com/specimen/Baloo+Thambi">Baloo Thambi</a> for Tamil</li>
 </ul></p>
 <p>
-Well fed and thoroughly nourished across every script, it took a team of committed type designers to rear Baloo and raise it to be the typeface we love. 
-Baloo Devanagari is designed by Sarang Kulkarni, Gurmukhi by Shuchita Grover, Bangla by Noopur Datye, Oriya by Manish Minz and Shuchita Grover, Gujarati by Supriya Tembe and Noopur Datye, Kannada by Divya Kowshik, Telugu by Omkar Shende, Malayalam by Maithili Shingre, Urdu by Devika Bhansali and Tamil by Aadarsh Rajan.
-Baloo Latin is collaboratively designed by Ek Type. 
-Type design assistance and font engineering by Girish Dalvi.
-</p>
-<p>
-Baloo is grateful to Sulekha Rajkumar, Vaishnavi Murthy, Gangadharan Menon, Vinay Saynekar, Dave Crossland and others for their involvement, suggestions and feedback. 
+Baloo Da for Bengali is designed by Noopur Datye. Type design assistance and font engineering by Girish Dalvi.
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/EkType/Baloo">github.com/EkType/Baloo</a>

--- a/ofl/baloopaaji/DESCRIPTION.en_us.html
+++ b/ofl/baloopaaji/DESCRIPTION.en_us.html
@@ -24,13 +24,7 @@ Each font supports one Indic subset plus Latin, Latin Extended, and Vietnamese.
 <li><a href="https://fonts.google.com/specimen/Baloo+Thambi">Baloo Thambi</a> for Tamil</li>
 </ul></p>
 <p>
-Well fed and thoroughly nourished across every script, it took a team of committed type designers to rear Baloo and raise it to be the typeface we love. 
-Baloo Devanagari is designed by Sarang Kulkarni, Gurmukhi by Shuchita Grover, Bangla by Noopur Datye, Oriya by Manish Minz and Shuchita Grover, Gujarati by Supriya Tembe and Noopur Datye, Kannada by Divya Kowshik, Telugu by Omkar Shende, Malayalam by Maithili Shingre, Urdu by Devika Bhansali and Tamil by Aadarsh Rajan.
-Baloo Latin is collaboratively designed by Ek Type. 
-Type design assistance and font engineering by Girish Dalvi.
-</p>
-<p>
-Baloo is grateful to Sulekha Rajkumar, Vaishnavi Murthy, Gangadharan Menon, Vinay Saynekar, Dave Crossland and others for their involvement, suggestions and feedback. 
+Baloo Paaji for Gurmukhi is designed by Shuchita Grover. Type design assistance and font engineering by Girish Dalvi.
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/EkType/Baloo">github.com/EkType/Baloo</a>

--- a/ofl/balootamma/DESCRIPTION.en_us.html
+++ b/ofl/balootamma/DESCRIPTION.en_us.html
@@ -24,13 +24,8 @@ Each font supports one Indic subset plus Latin, Latin Extended, and Vietnamese.
 <li><a href="https://fonts.google.com/specimen/Baloo+Thambi">Baloo Thambi</a> for Tamil</li>
 </ul></p>
 <p>
-Well fed and thoroughly nourished across every script, it took a team of committed type designers to rear Baloo and raise it to be the typeface we love. 
-Baloo Devanagari is designed by Sarang Kulkarni, Gurmukhi by Shuchita Grover, Bangla by Noopur Datye, Oriya by Manish Minz and Shuchita Grover, Gujarati by Supriya Tembe and Noopur Datye, Kannada by Divya Kowshik, Telugu by Omkar Shende, Malayalam by Maithili Shingre, Urdu by Devika Bhansali and Tamil by Aadarsh Rajan.
-Baloo Latin is collaboratively designed by Ek Type. 
+Baloo Tamma for Kannada is designed by Divya Kowshik. 
 Type design assistance and font engineering by Girish Dalvi.
-</p>
-<p>
-Baloo is grateful to Sulekha Rajkumar, Vaishnavi Murthy, Gangadharan Menon, Vinay Saynekar, Dave Crossland and others for their involvement, suggestions and feedback. 
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/EkType/Baloo">github.com/EkType/Baloo</a>

--- a/ofl/balootammudu/DESCRIPTION.en_us.html
+++ b/ofl/balootammudu/DESCRIPTION.en_us.html
@@ -24,13 +24,8 @@ Each font supports one Indic subset plus Latin, Latin Extended, and Vietnamese.
 <li><a href="https://fonts.google.com/specimen/Baloo+Thambi">Baloo Thambi</a> for Tamil</li>
 </ul></p>
 <p>
-Well fed and thoroughly nourished across every script, it took a team of committed type designers to rear Baloo and raise it to be the typeface we love. 
-Baloo Devanagari is designed by Sarang Kulkarni, Gurmukhi by Shuchita Grover, Bangla by Noopur Datye, Oriya by Manish Minz and Shuchita Grover, Gujarati by Supriya Tembe and Noopur Datye, Kannada by Divya Kowshik, Telugu by Omkar Shende, Malayalam by Maithili Shingre, Urdu by Devika Bhansali and Tamil by Aadarsh Rajan.
-Baloo Latin is collaboratively designed by Ek Type. 
+Baloo Tammudu for Telugu is designed by Omkar Shende. 
 Type design assistance and font engineering by Girish Dalvi.
-</p>
-<p>
-Baloo is grateful to Sulekha Rajkumar, Vaishnavi Murthy, Gangadharan Menon, Vinay Saynekar, Dave Crossland and others for their involvement, suggestions and feedback. 
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/EkType/Baloo">github.com/EkType/Baloo</a>

--- a/ofl/baloothambi/DESCRIPTION.en_us.html
+++ b/ofl/baloothambi/DESCRIPTION.en_us.html
@@ -24,13 +24,8 @@ Each font supports one Indic subset plus Latin, Latin Extended, and Vietnamese.
 <li>Baloo Thambi for Tamil</li>
 </ul></p>
 <p>
-Well fed and thoroughly nourished across every script, it took a team of committed type designers to rear Baloo and raise it to be the typeface we love. 
-Baloo Devanagari is designed by Sarang Kulkarni, Gurmukhi by Shuchita Grover, Bangla by Noopur Datye, Oriya by Manish Minz and Shuchita Grover, Gujarati by Supriya Tembe and Noopur Datye, Kannada by Divya Kowshik, Telugu by Omkar Shende, Malayalam by Maithili Shingre, Urdu by Devika Bhansali and Tamil by Aadarsh Rajan.
-Baloo Latin is collaboratively designed by Ek Type. 
+Baloo Thambi for Tamil is designed by Aadarsh Rajan. 
 Type design assistance and font engineering by Girish Dalvi.
-</p>
-<p>
-Baloo is grateful to Sulekha Rajkumar, Vaishnavi Murthy, Gangadharan Menon, Vinay Saynekar, Dave Crossland and others for their involvement, suggestions and feedback. 
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/EkType/Baloo">github.com/EkType/Baloo</a>

--- a/ofl/cormorant/DESCRIPTION.en_us.html
+++ b/ofl/cormorant/DESCRIPTION.en_us.html
@@ -1,4 +1,15 @@
-<p>Cormorant is a free display type family developed by Christian Thalmann. The project currently comprises a total of 45 font files spanning 9 different visual styles (Roman, Italic, Infant, Infant Italic, Garamond, Garamond Italic, Upright Cursive, Small Caps, and Unicase) and 5 weights (Light, Regular, Medium, SemiBold, and Bold.) Cormorant was conceived, drawn, spaced, kerned, programmed, interpolated, and produced in its entirety by Christian Thalmann of Catharsis Fonts. For an illustrated presentation and description of the family, please visit its <a href="https://www.behance.net/gallery/28579883/Cormorant-an-open-source-display-font-family">B&#275;hance page</a>.</p>
-<p>While this project was heavily inspired by Claude Garamont's immortal legacy, Christian did not use any specific font as a starting point or direct reference for the designs. Most glyphs were drawn from scratch; when he needed guidance on a specific character, he searched for the term Garamond and skimmed through the results for a general impression.</p>
-<p>He is grateful to the creative souls on the Typophile, TypeDrawers and Typografie forums, and Github, for a wealth of knowledge about type design, and for providing a large amount of excellent feedback on Cormorant during its development. He also thanks the tireless folks at Glyphs, in particular Rainer Erich Scheichelbauer of Schriftlabor and Georg Seifert. Special thanks go to Dave Crossland and Google Fonts for making the libre release of this font family possible through generous funding of the development process.</p>
-<p>The Cormorant project is led by Christian Thalmann, a type designer based in Zurich, Switzerland. To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a></p>
+<p>Cormorant is a free display type family developed by Christian Thalmann. 
+The project currently comprises a total of 45 font files spanning 9 different visual styles 
+(Roman, Italic, Infant, Infant Italic, Garamond, Garamond Italic, Upright Cursive, Small Caps, and Unicase) 
+and 5 weights (Light, Regular, Medium, SemiBold, and Bold.)  
+For an illustrated presentation and description of the family, 
+please visit its <a href="https://www.behance.net/gallery/28579883/Cormorant-an-open-source-display-font-family">B&#275;hance page</a>.
+</p>
+<p>
+While this project was heavily inspired by Claude Garamont's immortal legacy, Christian did not use any specific font as a starting point 
+or direct reference for the designs. Most glyphs were drawn from scratch; when he needed guidance on a specific character, 
+he searched for the term Garamond and skimmed through the results for a general impression.
+</p>
+<p> 
+To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a>
+</p>

--- a/ofl/cormorantgaramond/DESCRIPTION.en_us.html
+++ b/ofl/cormorantgaramond/DESCRIPTION.en_us.html
@@ -1,4 +1,15 @@
-<p>Cormorant is a free display type family developed by Christian Thalmann. The project currently comprises a total of 45 font files spanning 9 different visual styles (Roman, Italic, Infant, Infant Italic, Garamond, Garamond Italic, Upright Cursive, Small Caps, and Unicase) and 5 weights (Light, Regular, Medium, SemiBold, and Bold.) Cormorant was conceived, drawn, spaced, kerned, programmed, interpolated, and produced in its entirety by Christian Thalmann of Catharsis Fonts. For an illustrated presentation and description of the family, please visit its <a href="https://www.behance.net/gallery/28579883/Cormorant-an-open-source-display-font-family">B&#275;hance page</a>.</p>
-<p>While this project was heavily inspired by Claude Garamont's immortal legacy, Christian did not use any specific font as a starting point or direct reference for the designs. Most glyphs were drawn from scratch; when he needed guidance on a specific character, he searched for the term Garamond and skimmed through the results for a general impression.</p>
-<p>He is grateful to the creative souls on the Typophile, TypeDrawers and Typografie forums, and Github, for a wealth of knowledge about type design, and for providing a large amount of excellent feedback on Cormorant during its development. He also thanks the tireless folks at Glyphs, in particular Rainer Erich Scheichelbauer of Schriftlabor and Georg Seifert. Special thanks go to Dave Crossland and Google Fonts for making the libre release of this font family possible through generous funding of the development process.</p>
-<p>The Cormorant project is led by Christian Thalmann, a type designer based in Zurich, Switzerland. To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a></p>
+<p>Cormorant Garamond is a member of the Cormorant family - a free display type family developed by Christian Thalmann. 
+The project currently comprises a total of 45 font files spanning 9 different visual styles 
+(Roman, Italic, Infant, Infant Italic, Garamond, Garamond Italic, Upright Cursive, Small Caps, and Unicase) 
+and 5 weights (Light, Regular, Medium, SemiBold, and Bold.)  
+For an illustrated presentation and description of the family, 
+please visit its <a href="https://www.behance.net/gallery/28579883/Cormorant-an-open-source-display-font-family">B&#275;hance page</a>.
+</p>
+<p>
+While this project was heavily inspired by Claude Garamont's immortal legacy, Christian did not use any specific font as a starting point 
+or direct reference for the designs. Most glyphs were drawn from scratch; when he needed guidance on a specific character, 
+he searched for the term Garamond and skimmed through the results for a general impression.
+</p>
+<p> 
+To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a>
+</p>

--- a/ofl/cormorantinfant/DESCRIPTION.en_us.html
+++ b/ofl/cormorantinfant/DESCRIPTION.en_us.html
@@ -1,4 +1,15 @@
-<p>Cormorant is a free display type family developed by Christian Thalmann. The project currently comprises a total of 45 font files spanning 9 different visual styles (Roman, Italic, Infant, Infant Italic, Garamond, Garamond Italic, Upright Cursive, Small Caps, and Unicase) and 5 weights (Light, Regular, Medium, SemiBold, and Bold.) Cormorant was conceived, drawn, spaced, kerned, programmed, interpolated, and produced in its entirety by Christian Thalmann of Catharsis Fonts. For an illustrated presentation and description of the family, please visit its <a href="https://www.behance.net/gallery/28579883/Cormorant-an-open-source-display-font-family">B&#275;hance page</a>.</p>
-<p>While this project was heavily inspired by Claude Garamont's immortal legacy, Christian did not use any specific font as a starting point or direct reference for the designs. Most glyphs were drawn from scratch; when he needed guidance on a specific character, he searched for the term Garamond and skimmed through the results for a general impression.</p>
-<p>He is grateful to the creative souls on the Typophile, TypeDrawers and Typografie forums, and Github, for a wealth of knowledge about type design, and for providing a large amount of excellent feedback on Cormorant during its development. He also thanks the tireless folks at Glyphs, in particular Rainer Erich Scheichelbauer of Schriftlabor and Georg Seifert. Special thanks go to Dave Crossland and Google Fonts for making the libre release of this font family possible through generous funding of the development process.</p>
-<p>The Cormorant project is led by Christian Thalmann, a type designer based in Zurich, Switzerland. To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a></p>
+<p>Cormorant Infant belongs to the Cormorant family - a free display type family developed by Christian Thalmann. 
+The project currently comprises a total of 45 font files spanning 9 different visual styles 
+(Roman, Italic, Infant, Infant Italic, Garamond, Garamond Italic, Upright Cursive, Small Caps, and Unicase) 
+and 5 weights (Light, Regular, Medium, SemiBold, and Bold.)  
+For an illustrated presentation and description of the family, 
+please visit its <a href="https://www.behance.net/gallery/28579883/Cormorant-an-open-source-display-font-family">B&#275;hance page</a>.
+</p>
+<p>
+While this project was heavily inspired by Claude Garamont's immortal legacy, Christian did not use any specific font as a starting point 
+or direct reference for the designs. Most glyphs were drawn from scratch; when he needed guidance on a specific character, 
+he searched for the term Garamond and skimmed through the results for a general impression.
+</p>
+<p> 
+To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a>
+</p>

--- a/ofl/cormorantsc/DESCRIPTION.en_us.html
+++ b/ofl/cormorantsc/DESCRIPTION.en_us.html
@@ -1,4 +1,15 @@
-<p>Cormorant is a free display type family developed by Christian Thalmann. The project currently comprises a total of 45 font files spanning 9 different visual styles (Roman, Italic, Infant, Infant Italic, Garamond, Garamond Italic, Upright Cursive, Small Caps, and Unicase) and 5 weights (Light, Regular, Medium, SemiBold, and Bold.) Cormorant was conceived, drawn, spaced, kerned, programmed, interpolated, and produced in its entirety by Christian Thalmann of Catharsis Fonts. For an illustrated presentation and description of the family, please visit its <a href="https://www.behance.net/gallery/28579883/Cormorant-an-open-source-display-font-family">B&#275;hance page</a>.</p>
-<p>While this project was heavily inspired by Claude Garamont's immortal legacy, Christian did not use any specific font as a starting point or direct reference for the designs. Most glyphs were drawn from scratch; when he needed guidance on a specific character, he searched for the term Garamond and skimmed through the results for a general impression.</p>
-<p>He is grateful to the creative souls on the Typophile, TypeDrawers and Typografie forums, and Github, for a wealth of knowledge about type design, and for providing a large amount of excellent feedback on Cormorant during its development. He also thanks the tireless folks at Glyphs, in particular Rainer Erich Scheichelbauer of Schriftlabor and Georg Seifert. Special thanks go to Dave Crossland and Google Fonts for making the libre release of this font family possible through generous funding of the development process.</p>
-<p>The Cormorant project is led by Christian Thalmann, a type designer based in Zurich, Switzerland. To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a></p>
+<p>Cormorant SC is the small cap version of the Cormorant family - a free display type family developed by Christian Thalmann. 
+The project currently comprises a total of 45 font files spanning 9 different visual styles 
+(Roman, Italic, Infant, Infant Italic, Garamond, Garamond Italic, Upright Cursive, Small Caps, and Unicase) 
+and 5 weights (Light, Regular, Medium, SemiBold, and Bold.)  
+For an illustrated presentation and description of the family, 
+please visit its <a href="https://www.behance.net/gallery/28579883/Cormorant-an-open-source-display-font-family">B&#275;hance page</a>.
+</p>
+<p>
+While this project was heavily inspired by Claude Garamont's immortal legacy, Christian did not use any specific font as a starting point 
+or direct reference for the designs. Most glyphs were drawn from scratch; when he needed guidance on a specific character, 
+he searched for the term Garamond and skimmed through the results for a general impression.
+</p>
+<p> 
+To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a>
+</p>

--- a/ofl/cormorantunicase/DESCRIPTION.en_us.html
+++ b/ofl/cormorantunicase/DESCRIPTION.en_us.html
@@ -1,4 +1,15 @@
-<p>Cormorant is a free display type family developed by Christian Thalmann. The project currently comprises a total of 45 font files spanning 9 different visual styles (Roman, Italic, Infant, Infant Italic, Garamond, Garamond Italic, Upright Cursive, Small Caps, and Unicase) and 5 weights (Light, Regular, Medium, SemiBold, and Bold.) Cormorant was conceived, drawn, spaced, kerned, programmed, interpolated, and produced in its entirety by Christian Thalmann of Catharsis Fonts. For an illustrated presentation and description of the family, please visit its <a href="https://www.behance.net/gallery/28579883/Cormorant-an-open-source-display-font-family">B&#275;hance page</a>.</p>
-<p>While this project was heavily inspired by Claude Garamont's immortal legacy, Christian did not use any specific font as a starting point or direct reference for the designs. Most glyphs were drawn from scratch; when he needed guidance on a specific character, he searched for the term Garamond and skimmed through the results for a general impression.</p>
-<p>He is grateful to the creative souls on the Typophile, TypeDrawers and Typografie forums, and Github, for a wealth of knowledge about type design, and for providing a large amount of excellent feedback on Cormorant during its development. He also thanks the tireless folks at Glyphs, in particular Rainer Erich Scheichelbauer of Schriftlabor and Georg Seifert. Special thanks go to Dave Crossland and Google Fonts for making the libre release of this font family possible through generous funding of the development process.</p>
-<p>The Cormorant project is led by Christian Thalmann, a type designer based in Zurich, Switzerland. To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a></p>
+<p>Cormorant Unicase is a member of the Cormorant family - a free display type family developed by Christian Thalmann. 
+The project currently comprises a total of 45 font files spanning 9 different visual styles 
+(Roman, Italic, Infant, Infant Italic, Garamond, Garamond Italic, Upright Cursive, Small Caps, and Unicase) 
+and 5 weights (Light, Regular, Medium, SemiBold, and Bold.)  
+For an illustrated presentation and description of the family, 
+please visit its <a href="https://www.behance.net/gallery/28579883/Cormorant-an-open-source-display-font-family">B&#275;hance page</a>.
+</p>
+<p>
+While this project was heavily inspired by Claude Garamont's immortal legacy, Christian did not use any specific font as a starting point 
+or direct reference for the designs. Most glyphs were drawn from scratch; when he needed guidance on a specific character, 
+he searched for the term Garamond and skimmed through the results for a general impression.
+</p>
+<p> 
+To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a>
+</p>

--- a/ofl/cormorantupright/DESCRIPTION.en_us.html
+++ b/ofl/cormorantupright/DESCRIPTION.en_us.html
@@ -11,5 +11,6 @@ or direct reference for the designs. Most glyphs were drawn from scratch; when h
 he searched for the term Garamond and skimmed through the results for a general impression.
 </p>
 <p> 
+The Cormorant project is led by Christian Thalmann, a type designer based in Zurich, Switzerland. 
 To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a>
 </p>

--- a/ofl/cormorantupright/DESCRIPTION.en_us.html
+++ b/ofl/cormorantupright/DESCRIPTION.en_us.html
@@ -1,4 +1,15 @@
-<p>Cormorant is a free display type family developed by Christian Thalmann. The project currently comprises a total of 45 font files spanning 9 different visual styles (Roman, Italic, Infant, Infant Italic, Garamond, Garamond Italic, Upright Cursive, Small Caps, and Unicase) and 5 weights (Light, Regular, Medium, SemiBold, and Bold.) Cormorant was conceived, drawn, spaced, kerned, programmed, interpolated, and produced in its entirety by Christian Thalmann of Catharsis Fonts. For an illustrated presentation and description of the family, please visit its <a href="https://www.behance.net/gallery/28579883/Cormorant-an-open-source-display-font-family">B&#275;hance page</a>.</p>
-<p>While this project was heavily inspired by Claude Garamont's immortal legacy, Christian did not use any specific font as a starting point or direct reference for the designs. Most glyphs were drawn from scratch; when he needed guidance on a specific character, he searched for the term Garamond and skimmed through the results for a general impression.</p>
-<p>He is grateful to the creative souls on the Typophile, TypeDrawers and Typografie forums, and Github, for a wealth of knowledge about type design, and for providing a large amount of excellent feedback on Cormorant during its development. He also thanks the tireless folks at Glyphs, in particular Rainer Erich Scheichelbauer of Schriftlabor and Georg Seifert. Special thanks go to Dave Crossland and Google Fonts for making the libre release of this font family possible through generous funding of the development process.</p>
-<p>The Cormorant project is led by Christian Thalmann, a type designer based in Zurich, Switzerland. To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a></p>N/A
+<p>Cormorant Upright is a member of the Cormorant family - a free display type family developed by Christian Thalmann. 
+The project currently comprises a total of 45 font files spanning 9 different visual styles 
+(Roman, Italic, Infant, Infant Italic, Garamond, Garamond Italic, Upright Cursive, Small Caps, and Unicase) 
+and 5 weights (Light, Regular, Medium, SemiBold, and Bold.)  
+For an illustrated presentation and description of the family, 
+please visit its <a href="https://www.behance.net/gallery/28579883/Cormorant-an-open-source-display-font-family">B&#275;hance page</a>.
+</p>
+<p>
+While this project was heavily inspired by Claude Garamont's immortal legacy, Christian did not use any specific font as a starting point 
+or direct reference for the designs. Most glyphs were drawn from scratch; when he needed guidance on a specific character, 
+he searched for the term Garamond and skimmed through the results for a general impression.
+</p>
+<p> 
+To contribute, see <a href="http://www.github.com/CatharsisFonts/Cormorant">github.com/CatharsisFonts/Cormorant</a>
+</p>

--- a/ofl/londrinaoutline/DESCRIPTION.en_us.html
+++ b/ofl/londrinaoutline/DESCRIPTION.en_us.html
@@ -1,16 +1,19 @@
 <p>
 The Londrina super family is composed of 4 family styles: 
 <a href="http://www.google.com/webfonts/specimen/Londrina+Solid">Londrina Solid</a>, 
-<a href="http://www.google.com/webfonts/specimen/Londrina+Shadow">Londrina Shadow</a>, 
-Londrina Outline, 
+Londrina Shadow, 
+<a href="http://www.google.com/fonts/specimen/Londrina+Outline">Londrina Outline</a>, 
 and <a href="http://www.google.com/webfonts/specimen/Londrina+Sketch">Londrina Sketch</a>. 
-You can combine the main style, Solid, with the others to create different effects. 
-The origins of the Londrina typeface project is in the streets of Sao Paulo, Brazil: 
-Urban confusion. 
-Initially I designed the "New Folk" for use in a poster, with only uppercase letters. 
-I saw at the start some potential for a typeface that could recall the feelings of the writing used day-to-day in my city's informal communication, and developed it into a typeface family with lowercases too. 
-This is the Londrina Outline member of the Londrina family.
 </p>
 <p>
-To contribute to the project contact <a href="mailto:marcelommp@gmail.com">Marcelo Magalhães</a>
+Londrina Outline has a thin and faint outlook and can be combined with the main style to create different effects. 
 </p>
+<p>
+The origins of the Londrina typeface project is in the streets of Sao Paulo, Brazil: Urban confusion. 
+Initially designed for use in a poster, with only uppercase letters, the potential for it to be a typeface that could recall the feelings of the writing
+used day-to-day in Sao Paulo’s informal communication, developed the font into a typeface family with lowercases too. 
+The variety in texture allows you to create different projects from posters to magazines and t-shirts etc.
+</p>
+<p>
+To contribute to the project please see <a href="https://github.com/marcelommp/Londrina-Typeface">github.com/marcelommp/Londrina-Typeface</a>
+</p

--- a/ofl/londrinashadow/DESCRIPTION.en_us.html
+++ b/ofl/londrinashadow/DESCRIPTION.en_us.html
@@ -4,13 +4,16 @@ The Londrina super family is composed of 4 family styles:
 Londrina Shadow, 
 <a href="http://www.google.com/fonts/specimen/Londrina+Outline">Londrina Outline</a>, 
 and <a href="http://www.google.com/webfonts/specimen/Londrina+Sketch">Londrina Sketch</a>. 
-You can combine the main style, Solid, with the others to create different effects. 
-The origins of the Londrina typeface project is in the streets of Sao Paulo, Brazil: 
-Urban confusion. 
-Initially I designed the "New Folk" for use in a poster, with only uppercase letters. 
-I saw at the start some potential for a typeface that could recall the feelings of the writing used day-to-day in my city's informal communication, and developed it into a typeface family with lowercases too. 
-This is the Londrina Outline member of the Londrina family.
 </p>
 <p>
-To contribute to the project contact <a href="mailto:marcelommp@gmail.com">Marcelo Magalhães</a>
+Londrina Shadow has a somewhat three-dimensional feel to it and can be combined with the main style to create different effects. 
 </p>
+<p>
+The origins of the Londrina typeface project is in the streets of Sao Paulo, Brazil: Urban confusion. 
+Initially designed for use in a poster, with only uppercase letters, the potential for it to be a typeface that could recall the feelings of the writing
+used day-to-day in Sao Paulo’s informal communication, developed the font into a typeface family with lowercases too. 
+The variety in texture allows you to create different projects from posters to magazines and t-shirts etc.
+</p>
+<p>
+To contribute to the project please see <a href="https://github.com/marcelommp/Londrina-Typeface">github.com/marcelommp/Londrina-Typeface</a>
+</p

--- a/ofl/londrinasketch/DESCRIPTION.en_us.html
+++ b/ofl/londrinasketch/DESCRIPTION.en_us.html
@@ -1,16 +1,19 @@
 <p>
 The Londrina super family is composed of 4 family styles: 
 <a href="http://www.google.com/webfonts/specimen/Londrina+Solid">Londrina Solid</a>, 
-<a href="http://www.google.com/webfonts/specimen/Londrina+Shadow">Londrina Shadow</a>, 
+Londrina Shadow, 
 <a href="http://www.google.com/fonts/specimen/Londrina+Outline">Londrina Outline</a>, 
-and Londrina Sketch. 
-You can combine the main style, Solid, with the others to create different effects. 
-The origins of the Londrina typeface project is in the streets of Sao Paulo, Brazil: 
-Urban confusion. 
-Initially I designed the "New Folk" for use in a poster, with only uppercase letters. 
-I saw at the start some potential for a typeface that could recall the feelings of the writing used day-to-day in my city's informal communication, and developed it into a typeface family with lowercases too. 
-This is the Londrina Outline member of the Londrina family.
+and <a href="http://www.google.com/webfonts/specimen/Londrina+Sketch">Londrina Sketch</a>. 
 </p>
 <p>
-To contribute to the project contact <a href="mailto:marcelommp@gmail.com">Marcelo Magalhães</a>
+Londrina Sketch has an enhanced handwritten texture and can be combined with the main style to create different effects. 
 </p>
+<p>
+The origins of the Londrina typeface project is in the streets of Sao Paulo, Brazil: Urban confusion. 
+Initially designed for use in a poster, with only uppercase letters, the potential for it to be a typeface that could recall the feelings of the writing
+used day-to-day in Sao Paulo’s informal communication, developed the font into a typeface family with lowercases too. 
+The variety in texture allows you to create different projects from posters to magazines and t-shirts etc.
+</p>
+<p>
+To contribute to the project please see <a href="https://github.com/marcelommp/Londrina-Typeface">github.com/marcelommp/Londrina-Typeface</a>
+</p

--- a/ofl/londrinasolid/DESCRIPTION.en_us.html
+++ b/ofl/londrinasolid/DESCRIPTION.en_us.html
@@ -4,13 +4,17 @@ Londrina Solid,
 <a href="http://www.google.com/webfonts/specimen/Londrina+Shadow">Londrina Shadow</a>, 
 <a href="http://www.google.com/fonts/specimen/Londrina+Outline">Londrina Outline</a>, 
 and <a href="http://www.google.com/webfonts/specimen/Londrina+Sketch">Londrina Sketch</a>. 
-You can combine the main style, Solid, with the others to create different effects. 
-The origins of the Londrina typeface project is in the streets of Sao Paulo, Brazil: 
-Urban confusion. 
-Initially I designed the "New Folk" for use in a poster, with only uppercase letters. 
-I saw at the start some potential for a typeface that could recall the feelings of the writing used day-to-day in my city's informal communication, and developed it into a typeface family with lowercases too. 
-This is the Londrina Outline member of the Londrina family.
+It is a fairly square-shaped display type with a handwritten feel. 
 </p>
 <p>
-To contribute to the project contact <a href="mailto:marcelommp@gmail.com">Marcelo Magalhães</a>
+The main style - Londrina Solid is a bold version and can be combined with the others to create different effects. 
+</p>
+<p>
+The origins of the Londrina typeface project is in the streets of Sao Paulo, Brazil: Urban confusion. 
+Initially designed for use in a poster, with only uppercase letters, the potential for it to be a typeface that could recall the feelings of the writing
+used day-to-day in Sao Paulo’s informal communication, developed the font into a typeface family with lowercases too. 
+The variety in texture allows you to create different projects from posters to magazines and t-shirts etc.
+</p>
+<p>
+To contribute to the project please see <a href="https://github.com/marcelommp/Londrina-Typeface">github.com/marcelommp/Londrina-Typeface</a>
 </p>

--- a/ofl/mukta/DESCRIPTION.en_us.html
+++ b/ofl/mukta/DESCRIPTION.en_us.html
@@ -1,20 +1,17 @@
 <p>
-Mukta is a Unicode compliant, versatile, contemporary, humanist, mono-linear typeface family available in seven weights, supporting Devanagari, Gujarati, Gurumukhi, Tamil and Latin scripts.
-This type family is a libre licensed version of Ek's self-titled multi-script project, an ongoing effort to develop a unified type family for each Indian script.
+Mukta is a Unicode compliant, versatile, contemporary, humanist, mono-linear typeface family available in seven weights, 
+supporting Devanagari, Gujarati, Gurumukhi, Tamil and Latin scripts.
+This type family is a libre licensed version of Ek's self-titled multi-script project.
 The goal is to build one harmonious family across all Indian scripts without letting the visual features of one script dominate over others.
 This ensures that the fonts can be used successfully for both single and multi-script purposes.
 </p>
 <p>
-Mukta was designed by Girish Dalvi and Yashodeep Gholap.
-<a href="https://fonts.google.com/specimen/Mukta+Vaani">Mukta Vaani</a> was designed by Noopur Datye and Pallavi Karambelkar with support from Sarang Kulkarni and Maithili Shingre.
-<a href="https://fonts.google.com/specimen/Mukta+Malar">Mukta Malar</a> was designed by Aadarsh Rajan.
-<a href="https://fonts.google.com/specimen/Mukta+Mahee">Mukta Mahee</a> was designed by Shuchita Grover and Noopur Datye.
+Mukta was designed by Girish Dalvi and Yashodeep Gholap. 
+The other fonts in the family are:
+<a href="https://fonts.google.com/specimen/Mukta+Vaani">Mukta Vaani</a> 
+<a href="https://fonts.google.com/specimen/Mukta+Malar">Mukta Malar</a> and
+<a href="https://fonts.google.com/specimen/Mukta+Mahee">Mukta Mahee</a> 
 </p>
 <p>
-Ek would like to thank Vinay Saynekar, Santosh Kshirsagar, Shubhanand Jog, Yogesh Jahargirdar, Pradnya Naik, Snehal Patil, Omkar Shende and Dave Crossland for their suggestions and feedback during the font design process.
-Ek would also like to thank faculty and friends from the Industrial Design Centre, IIT Bombay, and from Sir J J Institute of Applied Art, for their support and encouragement.
-</p>
-<p>
-This project is led by Ek Type, a collective of type designers based in Mumbai focused on designing contemporary Indian typefaces.
 To contribute, see <a href="https://github.com/EkType/Mukta">github.com/EkType/Mukta</a>
 </p>

--- a/ofl/muktamahee/DESCRIPTION.en_us.html
+++ b/ofl/muktamahee/DESCRIPTION.en_us.html
@@ -1,20 +1,15 @@
 <p>
-Mukta is a Unicode compliant, versatile, contemporary, humanist, mono-linear typeface family available in seven weights, supporting Devanagari, Gujarati, Gurumukhi, Tamil and Latin scripts.
-This type family is a libre licensed version of Ek's self-titled multi-script project, an ongoing effort to develop a unified type family for each Indian script.
+Mukta Mahee belongs to the Mukta family - a Unicode compliant, versatile, contemporary, humanist, mono-linear typeface family available in seven weights, 
+supporting Devanagari, Gujarati, Gurumukhi, Tamil and Latin scripts.
+This type family is a libre licensed version of Ek's self-titled multi-script project.
 The goal is to build one harmonious family across all Indian scripts without letting the visual features of one script dominate over others.
 This ensures that the fonts can be used successfully for both single and multi-script purposes.
 </p>
-<p>
-<a href="https://fonts.google.com/specimen/Mukta">Mukta</a> was designed by Girish Dalvi and Yashodeep Gholap.
-<a href="https://fonts.google.com/specimen/Mukta+Vaani">Mukta Vaani</a> was designed by Noopur Datye and Pallavi Karambelkar with support from Sarang Kulkarni and Maithili Shingre.
-<a href="https://fonts.google.com/specimen/Mukta+Malar">Mukta Malar</a> was designed by Aadarsh Rajan.
-Mukta Mahee was designed by Shuchita Grover and Noopur Datye.
+<p>Mukta Mahee was designed by Shuchita Grover and Noopur Datye. The other fonts in the family are:
+<a href="https://fonts.google.com/specimen/Mukta">Mukta</a> 
+<a href="https://fonts.google.com/specimen/Mukta+Vaani">Mukta Vaani</a> and
+<a href="https://fonts.google.com/specimen/Mukta+Malar">Mukta Malar</a>
 </p>
 <p>
-Ek would like to thank Vinay Saynekar, Santosh Kshirsagar, Shubhanand Jog, Yogesh Jahargirdar, Pradnya Naik, Snehal Patil, Omkar Shende and Dave Crossland for their suggestions and feedback during the font design process.
-Ek would also like to thank faculty and friends from the Industrial Design Centre, IIT Bombay, and from Sir J J Institute of Applied Art, for their support and encouragement.
-</p>
-<p>
-This project is led by Ek Type, a collective of type designers based in Mumbai focused on designing contemporary Indian typefaces.
 To contribute, see <a href="https://github.com/EkType/Mukta">github.com/EkType/Mukta</a>
 </p>

--- a/ofl/muktamalar/DESCRIPTION.en_us.html
+++ b/ofl/muktamalar/DESCRIPTION.en_us.html
@@ -1,20 +1,15 @@
 <p>
-Mukta is a Unicode compliant, versatile, contemporary, humanist, mono-linear typeface family available in seven weights, supporting Devanagari, Gujarati, Gurumukhi, Tamil and Latin scripts.
-This type family is a libre licensed version of Ek's self-titled multi-script project, an ongoing effort to develop a unified type family for each Indian script.
+Mukta Malar belongs to the Mukta family - a Unicode compliant, versatile, contemporary, humanist, mono-linear typeface family available in seven weights, 
+supporting Devanagari, Gujarati, Gurumukhi, Tamil and Latin scripts.
+This type family is a libre licensed version of Ek's self-titled multi-script project.
 The goal is to build one harmonious family across all Indian scripts without letting the visual features of one script dominate over others.
 This ensures that the fonts can be used successfully for both single and multi-script purposes.
 </p>
-<p>
-<a href="https://fonts.google.com/specimen/Mukta">Mukta</a> was designed by Girish Dalvi and Yashodeep Gholap.
-<a href="https://fonts.google.com/specimen/Mukta+Vaani">Mukta Vaani</a> was designed by Noopur Datye and Pallavi Karambelkar with support from Sarang Kulkarni and Maithili Shingre.
-Mukta Malar was designed by Aadarsh Rajan.
-<a href="https://fonts.google.com/specimen/Mukta+Mahee">Mukta Mahee</a> was designed by Shuchita Grover and Noopur Datye.
+<p>Mukta Malar was designed by Aadarsh Rajan. The other fonts in the family are:
+<a href="https://fonts.google.com/specimen/Mukta">Mukta</a>
+<a href="https://fonts.google.com/specimen/Mukta+Vaani">Mukta Vaani</a> and
+<a href="https://fonts.google.com/specimen/Mukta+Mahee">Mukta Mahee</a> 
 </p>
 <p>
-Ek would like to thank Vinay Saynekar, Santosh Kshirsagar, Shubhanand Jog, Yogesh Jahargirdar, Pradnya Naik, Snehal Patil, Omkar Shende and Dave Crossland for their suggestions and feedback during the font design process.
-Ek would also like to thank faculty and friends from the Industrial Design Centre, IIT Bombay, and from Sir J J Institute of Applied Art, for their support and encouragement.
-</p>
-<p>
-This project is led by Ek Type, a collective of type designers based in Mumbai focused on designing contemporary Indian typefaces.
 To contribute, see <a href="https://github.com/EkType/Mukta">github.com/EkType/Mukta</a>
 </p>

--- a/ofl/muktavaani/DESCRIPTION.en_us.html
+++ b/ofl/muktavaani/DESCRIPTION.en_us.html
@@ -1,20 +1,16 @@
 <p>
-Mukta is a Unicode compliant, versatile, contemporary, humanist, mono-linear typeface family available in seven weights, supporting Devanagari, Gujarati, Gurumukhi, Tamil and Latin scripts.
-This type family is a libre licensed version of Ek's self-titled multi-script project, an ongoing effort to develop a unified type family for each Indian script.
+Mukta Vaani belongs to the Mukta family - a Unicode compliant, versatile, contemporary, humanist, mono-linear typeface family available in seven weights, 
+supporting Devanagari, Gujarati, Gurumukhi, Tamil and Latin scripts.
+This type family is a libre licensed version of Ek's self-titled multi-script project.
 The goal is to build one harmonious family across all Indian scripts without letting the visual features of one script dominate over others.
 This ensures that the fonts can be used successfully for both single and multi-script purposes.
 </p>
-<p>
-<a href="https://fonts.google.com/specimen/Mukta">Mukta</a> was designed by Girish Dalvi and Yashodeep Gholap.
-Mukta Vaani was designed by Noopur Datye and Pallavi Karambelkar with support from Sarang Kulkarni and Maithili Shingre.
-<a href="https://fonts.google.com/specimen/Mukta+Malar">Mukta Malar</a> was designed by Aadarsh Rajan.
-<a href="https://fonts.google.com/specimen/Mukta+Mahee">Mukta Mahee</a> was designed by Shuchita Grover and Noopur Datye.
+<p>Mukta Vaani was designed by Noopur Datye and Pallavi Karambelkar with support from Sarang Kulkarni and Maithili Shingre.
+The other fonts in the family are: 
+<a href="https://fonts.google.com/specimen/Mukta">Mukta</a> 
+<a href="https://fonts.google.com/specimen/Mukta+Malar">Mukta Malar</a> and 
+<a href="https://fonts.google.com/specimen/Mukta+Mahee">Mukta Mahee</a> 
 </p>
 <p>
-Ek would like to thank Vinay Saynekar, Santosh Kshirsagar, Shubhanand Jog, Yogesh Jahargirdar, Pradnya Naik, Snehal Patil, Omkar Shende and Dave Crossland for their suggestions and feedback during the font design process.
-Ek would also like to thank faculty and friends from the Industrial Design Centre, IIT Bombay, and from Sir J J Institute of Applied Art, for their support and encouragement.
-</p>
-<p>
-This project is led by Ek Type, a collective of type designers based in Mumbai focused on designing contemporary Indian typefaces.
 To contribute, see <a href="https://github.com/EkType/Mukta">github.com/EkType/Mukta</a>
 </p>

--- a/ofl/seoulhangang/DESCRIPTION.en_us.html
+++ b/ofl/seoulhangang/DESCRIPTION.en_us.html
@@ -11,9 +11,4 @@ The family has 4 weights of regular width (Light, Medium, Bold and
 Extra Bold) and 5 weights of condensed (Light, Medium, Bold, Extra
 Bold and Black.)
 </p>
-<p>
-서울한강체는 명조계열의 서체로, 서울의 고유글꼴로 널리 활용되며 도시정체성과 브랜드 가치를 높여줄 서울서체로 개발되었다. 정체
-4종(Light, Medium, Bold, Extra Bold)과 장체 5종(Light, Medium, Bold, Extra
-Bold, Black)으로 구성된다.
-서울서체는 강직한 선비정신과 단아한 여백을 담고 있으며 조형적으로는 한옥의 열림과 기와의 곡선미를 표현하였다.
-</p>
+

--- a/ofl/seoulhangangcondensed/DESCRIPTION.en_us.html
+++ b/ofl/seoulhangangcondensed/DESCRIPTION.en_us.html
@@ -11,9 +11,3 @@ The family has 4 weights of regular width (Light, Medium, Bold and
 Extra Bold) and 5 weights of condensed (Light, Medium, Bold, Extra
 Bold and Black.)
 </p>
-<p>
-서울한강체는 명조계열의 서체로, 서울의 고유글꼴로 널리 활용되며 도시정체성과 브랜드 가치를 높여줄 서울서체로 개발되었다. 정체
-4종(Light, Medium, Bold, Extra Bold)과 장체 5종(Light, Medium, Bold, Extra
-Bold, Black)으로 구성된다.
-서울서체는 강직한 선비정신과 단아한 여백을 담고 있으며 조형적으로는 한옥의 열림과 기와의 곡선미를 표현하였다.
-</p>

--- a/ofl/seoulnamsan/DESCRIPTION.en_us.html
+++ b/ofl/seoulnamsan/DESCRIPTION.en_us.html
@@ -9,8 +9,3 @@ traditional roof tiles. The family has 4 weights of regular width
 (Light, Medium, Bold, Extra Bold and Black.) It also has 1 style for
 vertical writing.
 </p>
-<p>
-서울남산체는 고딕계열의 서체로, 서울의 고유글꼴로 널리 활용되며 도시정체성과 브랜드 가치를 높여줄 서울서체로 개발되었다. 정체
-4종(Light, Medium, Bold, Extra Bold)과 장체 5종(Light, Medium, Bold, Extra
-Bold, Black), 세로쓰기 1종으로 구성된다.
-</p>

--- a/ofl/seoulnamsancondensed/DESCRIPTION.en_us.html
+++ b/ofl/seoulnamsancondensed/DESCRIPTION.en_us.html
@@ -9,8 +9,4 @@ traditional roof tiles. The family has 4 weights of regular width
 (Light, Medium, Bold, Extra Bold and Black.) It also has 1 style for
 vertical writing.
 </p>
-<p>
-서울남산체는 고딕계열의 서체로, 서울의 고유글꼴로 널리 활용되며 도시정체성과 브랜드 가치를 높여줄 서울서체로 개발되었다. 정체
-4종(Light, Medium, Bold, Extra Bold)과 장체 5종(Light, Medium, Bold, Extra
-Bold, Black), 세로쓰기 1종으로 구성된다.
-</p>
+<

--- a/ofl/seoulnamsanvertical/DESCRIPTION.en_us.html
+++ b/ofl/seoulnamsanvertical/DESCRIPTION.en_us.html
@@ -9,8 +9,4 @@ traditional roof tiles. The family has 4 weights of regular width
 (Light, Medium, Bold, Extra Bold and Black.) It also has 1 style for
 vertical writing.
 </p>
-<p>
-서울남산체는 고딕계열의 서체로, 서울의 고유글꼴로 널리 활용되며 도시정체성과 브랜드 가치를 높여줄 서울서체로 개발되었다. 정체
-4종(Light, Medium, Bold, Extra Bold)과 장체 5종(Light, Medium, Bold, Extra
-Bold, Black), 세로쓰기 1종으로 구성된다.
-</p>
+


### PR DESCRIPTION
Londrina & Almendra family - added a description to distinguish between font types within the family

Baloo & Mukta & Cormorant family - cut out repeated data

Seoul family - cut out foreign text