### PR TITLE
Kiwi Maru: Version 1.100 added

### DIFF
--- a/ofl/kiwimaru/DESCRIPTION.en_us.html
+++ b/ofl/kiwimaru/DESCRIPTION.en_us.html
@@ -1,5 +1,5 @@
 <p>
-Kiwi Maru was created mainly for use in digital devices, and I hope you will use it experimentally in your papers and reports.
+Kiwi Maru was created mainly for use in digital devices, and I hope you will use it experimentally in your web fonts, papers and reports.
 </p>
 <p>
 The basic vocabulary of the Japanese language is divided into three categories: "everyday words", which are used freely in everyday conversation, articles and novels, "written words", which are used in official situations and sentences, and "slang", which is more informal in style.

--- a/ofl/kiwimaru/DESCRIPTION.en_us.html
+++ b/ofl/kiwimaru/DESCRIPTION.en_us.html
@@ -1,5 +1,5 @@
 <p>
-Kiwi Maru was created mainly for use in digital devices, and I hope you will use it experimentally in your web fonts, papers and reports.
+Kiwi Maru was created mainly for use in digital devices, and I hope you will use it experimentally in your papers and reports.
 </p>
 <p>
 The basic vocabulary of the Japanese language is divided into three categories: "everyday words", which are used freely in everyday conversation, articles and novels, "written words", which are used in official situations and sentences, and "slang", which is more informal in style.

--- a/ofl/kiwimaru/METADATA.pb
+++ b/ofl/kiwimaru/METADATA.pb
@@ -30,8 +30,14 @@ fonts {
   full_name: "Kiwi Maru Medium"
   copyright: "Copyright 2020 The Kiwi Maru Project Authors (https://github.com/Kiwi-KawagotoKajiru/Kiwi-Maru)"
 }
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+source {
+  repository_url: "https://github.com/Kiwi-KawagotoKajiru/Kiwi-Maru.git"
+  commit: "65a112c7ec9ffe81595406982a670c7f945d7c5b"
+}

--- a/ofl/kiwimaru/METADATA.pb
+++ b/ofl/kiwimaru/METADATA.pb
@@ -30,14 +30,8 @@ fonts {
   full_name: "Kiwi Maru Medium"
   copyright: "Copyright 2020 The Kiwi Maru Project Authors (https://github.com/Kiwi-KawagotoKajiru/Kiwi-Maru)"
 }
-subsets: "chinese-simplified"
-subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
-source {
-  repository_url: "https://github.com/Kiwi-KawagotoKajiru/Kiwi-Maru.git"
-  commit: "65a112c7ec9ffe81595406982a670c7f945d7c5b"
-}

--- a/ofl/kiwimaru/upstream.yaml
+++ b/ofl/kiwimaru/upstream.yaml
@@ -5,3 +5,4 @@ files:
   fonts/ttf/KiwiMaru-Regular.ttf: KiwiMaru-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
+repository_url: https://github.com/Kiwi-KawagotoKajiru/Kiwi-Maru.git

--- a/ofl/kiwimaru/upstream.yaml
+++ b/ofl/kiwimaru/upstream.yaml
@@ -5,4 +5,3 @@ files:
   fonts/ttf/KiwiMaru-Regular.ttf: KiwiMaru-Regular.ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
-repository_url: https://github.com/Kiwi-KawagotoKajiru/Kiwi-Maru.git


### PR DESCRIPTION
 194516d: [gftools-packager] Kiwi Maru: Version 1.100 added

* Kiwi Maru Version 1.100 taken from the upstream repo https://github.com/Kiwi-KawagotoKajiru/Kiwi-Maru.git at commit https://github.com/Kiwi-KawagotoKajiru/Kiwi-Maru/commit/65a112c7ec9ffe81595406982a670c7f945d7c5b.