### PR TITLE
Stick: Version 1.100 added

### DIFF
--- a/ofl/stick/METADATA.pb
+++ b/ofl/stick/METADATA.pb
@@ -12,8 +12,14 @@ fonts {
   full_name: "Stick Regular"
   copyright: "Copyright 2020 The Stick Project Authors (https://github.com/fontworks-fonts/Stick/)"
 }
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/fontworks-fonts/Stick.git"
+  commit: "7872941e6d29cb238ea7cc8d0e1d1499d02bc482"
+}

--- a/ofl/stick/METADATA.pb
+++ b/ofl/stick/METADATA.pb
@@ -12,14 +12,8 @@ fonts {
   full_name: "Stick Regular"
   copyright: "Copyright 2020 The Stick Project Authors (https://github.com/fontworks-fonts/Stick/)"
 }
-subsets: "chinese-simplified"
-subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
-source {
-  repository_url: "https://github.com/fontworks-fonts/Stick.git"
-  commit: "7872941e6d29cb238ea7cc8d0e1d1499d02bc482"
-}

--- a/ofl/stick/upstream.yaml
+++ b/ofl/stick/upstream.yaml
@@ -3,4 +3,3 @@ files:
   fonts/ttf/Stick-Regular.ttf: Stick-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
-repository_url: https://github.com/fontworks-fonts/Stick.git

--- a/ofl/stick/upstream.yaml
+++ b/ofl/stick/upstream.yaml
@@ -3,3 +3,4 @@ files:
   fonts/ttf/Stick-Regular.ttf: Stick-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
+repository_url: https://github.com/fontworks-fonts/Stick.git


### PR DESCRIPTION
 2d0856d: [gftools-packager] Stick: Version 1.100 added

* Stick Version 1.100 taken from the upstream repo https://github.com/fontworks-fonts/Stick.git at commit https://github.com/fontworks-fonts/Stick/commit/7872941e6d29cb238ea7cc8d0e1d1499d02bc482.