### PR TITLE
Fix designer attributes in ofl/lexend*/METADATA.pb

### DIFF
--- a/ofl/lexenddeca/METADATA.pb
+++ b/ofl/lexenddeca/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Lexend Deca"
-designer: "Thomas Jockin"
+designer: "Bonnie Shaver-Troup, Thomas Jockin"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2019-08-01"

--- a/ofl/lexendexa/METADATA.pb
+++ b/ofl/lexendexa/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Lexend Exa"
-designer: "Thomas Jockin"
+designer: "Bonnie Shaver-Troup, Thomas Jockin"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2019-08-01"

--- a/ofl/lexendgiga/METADATA.pb
+++ b/ofl/lexendgiga/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Lexend Giga"
-designer: "Thomas Jockin"
+designer: "Bonnie Shaver-Troup, Thomas Jockin"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2019-08-01"

--- a/ofl/lexendmega/METADATA.pb
+++ b/ofl/lexendmega/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Lexend Mega"
-designer: "Thomas Jockin"
+designer: "Bonnie Shaver-Troup, Thomas Jockin"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2019-08-01"

--- a/ofl/lexendpeta/METADATA.pb
+++ b/ofl/lexendpeta/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Lexend Peta"
-designer: "Thomas Jockin"
+designer: "Bonnie Shaver-Troup, Thomas Jockin"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2019-08-01"

--- a/ofl/lexendtera/METADATA.pb
+++ b/ofl/lexendtera/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Lexend Tera"
-designer: "Thomas Jockin"
+designer: "Bonnie Shaver-Troup, Thomas Jockin"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2019-08-01"

--- a/ofl/lexendzetta/METADATA.pb
+++ b/ofl/lexendzetta/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Lexend Zetta"
-designer: "Thomas Jockin"
+designer: "Bonnie Shaver-Troup, Thomas Jockin"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2019-08-01"


### PR DESCRIPTION
This was changed in the internal METADATA files 2019-8-14, but this wasn't back-propagated to this repo, and then regressed to what is in this repo 2020-11-19. 