### PR TITLE
Raleway: Multiple designers fix

### DIFF
--- a/ofl/raleway/METADATA.pb
+++ b/ofl/raleway/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Raleway"
-designer: "Multiple Designers"
+designer: "Matt McInerney, Pablo Impallari, Rodrigo Fuenzalida"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2012-09-07"


### PR DESCRIPTION
Only METADATA.pb updated, designers changed to:

- Matt McInerney, Pablo Impallari, Rodrigo Fuenzalida

**Note:** This project wasn't included in the list of the original Issue #3103. Nevertheless, when working on Raleway Dots I found this is also a "Multiple Designers" project to be fixed. I didn't see it included in the latest PR neither assigned to anyone, so I decided to include it.