### PR TITLE
RocknRoll One: Version 1.000; ttfautohint (v1.8.3) added

### DIFF
--- a/ofl/rocknrollone/DESCRIPTION.en_us.html
+++ b/ofl/rocknrollone/DESCRIPTION.en_us.html
@@ -1,0 +1,6 @@
+<p>
+RocknRoll is an original pop-style font. The strokes of varying intensity add momentum and the rounded dots create a lively and dynamic feel.  
+</p>
+<p>
+To contribute to the project, visit <a href="https://github.com/fontworks-fonts/RocknRoll">github.com/fontworks-fonts/RocknRoll</a>
+</p>

--- a/ofl/rocknrollone/METADATA.pb
+++ b/ofl/rocknrollone/METADATA.pb
@@ -12,8 +12,6 @@ fonts {
   full_name: "RocknRoll One Regular"
   copyright: "Copyright 2020 The RocknRoll Project Authors (https://github.com/fontworks-fonts/RocknRoll)"
 }
-subsets: "chinese-simplified"
-subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"

--- a/ofl/rocknrollone/METADATA.pb
+++ b/ofl/rocknrollone/METADATA.pb
@@ -1,0 +1,25 @@
+name: "RocknRoll One"
+designer: "Fontworks Inc."
+license: "OFL"
+category: "SANS_SERIF"
+date_added: "2020-12-15"
+fonts {
+  name: "RocknRoll One"
+  style: "normal"
+  weight: 400
+  filename: "RocknRollOne-Regular.ttf"
+  post_script_name: "RocknRollOne-Regular"
+  full_name: "RocknRoll One Regular"
+  copyright: "Copyright 2020 The RocknRoll Project Authors (https://github.com/fontworks-fonts/RocknRoll)"
+}
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
+subsets: "cyrillic"
+subsets: "japanese"
+subsets: "latin"
+subsets: "latin-ext"
+subsets: "menu"
+source {
+  repository_url: "https://github.com/fontworks-fonts/RocknRoll.git"
+  commit: "3c40a139895aadb40811ac84862cb74ca8290216"
+}

--- a/ofl/rocknrollone/METADATA.pb
+++ b/ofl/rocknrollone/METADATA.pb
@@ -19,7 +19,3 @@ subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
-source {
-  repository_url: "https://github.com/fontworks-fonts/RocknRoll.git"
-  commit: "3c40a139895aadb40811ac84862cb74ca8290216"
-}

--- a/ofl/rocknrollone/OFL.txt
+++ b/ofl/rocknrollone/OFL.txt
@@ -1,0 +1,93 @@
+Copyright 2020 The RocknRoll Project Authors (https://github.com/fontworks-fonts/RocknRoll)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/ofl/rocknrollone/upstream.yaml
+++ b/ofl/rocknrollone/upstream.yaml
@@ -3,3 +3,4 @@ files:
   fonts/ttf/RocknRollOne-Regular.ttf: RocknRollOne-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
+repository_url: https://github.com/fontworks-fonts/RocknRoll.git

--- a/ofl/rocknrollone/upstream.yaml
+++ b/ofl/rocknrollone/upstream.yaml
@@ -1,0 +1,5 @@
+branch: master
+files:
+  fonts/ttf/RocknRollOne-Regular.ttf: RocknRollOne-Regular.ttf
+  OFL.txt: OFL.txt
+  DESCRIPTION.en_us.html: DESCRIPTION.en_us.html


### PR DESCRIPTION
 d465353: [gftools-packager] RocknRoll One: Version 1.000; ttfautohint (v1.8.3) added

* RocknRoll One Version 1.000; ttfautohint (v1.8.3) taken from the upstream repo https://github.com/fontworks-fonts/RocknRoll.git at commit https://github.com/fontworks-fonts/RocknRoll/commit/3c40a139895aadb40811ac84862cb74ca8290216.

 00e0eeb: [gftools-packager] ofl/rocknrollone remove METADATA "source".  google/fonts#2587