### PR TITLE
update SOFT axis to close issue #2760

### DIFF
--- a/axisregistry/softness.textproto
+++ b/axisregistry/softness.textproto
@@ -14,7 +14,7 @@ fallback {
   value: 50
 }
 fallback {
-  name: "Extra Soft"
+  name: "SuperSoft"
   value: 100
 }
 description: "Letterforms become more soft and rounded."


### PR DESCRIPTION
Summary: this updates the `SOFT=100` style name to `SuperSoft` to allow fonts to sort alphabetically in a way that is more logical & useful for users.

See https://github.com/google/fonts/issues/2760 for details.

Question: do we mark elided style names in axis definitions? If not, should we?