### PR TITLE
fixed METADATA for FiraCode font

### DIFF
--- a/ofl/firacode/METADATA.pb
+++ b/ofl/firacode/METADATA.pb
@@ -1,7 +1,7 @@
 name: "Fira Code"
 designer: "Multiple Designers"
 license: "OFL"
-category: "Monospace"
+category: "MONOSPACE"
 date_added: "2019-03-25"
 fonts {
   name: "Fira Code"


### PR DESCRIPTION
It is now 'MONOSPACE', same as other fonts, not 'Monospace'