### PR TITLE
Update Cairo METADATA designer field

### DIFF
--- a/ofl/cairo/METADATA.pb
+++ b/ofl/cairo/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Cairo"
-designer: "Mohamed Gaber, Multiple Designers"
+designer: "Mohamed Gaber, Accademia di Belle Arti di Urbino"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2016-06-20"


### PR DESCRIPTION
There was a previous PR merged attempting to add Mohamed Gaber as the principal designer for the Cairo typeface on https://fonts.google.com here:
https://github.com/google/fonts/pull/2337

Currently, https://fonts.google.com/specimen/Cairo lists the typeface as designed by "Multiple Designers" despite the previously merged commit.

This commit should make "Mohamed Gaber" the principal designer listed for the Cairo typeface and "Accademia di Belle Arti di Urbino" the secondary designer.

For reference, Amiri credits designers in the way intended: https://fonts.google.com/specimen/Amiri