### PR TITLE
Update travis dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,14 @@
 language: python
 
-dist: xenial 
+dist: focal
 
 python:
-  - "3.7"
+  - "3.8"
 
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y jq
-  - sudo apt-get install -y libfreetype6-dev libglib2.0-dev libcairo2-dev
-  - curl -O "https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-2.3.0.tar.bz2"
-  - tar -xjvf "harfbuzz-2.3.0.tar.bz2"
-  - cd harfbuzz-2.3.0
-  - ./configure --with-cairo=yes
-  - make
-  - cd util
-  - PATH=$(pwd):$PATH
-  - cd ../..
+  - sudo apt-get install -y libharfbuzz-dev libfreetype6-dev libglib2.0-dev libcairo2-dev
 
 install:
   - pip install gftools[qa]


### PR DESCRIPTION
Travis recently [stopped working](https://travis-ci.org/github/google/fonts/builds/733651279) because the latest [pyCairo (v1.20.0)](https://pycairo.readthedocs.io/en/latest/changelog.html#v1-20-0) now requires Cairo 1.15.10+. Instead of just fixing this dependency, I thought I'd review all the dependencies in the .travis.yml file and update them.

By updating the Linux distro, we no longer need to manually upgrade harfbuzz to a version which supports VFs as well.

To verify everything is working, I opened up a PR on my fork, https://github.com/m4rc1e/fonts/pull/224.

