### PR TITLE
DotGothic16: Version 1.100 added

### DIFF
--- a/ofl/dotgothic16/DESCRIPTION.en_us.html
+++ b/ofl/dotgothic16/DESCRIPTION.en_us.html
@@ -1,5 +1,5 @@
 <p>
-Dotgothic 16 is based on the old 16x16 Gothic bitmap font that can best recreate the feel of pixel fonts from old video games, cell phones and computer screens on print. With its high readability, this font has become more popular in recent years due to the growing popularity of pixel art.
+Dotgothic 16 is based on the old 16x16 Gothic bitmap font that recreates the feel of pixel fonts from old video games, cell phones and computer screens on print. With its high readability, this font has become more popular in recent years due to the growing popularity of pixel art.
 </p>
 <p>
 To contribute to the project, visit <a href="https://github.com/fontworks-fonts/DotGothic16">github.com/fontworks-fonts/DotGothic16</a>

--- a/ofl/dotgothic16/METADATA.pb
+++ b/ofl/dotgothic16/METADATA.pb
@@ -12,8 +12,14 @@ fonts {
   full_name: "DotGothic16 Regular"
   copyright: "Copyright 2020 The DotGothic16 Project Authors (https://github.com/fontworks-fonts/DotGothic16/)"
 }
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/fontworks-fonts/DotGothic16.git"
+  commit: "e44ca7bb46e7f353302c1431bf752af007c4fdfe"
+}

--- a/ofl/dotgothic16/upstream.yaml
+++ b/ofl/dotgothic16/upstream.yaml
@@ -3,4 +3,3 @@ files:
   fonts/ttf/DotGothic16-Regular.ttf: DotGothic16-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
-repository_url: https://github.com/fontworks-fonts/DotGothic16.git


### PR DESCRIPTION
 835ff3b: [gftools-packager] DotGothic16: Version 1.100 added

* DotGothic16 Version 1.100 taken from the upstream repo https://github.com/fontworks-fonts/DotGothic16.git at commit https://github.com/fontworks-fonts/DotGothic16/commit/e44ca7bb46e7f353302c1431bf752af007c4fdfe.