### PR TITLE
Yusei Magic: Version 1.200 added

### DIFF
--- a/ofl/yuseimagic/METADATA.pb
+++ b/ofl/yuseimagic/METADATA.pb
@@ -12,7 +12,13 @@ fonts {
   full_name: "Yusei Magic Regular"
   copyright: "Copyright 2020 The Yusei Magic Project Authors (https://github.com/tanukifont/YuseiMagic)"
 }
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/tanukifont/YuseiMagic.git"
+  commit: "77e9fd3bcea003fc115f377cbd0f2fe2963d4979"
+}

--- a/ofl/yuseimagic/METADATA.pb
+++ b/ofl/yuseimagic/METADATA.pb
@@ -12,13 +12,7 @@ fonts {
   full_name: "Yusei Magic Regular"
   copyright: "Copyright 2020 The Yusei Magic Project Authors (https://github.com/tanukifont/YuseiMagic)"
 }
-subsets: "chinese-simplified"
-subsets: "chinese-traditional"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
-source {
-  repository_url: "https://github.com/tanukifont/YuseiMagic.git"
-  commit: "77e9fd3bcea003fc115f377cbd0f2fe2963d4979"
-}

--- a/ofl/yuseimagic/upstream.yaml
+++ b/ofl/yuseimagic/upstream.yaml
@@ -3,4 +3,3 @@ files:
   fonts/ttf/YuseiMagic-Regular.ttf: YuseiMagic-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
-repository_url: https://github.com/tanukifont/YuseiMagic.git

--- a/ofl/yuseimagic/upstream.yaml
+++ b/ofl/yuseimagic/upstream.yaml
@@ -3,3 +3,4 @@ files:
   fonts/ttf/YuseiMagic-Regular.ttf: YuseiMagic-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
+repository_url: https://github.com/tanukifont/YuseiMagic.git


### PR DESCRIPTION
 0af35da: [gftools-packager] Yusei Magic: Version 1.200 added

* Yusei Magic Version 1.200 taken from the upstream repo https://github.com/tanukifont/YuseiMagic.git at commit https://github.com/tanukifont/YuseiMagic/commit/77e9fd3bcea003fc115f377cbd0f2fe2963d4979.