### PR TITLE
Ballet: metadata fix

### DIFF
--- a/ofl/ballet/METADATA.pb
+++ b/ofl/ballet/METADATA.pb
@@ -16,3 +16,8 @@ subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
+axes {
+  tag: "opsz"
+  min_value: 16.0
+  max_value: 72.0
+}


### PR DESCRIPTION
Added opsz to metadata.pb
Fix https://github.com/google/fonts/pull/2696
