### PR TITLE
Yusei Magic: Version 1.100; ttfautohint (v1.8.3) added

### DIFF
--- a/ofl/yuseimagic/METADATA.pb
+++ b/ofl/yuseimagic/METADATA.pb
@@ -12,8 +12,6 @@ fonts {
   full_name: "Yusei Magic Regular"
   copyright: "Copyright 2020 The Yusei Magic Project Authors (https://github.com/tanukifont/YuseiMagic)"
 }
-subsets: "chinese-simplified"
-subsets: "chinese-traditional"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/yuseimagic/METADATA.pb
+++ b/ofl/yuseimagic/METADATA.pb
@@ -12,7 +12,13 @@ fonts {
   full_name: "Yusei Magic Regular"
   copyright: "Copyright 2020 The Yusei Magic Project Authors (https://github.com/tanukifont/YuseiMagic)"
 }
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/tanukifont/YuseiMagic.git"
+  commit: "360b28e0e83ed76cb8c51c57c89d239da261880e"
+}

--- a/ofl/yuseimagic/METADATA.pb
+++ b/ofl/yuseimagic/METADATA.pb
@@ -18,7 +18,3 @@ subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
-source {
-  repository_url: "https://github.com/tanukifont/YuseiMagic.git"
-  commit: "360b28e0e83ed76cb8c51c57c89d239da261880e"
-}

--- a/ofl/yuseimagic/upstream.yaml
+++ b/ofl/yuseimagic/upstream.yaml
@@ -3,4 +3,3 @@ files:
   fonts/ttf/YuseiMagic-Regular.ttf: YuseiMagic-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
-repository_url: https://github.com/tanukifont/YuseiMagic.git

--- a/ofl/yuseimagic/upstream.yaml
+++ b/ofl/yuseimagic/upstream.yaml
@@ -3,3 +3,4 @@ files:
   fonts/ttf/YuseiMagic-Regular.ttf: YuseiMagic-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
+repository_url: https://github.com/tanukifont/YuseiMagic.git


### PR DESCRIPTION
 775a45f: [gftools-packager] Yusei Magic: Version 1.100; ttfautohint (v1.8.3) added

* Yusei Magic Version 1.100; ttfautohint (v1.8.3) taken from the upstream repo https://github.com/tanukifont/YuseiMagic.git at commit https://github.com/tanukifont/YuseiMagic/commit/360b28e0e83ed76cb8c51c57c89d239da261880e.

 3896cc7: [gftools-packager] ofl/yuseimagic remove METADATA "source".  google/fonts#2587