### PR TITLE
Train One: Version 1.100 added

### DIFF
--- a/ofl/trainone/METADATA.pb
+++ b/ofl/trainone/METADATA.pb
@@ -17,7 +17,3 @@ subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
-source {
-  repository_url: "https://github.com/fontworks-fonts/Train.git"
-  commit: "7c77b21fbff6c182395862ab07273cb15423803e"
-}

--- a/ofl/trainone/METADATA.pb
+++ b/ofl/trainone/METADATA.pb
@@ -17,3 +17,7 @@ subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/fontworks-fonts/Train.git"
+  commit: "7c77b21fbff6c182395862ab07273cb15423803e"
+}

--- a/ofl/trainone/upstream.yaml
+++ b/ofl/trainone/upstream.yaml
@@ -3,3 +3,4 @@ files:
   fonts/ttf/TrainOne-Regular.ttf: TrainOne-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
+repository_url: https://github.com/fontworks-fonts/Train.git

--- a/ofl/trainone/upstream.yaml
+++ b/ofl/trainone/upstream.yaml
@@ -3,4 +3,3 @@ files:
   fonts/ttf/TrainOne-Regular.ttf: TrainOne-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
-repository_url: https://github.com/fontworks-fonts/Train.git


### PR DESCRIPTION
 1f72f9f: [gftools-packager] Train One: Version 1.100 added

* Train One Version 1.100 taken from the upstream repo https://github.com/fontworks-fonts/Train.git at commit https://github.com/fontworks-fonts/Train/commit/7c77b21fbff6c182395862ab07273cb15423803e.