### PR TITLE
Add all Roboto Flex axes except YTFI 

### DIFF
--- a/axisregistry/x_opaque.textproto
+++ b/axisregistry/x_opaque.textproto
@@ -1,0 +1,13 @@
+# XOPQ based on https://variationsguide.typenetwork.com/#xopq
+tag: "XOPQ"
+display_name: "Y transparent"
+min_value: -1000
+max_value: 2000
+default_value: 88
+precision: 0
+fallback {
+  name: "Normal"
+  value: 0
+}
+description:
+  "Assigns a 'black' per mille value to each instance of the design space."

--- a/axisregistry/x_transparent.textproto
+++ b/axisregistry/x_transparent.textproto
@@ -1,0 +1,13 @@
+# XTRA based on https://variationsguide.typenetwork.com/#xtra
+tag: "XTRA"
+display_name: "X transparent"
+min_value: -1000
+max_value: 2000
+default_value: 400
+precision: 0
+fallback {
+  name: "Normal"
+  value: 400
+}
+description:
+  "Assigns a 'white'”' per mille value to each instance of the design space."

--- a/axisregistry/y_opaque.textproto
+++ b/axisregistry/y_opaque.textproto
@@ -1,0 +1,13 @@
+# YOPQ based on https://variationsguide.typenetwork.com/#yopq
+tag: "YOPQ"
+display_name: "Y transparent"
+min_value: -1000
+max_value: 2000
+default_value: 116
+precision: 0
+fallback {
+  name: "Normal"
+  value: 116
+}
+description:
+  "Assigns a 'black' per mille value to each instance of the design space."

--- a/axisregistry/y_transparent_ascender.textproto
+++ b/axisregistry/y_transparent_ascender.textproto
@@ -1,0 +1,13 @@
+# YTAS based on https://variationsguide.typenetwork.com/#ytas
+tag: "YTAS"
+display_name: "Y transparent ascender"
+min_value: 0
+max_value: 1000
+default_value: 750
+precision: 0
+fallback {
+  name: "Normal"
+  value: 750
+}
+description:
+  "Assigns a 'white' per mille value to each instance of the design space."

--- a/axisregistry/y_transparent_descender.textproto
+++ b/axisregistry/y_transparent_descender.textproto
@@ -1,0 +1,13 @@
+# YTDE based on https://variationsguide.typenetwork.com/#ytde
+tag: "YTDE"
+display_name: "Y transparent descender"
+min_value: -1000
+max_value: 0
+default_value: -250
+precision: 0
+fallback {
+  name: "Normal"
+  value: -250
+}
+description:
+  "Assigns a 'white' per mille value to each instance of the design space."

--- a/axisregistry/y_transparent_lowercase.textproto
+++ b/axisregistry/y_transparent_lowercase.textproto
@@ -1,0 +1,13 @@
+# YTLC based on https://variationsguide.typenetwork.com/#ytlc
+tag: "YTLC"
+display_name: "Y transparent"
+min_value: 0
+max_value: 1000
+default_value: 500
+precision: 0
+fallback {
+  name: "Normal"
+  value: 500
+}
+description:
+  "Assigns a 'white' per mille value to each instance of the design space."

--- a/axisregistry/y_transparent_uppercase.textproto
+++ b/axisregistry/y_transparent_uppercase.textproto
@@ -1,0 +1,13 @@
+# YTUC based on https://variationsguide.typenetwork.com/#ytuc
+tag: "YTUC"
+display_name: "Y transparent uppercase"
+min_value: -1000
+max_value: 1000
+default_value: 500
+precision: 0
+fallback {
+  name: "Normal"
+  value: 725
+}
+description:
+  "Assigns a 'white' per mille value to each instance of the design space."


### PR DESCRIPTION
Exploratory addition of axes for Roboto Flex. Don't stress the descriptions too much as these are just to experiment with for now.

YTFI is not defined in https://variationsguide.typenetwork.com/