### PR TITLE
Add detail to description for Recursive

### DIFF
--- a/ofl/recursive/DESCRIPTION.en_us.html
+++ b/ofl/recursive/DESCRIPTION.en_us.html
@@ -1,7 +1,9 @@
 <p>
-The Recursive project is led by Arrow Type, a type design foundry based in Brooklyn, USA.
-To contribute, see <a href="https://github.com/arrowtype/recursive">github.com/arrowtype/recursive</a>.
+Recursive draws inspiration from single-stroke casual signpainting, a style of brush writing that is stylistically flexible and warmly energetic. Adapting this aesthetic basis into an extensive type system, Recursive is designed to excel in digital interactive environments, including data-rich user interfaces, technical documentation, and code editors.
 </p>
 <p>
-<b>Check out the Recursive homepage at <a href="https://www.recursive.design/">recursive.design</a></b>
+Recursive is a five-axis variable font, enabling you to choose from 64 predefined styles or dial in exactly what you want for each of its axes: Monospace, Casual, Weight, Slant, and Cursive. Taking full advantage of variable font technology, Recursive offers an unprecedented level of flexibility, all from a single font file. To contribute, see <a href="https://github.com/arrowtype/recursive">github.com/arrowtype/recursive</a>.
+</p>
+<p>
+<b>To learn more about the project and to configure Google Fonts embed code from the full set of styles and variable axes, visit the Recursive website at <a href="https://www.recursive.design/">recursive.design</a></b>.
 </p>

--- a/ofl/recursive/DESCRIPTION.en_us.html
+++ b/ofl/recursive/DESCRIPTION.en_us.html
@@ -1,9 +1,12 @@
 <p>
-Recursive draws inspiration from single-stroke casual signpainting, a style of brush writing that is stylistically flexible and warmly energetic. Adapting this aesthetic basis into an extensive type system, Recursive is designed to excel in digital interactive environments, including data-rich user interfaces, technical documentation, and code editors.
+Recursive draws inspiration from single-stroke casual signpainting, a style of brush writing that is stylistically flexible and warmly energetic.
+Adapting this aesthetic basis into an extensive type system, Recursive is designed to excel in digital interactive environments, including data-rich user interfaces, technical documentation, and code editors.
 </p>
 <p>
-Recursive is a five-axis variable font, enabling you to choose from 64 predefined styles or dial in exactly what you want for each of its axes: Monospace, Casual, Weight, Slant, and Cursive. Taking full advantage of variable font technology, Recursive offers an unprecedented level of flexibility, all from a single font file. To contribute, see <a href="https://github.com/arrowtype/recursive">github.com/arrowtype/recursive</a>.
+Recursive is a five-axis variable font, enabling you to choose from 64 predefined styles or dial in exactly what you want for each of its axes:
+Monospace, Casual, Weight, Slant, and Cursive.
+Taking full advantage of variable font technology, Recursive offers an unprecedented level of flexibility, all from a single font file.
 </p>
 <p>
-<b>To learn more about the project and to configure Google Fonts embed code from the full set of styles and variable axes, visit the Recursive website at <a href="https://www.recursive.design/">recursive.design</a></b>.
+<b>To learn more about the project and to configure Google Fonts embed code from the full set of styles and variable axes, visit the Recursive website at <a href="https://www.recursive.design/">recursive.design</a></b>
 </p>


### PR DESCRIPTION
This description assumes we will publish Recursive around May 1, after an update to the Recursive site that will help users configure advanced Google Font API calls.

If we decide to publish it earlier, we should switch the final paragraph here to:

```html
<p>
To learn more, visit the Recursive website at <a href="https://www.recursive.design/">recursive.design</a>. To configure Google Fonts embed code from Recursive’s full set of styles and variable axes, please see <a href="https://developers.google.com/fonts/docs/css2">developers.google.com/fonts/docs/css2</a>.
</p>
```