### PR TITLE
update WONK axis to close issue #2741

### DIFF
--- a/axisregistry/wonkiness.textproto
+++ b/axisregistry/wonkiness.textproto
@@ -6,7 +6,7 @@ max_value: 1
 default_value: 0
 precision: 0
 fallback {
-  name: "NonWonky"
+  name: "Non Wonky"
   value: 0
 }
 fallback {

--- a/axisregistry/wonkiness.textproto
+++ b/axisregistry/wonkiness.textproto
@@ -1,12 +1,12 @@
 # WONK based on https://github.com/undercasetype/Fraunces#variable-axes
 tag: "WONK"
-display_name: "Wonkiness"
+display_name: "Wonky"
 min_value: 0
 max_value: 1
 default_value: 0
 precision: 0
 fallback {
-  name: "Normal"
+  name: "NonWonky"
   value: 0
 }
 fallback {


### PR DESCRIPTION
Summary:
- Updates axis name to “Wonky” to grammatically align with other binary axes such as Italic, Casual, Monospace (these are all `0–1`, `false / partly true / true` axes, so they should probably all have adjectives for names
- Updates “Normal” style name to “NonWonky” for more clarity to users, and to avoid a naming clash with Italic/Normal values for `font-style` in CSS

See https://github.com/google/fonts/issues/2741 for details.