### PR TITLE
Fix email address in copyright line of OFL.txt for librebaskerville

### DIFF
--- a/ofl/librebaskerville/OFL.txt
+++ b/ofl/librebaskerville/OFL.txt
@@ -1,5 +1,5 @@
 Copyright (c) 2012, Pablo Impallari (www.impallari.com|impallari@gmail.com), 
-Copyright (c) 2012, Rodrigo Fuenzalida (www.rfuenzalida.com|hello¨rfuenzalida.com), with Reserved Font Name Libre Baskerville.
+Copyright (c) 2012, Rodrigo Fuenzalida (www.rfuenzalida.com|hello@rfuenzalida.com), with Reserved Font Name Libre Baskerville.
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:


### PR DESCRIPTION
This also makes sure that the OFL.txt is valid UTF-8 instead of ISO-8859.