### PR TITLE
Reggae One: Version 1.100 added

### DIFF
--- a/ofl/reggaeone/METADATA.pb
+++ b/ofl/reggaeone/METADATA.pb
@@ -12,8 +12,6 @@ fonts {
   full_name: "Reggae One Regular"
   copyright: "Copyright 2020 The Reggae Project Authors (https://github.com/fontworks-fonts/Reggae/), all rights reserved."
 }
-subsets: "chinese-simplified"
-subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"

--- a/ofl/reggaeone/METADATA.pb
+++ b/ofl/reggaeone/METADATA.pb
@@ -19,7 +19,3 @@ subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
-source {
-  repository_url: "https://github.com/fontworks-fonts/Reggae.git"
-  commit: "fe9be09d02ad8ba5e71d5ce24efc5249fe77dcfc"
-}

--- a/ofl/reggaeone/METADATA.pb
+++ b/ofl/reggaeone/METADATA.pb
@@ -12,8 +12,14 @@ fonts {
   full_name: "Reggae One Regular"
   copyright: "Copyright 2020 The Reggae Project Authors (https://github.com/fontworks-fonts/Reggae/), all rights reserved."
 }
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/fontworks-fonts/Reggae.git"
+  commit: "fe9be09d02ad8ba5e71d5ce24efc5249fe77dcfc"
+}

--- a/ofl/reggaeone/upstream.yaml
+++ b/ofl/reggaeone/upstream.yaml
@@ -3,3 +3,4 @@ files:
   fonts/ttf/ReggaeOne-Regular.ttf: ReggaeOne-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
+repository_url: https://github.com/fontworks-fonts/Reggae.git

--- a/ofl/reggaeone/upstream.yaml
+++ b/ofl/reggaeone/upstream.yaml
@@ -3,4 +3,3 @@ files:
   fonts/ttf/ReggaeOne-Regular.ttf: ReggaeOne-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
-repository_url: https://github.com/fontworks-fonts/Reggae.git


### PR DESCRIPTION
 1e43012: [gftools-packager] Reggae One: Version 1.100 added

* Reggae One Version 1.100 taken from the upstream repo https://github.com/fontworks-fonts/Reggae.git at commit https://github.com/fontworks-fonts/Reggae/commit/d50383dfdd2f147e76b90277e4becba36d9ad4dd.