### PR TITLE
RocknRoll One: Version 1.100 added

### DIFF
--- a/ofl/rocknrollone/METADATA.pb
+++ b/ofl/rocknrollone/METADATA.pb
@@ -12,8 +12,14 @@ fonts {
   full_name: "RocknRoll One Regular"
   copyright: "Copyright 2020 The RocknRoll Project Authors (https://github.com/fontworks-fonts/RocknRoll)"
 }
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/fontworks-fonts/RocknRoll.git"
+  commit: "fdaf96faba984006fb8d2224872ecbd736ccab41"
+}

--- a/ofl/rocknrollone/METADATA.pb
+++ b/ofl/rocknrollone/METADATA.pb
@@ -12,14 +12,8 @@ fonts {
   full_name: "RocknRoll One Regular"
   copyright: "Copyright 2020 The RocknRoll Project Authors (https://github.com/fontworks-fonts/RocknRoll)"
 }
-subsets: "chinese-simplified"
-subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
-source {
-  repository_url: "https://github.com/fontworks-fonts/RocknRoll.git"
-  commit: "fdaf96faba984006fb8d2224872ecbd736ccab41"
-}

--- a/ofl/rocknrollone/upstream.yaml
+++ b/ofl/rocknrollone/upstream.yaml
@@ -3,3 +3,4 @@ files:
   fonts/ttf/RocknRollOne-Regular.ttf: RocknRollOne-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
+repository_url: https://github.com/fontworks-fonts/RocknRoll.git

--- a/ofl/rocknrollone/upstream.yaml
+++ b/ofl/rocknrollone/upstream.yaml
@@ -3,4 +3,3 @@ files:
   fonts/ttf/RocknRollOne-Regular.ttf: RocknRollOne-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
-repository_url: https://github.com/fontworks-fonts/RocknRoll.git


### PR DESCRIPTION
 1753cd1: [gftools-packager] RocknRoll One: Version 1.100 added

* RocknRoll One Version 1.100 taken from the upstream repo https://github.com/fontworks-fonts/RocknRoll.git at commit https://github.com/fontworks-fonts/RocknRoll/commit/fdaf96faba984006fb8d2224872ecbd736ccab41.