### PR TITLE
Axis registry : optical size: 16pt fallback added

### DIFF
--- a/axisregistry/optical_size.textproto
+++ b/axisregistry/optical_size.textproto
@@ -40,6 +40,10 @@ fallback {
   value: 14
 }
 fallback {
+  name: "16pt"
+  value: 16
+}
+fallback {
   name: "18pt"
   value: 18
 }


### PR DESCRIPTION
Quoting @rsheeter : "I don't think you want the default to be a non-fallback; that would mean on a non-VF browser the default is an instance we don't actually create. Probably better to just add the missing fallback."

In order to be able to merge newsreader which default is 16pt, I added this value to the tex proto.