### PR TITLE
Chathura: removed ITC from designer

### DIFF
--- a/ofl/chathura/METADATA.pb
+++ b/ofl/chathura/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Chathura"
-designer: "Appaji Ambarisha Darbha, Indian Type Foundry"
+designer: "Appaji Ambarisha Darbha"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2017-05-09"


### PR DESCRIPTION
For the records:
- The Latin part of this font was taken from one of ITC's fonts, so they are part of the copyright holders. 
- This PR is removing their name at their own demand (cf https://twitter.com/SatyaRajpurohit/status/1382276852161466373)