### PR TITLE
ofl/kufam/METADATA.pb add arabic subset

### DIFF
--- a/ofl/kufam/METADATA.pb
+++ b/ofl/kufam/METADATA.pb
@@ -21,6 +21,7 @@ fonts {
   full_name: "Kufam Italic"
   copyright: "Copyright 2019 The Kufam Project Authors (https://github.com/originaltype/kufam)"
 }
+subsets: "arabic"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"


### PR DESCRIPTION
In https://github.com/originaltype/kufam/issues/2 I proposed adding the arabic design to the italics, duplicated from Roman.

Since the arabic characters are not present in half the files, then `add-font` didn't include the arabic subset METADATA enumeration, so I'm adding it in this PR. 

When pushed to the catalog, the result will be tofu for arabic text in the Italic styles.