### PR TITLE
Simplify Arrow Type bio

### DIFF
--- a/catalog/designers/arrowtype/bio.html
+++ b/catalog/designers/arrowtype/bio.html
@@ -1,4 +1,4 @@
-<p>Arrow Type is the type design & development studio of Stephen Nixon. It is named for symbols ( ← ↑ → ↓ ) that
+<p>Arrow Type is a type design & development studio named for symbols ( ← ↑ → ↓ ) that
     are highly useful and present all around us – from public wayfinding to digital user interfaces – yet missing from
     the character sets of many traditional fonts. Arrow Type seeks to uncover and explore other such underserved facets 
     of design & technology, from the aesthetic to the cultural.


### PR DESCRIPTION
Currently, the Recursive page has designer bios that are a bit redundant, saying that Arrow Type is the studio of Stephen Nixon, then also listing my bio right below it. That feels kind of clunky, so this simplifies the Arrow Type bio a bit to avoid being redundant. As a bonus, if I ever end up growing the business, this won’t have to be updated. :)

<img width="833" alt="image" src="https://user-images.githubusercontent.com/7355414/90998149-66723200-e591-11ea-9873-026bcb71b2ff.png">


Before:

> Arrow Type is the type design & development studio of Stephen Nixon. It is named for symbols ( ← ↑ → ↓ ) that are highly useful and present all around us...

After:

> Arrow Type is a type design & development studio named for symbols ( ← ↑ → ↓ ) that are highly useful and present all around us...
