### PR TITLE
Commissioner: METADATA.pb updated with all axes

### DIFF
--- a/ofl/commissioner/METADATA.pb
+++ b/ofl/commissioner/METADATA.pb
@@ -20,6 +20,21 @@ subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
 axes {
+  tag: "FLAR"
+  min_value: 0.0
+  max_value: 100.0
+}
+axes {
+  tag: "VOLM"
+  min_value: 0.0
+  max_value: 100.0
+}
+axes {
+  tag: "slnt"
+  min_value: -12.0
+  max_value: 0.0
+}
+axes {
   tag: "wght"
   min_value: 100.0
   max_value: 900.0


### PR DESCRIPTION
So this is a great opportunity to clarify the metadata default values (related issue: https://github.com/googlefonts/gf-docs/issues/83#issuecomment-706113386)

- Default master has `weight=100` and `METADATA.pd` displays `weight=400`. What should I do ? change it to 100 manually ? or use `registry_default_overrides`?
- VOLUME and FLAIR should be added to the axis registry ?

