### PR TITLE
Fix broken link (typo) in Red Hat Display description

### DIFF
--- a/ofl/redhatdisplay/DESCRIPTION.en_us.html
+++ b/ofl/redhatdisplay/DESCRIPTION.en_us.html
@@ -1,6 +1,6 @@
 <p>Red Hat is a family of typefaces produced in 2 optical sizes, in a range of weights with italics. The fonts were originally commissioned by Paula Scher, Pentagram and designed by Jeremy Mickel, MCKL for the new Red Hat identity.</p>
 
-<p>Red Hat is a fresh take on the geometric sans genre, taking inspiration from a range of American sans serifs including Tempo and Highway Gothic. The Display styles are low contrast and spaced tightly, with a large x-height and open counters. The <a href="https://fonts.google.com/specimen/Redt+Hat+Text">Text</a> styles have a slightly smaller x-height and narrower width for better legibility, are spaced more generously, and have thinned joins for better performance at small sizes. The two families can be used together seamlessly at a range of sizes.</p>
+<p>Red Hat is a fresh take on the geometric sans genre, taking inspiration from a range of American sans serifs including Tempo and Highway Gothic. The Display styles are low contrast and spaced tightly, with a large x-height and open counters. The <a href="https://fonts.google.com/specimen/Red+Hat+Text">Text</a> styles have a slightly smaller x-height and narrower width for better legibility, are spaced more generously, and have thinned joins for better performance at small sizes. The two families can be used together seamlessly at a range of sizes.</p>
 
 <p>As part of Red Hat’s commitment to open source software, the fonts are made available for use under the SIL Open Font License.</p>
 


### PR DESCRIPTION
There's a typo in the link from the Red Hat Display page to the Red Hat Text page. This fixes it.