### PR TITLE
ci: Check server files for typos

### DIFF
--- a/.github/workflows/test_server_files.yaml
+++ b/.github/workflows/test_server_files.yaml
@@ -1,0 +1,23 @@
+# Check to_sandbox.txt and to_production.txt do not contain typos
+name: Google Fonts Test Server Files
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test_server_files:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: pip install gftools[qa]
+    - name: Check server files
+      run: gftools push-status . --lint
+


### PR DESCRIPTION
Check if typos exist in the to_sandbox.txt and to_production.txt files.

This PR relies on https://github.com/googlefonts/gftools/pull/284. Once this is merged and tagged, I'll need to update the pip installation in this gh action.