### PR TITLE
Upgrade Recursive description to better highlight the specimen website

### DIFF
--- a/ofl/recursive/DESCRIPTION.en_us.html
+++ b/ofl/recursive/DESCRIPTION.en_us.html
@@ -1,12 +1,13 @@
 <p>
-Recursive draws inspiration from single-stroke casual signpainting, a style of brush writing that is stylistically flexible and warmly energetic.
-Adapting this aesthetic basis into an extensive type system, Recursive is designed to excel in digital interactive environments, including data-rich user interfaces, technical documentation, and code editors.
+Recursive is typographic palette for UI & code. It draws inspiration from single-stroke casual, a style of brush writing used in signpainting that is stylistically flexible and warmly energetic. Recursive adapts this aesthetic basis into an extensive variable font family, designed to excel in digital interactive environments, including data-rich user interfaces, technical documentation, and code editors.
 </p>
 <p>
-Recursive is a five-axis variable font, enabling you to choose from 64 predefined styles or dial in exactly what you want for each of its axes:
-Monospace, Casual, Weight, Slant, and Cursive.
-Taking full advantage of variable font technology, Recursive offers an unprecedented level of flexibility, all from a single font file.
+Recursive offers a lot more styles than you see here! To download the full Recursive Sans &amp; Mono family, learn more about its 5 variable axes, and to configure advanced Google Fonts URL embed code for access to Recursive’s full stylistic range, check out its website at:
 </p>
 <p>
-<b>To learn more about the project and to configure Google Fonts embed code from the full set of styles and variable axes, visit the Recursive website at <a href="https://www.recursive.design/">recursive.design</a></b>
+<a href="https://www.recursive.design/">→ recursive.design</a>
+</p>
+
+<p>
+The Recursive project is led by Arrow Type, a type foundry based in Brooklyn, NY, USA. To contribute, see its <a href="https://github.com/arrowtype/recursive">GitHub repo</a>.
 </p>


### PR DESCRIPTION
The current Google Fonts [specimen page for Recursive](https://fonts.google.com/specimen/Recursive) has a description which I believe was meant to only be temporary, and fails to say almost anything about the project:

<img width="725" alt="image" src="https://user-images.githubusercontent.com/7355414/90997468-9f110c00-e58f-11ea-8251-ba3ecc9524c3.png">

This PR adds a description that improves this by adding a bit of detail and making the website link slightly more prominent. It will now look like this:

<img width="830" alt="image" src="https://user-images.githubusercontent.com/7355414/90997737-5b6ad200-e590-11ea-809d-c4cbf43875d5.png">

An earlier version of this PR incorporated ASCII art, but after some offline conversations, I have agreed to simplify. Thanks to everyone for the help, here!

<details>
<summary><b>Earlier version of this PR</b> (Click to expand)</summary>

The Google Fonts specimen page buries the link to the Recursive website, so basically any casual viewer would likely see only a few basic styles but totally miss most of what the project has to offer. This seems like a big miss (having commissioned a font and having worked on the full API, presumably you want to help people make use of both of these). Obviously, though, it is a tricky thing to design a specimen pages that works equally well for all 1000 fonts in the collection, including outliers like Recursive. So, this PR uses a bit of ascii art to make the page design bring a little more attention to the Recursive specimen website.

This is specifically designed to work with the Roboto UI font of Google Fonts, and tested to make sure it displays well down to small screens like the iPhone 5.

<img width="916" alt="image" src="https://user-images.githubusercontent.com/7355414/89716721-62cd9100-d97d-11ea-99f4-54fe014d89ea.png">

<img width="345" alt="image" src="https://user-images.githubusercontent.com/7355414/89716669-fc487300-d97c-11ea-969d-c3e804f30a58.png">

</details>