### PR TITLE
Categorize Laila as sans-serif

### DIFF
--- a/ofl/laila/METADATA.pb
+++ b/ofl/laila/METADATA.pb
@@ -1,7 +1,7 @@
 name: "Laila"
 designer: "Indian Type Foundry"
 license: "OFL"
-category: "SERIF"
+category: "SANS_SERIF"
 date_added: "2014-08-27"
 fonts {
   name: "Laila"


### PR DESCRIPTION
The description of Laila states: "Laila is an informal sans serif design with brush terminals." However, it's currently categorized as a serif font. Change the categorization to sans.