### PR TITLE
Yomogi: Version 3.100 added

### DIFF
--- a/ofl/yomogi/METADATA.pb
+++ b/ofl/yomogi/METADATA.pb
@@ -12,15 +12,9 @@ fonts {
   full_name: "Yomogi Regular"
   copyright: "Copyright 2020 The Yomogi Project Authors (https://github.com/satsuyako/YomogiFont), all rights reserved."
 }
-subsets: "chinese-simplified"
-subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
-source {
-  repository_url: "https://github.com/satsuyako/YomogiFont.git"
-  commit: "27a69d9253eb61d46772f65fcb7362647cedd148"
-}

--- a/ofl/yomogi/METADATA.pb
+++ b/ofl/yomogi/METADATA.pb
@@ -12,9 +12,15 @@ fonts {
   full_name: "Yomogi Regular"
   copyright: "Copyright 2020 The Yomogi Project Authors (https://github.com/satsuyako/YomogiFont), all rights reserved."
 }
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
+source {
+  repository_url: "https://github.com/satsuyako/YomogiFont.git"
+  commit: "27a69d9253eb61d46772f65fcb7362647cedd148"
+}


### PR DESCRIPTION
 8e77782: [gftools-packager] Yomogi: Version 3.100 added

* Yomogi Version 3.100 taken from the upstream repo https://github.com/satsuyako/YomogiFont.git at commit https://github.com/satsuyako/YomogiFont/commit/27a69d9253eb61d46772f65fcb7362647cedd148.