### PR TITLE
Ballet: metadata fixed

### DIFF
--- a/ofl/ballet/METADATA.pb
+++ b/ofl/ballet/METADATA.pb
@@ -19,5 +19,6 @@ subsets: "vietnamese"
 axes {
   tag: "opsz"
   min_value: 16.0
+  default_value: 16.0
   max_value: 72.0
 }


### PR DESCRIPTION
Added default_value to opsz axis in METADATA.pb