### PR TITLE
Adding Terminal Slope axis registry

### DIFF
--- a/axisregistry/terminal_sharpness.textproto
+++ b/axisregistry/terminal_sharpness.textproto
@@ -1,0 +1,19 @@
+#SHARP based on https://github.com/monokromskriftforlag/geologisk/#variable-axis
+tag: "TSHR"
+display_name: "Terminal_Sharpness"
+min_value: 0.0
+default_value: 0.0
+max_value: 100.0
+precision: 1
+fallback {
+  name: "Flat"
+  value: 0.0
+}
+fallback {
+  name: "Sharp"
+  value: 100.0
+}
+description: "Detailing and terminal treatment."
+  "Modifies the slope of the sans serif stem terminals from flat to pointed"
+  "As the sharpness increase, different levels of acuteness can be set"
+

--- a/axisregistry/terminal_slope.textproto
+++ b/axisregistry/terminal_slope.textproto
@@ -1,6 +1,6 @@
 #SHARP based on https://github.com/monokromskriftforlag/geologisk/#variable-axis
-tag: "TSHR"
-display_name: "Terminal_Sharpness"
+tag: "TSLO"
+display_name: "Terminal_Slope"
 min_value: 0.0
 default_value: 0.0
 max_value: 100.0
@@ -10,10 +10,10 @@ fallback {
   value: 0.0
 }
 fallback {
-  name: "Sharp"
+  name: "Sloped"
   value: 100.0
 }
 description: "Detailing and terminal treatment."
-  "Modifies the slope of the sans serif stem terminals from flat to pointed"
-  "As the sharpness increase, different levels of acuteness can be set"
+  "Modifies the slope of the sans serif stem terminals from flat to sloped"
+  "As the slop increase, different levels of acuteness can be set"
 

--- a/axisregistry/terminal_slope.textproto
+++ b/axisregistry/terminal_slope.textproto
@@ -13,7 +13,5 @@ fallback {
   name: "Sloped"
   value: 100.0
 }
-description: "Detailing and terminal treatment."
-  "Modifies the slope of the sans serif stem terminals from flat to sloped"
-  "As the slop increase, different levels of acuteness can be set"
+description: "Adjust the slope angle of sans-serif stem terminals."
 

--- a/axisregistry/terminal_slope.textproto
+++ b/axisregistry/terminal_slope.textproto
@@ -1,10 +1,10 @@
 #SHARP based on https://github.com/monokromskriftforlag/geologisk/#variable-axis
 tag: "TSLO"
-display_name: "Terminal_Slope"
+display_name: "Terminal slope"
 min_value: 0.0
 default_value: 0.0
 max_value: 100.0
-precision: 1
+precision: -1
 fallback {
   name: "Flat"
   value: 0.0


### PR DESCRIPTION
This axis modifies the slope and sharpness of stem terminals.
The inclusion of it was discussed in https://github.com/google/fonts/issues/2849