### PR TITLE
Manuale METADATA correction

### DIFF
--- a/ofl/manuale/METADATA.pb
+++ b/ofl/manuale/METADATA.pb
@@ -10,7 +10,7 @@ fonts {
   filename: "Manuale[wght].ttf"
   post_script_name: "Manuale-Regular"
   full_name: "Manuale Regular"
-  copyright: "Copyright 2016 The Manuale Project Authors (https://github.com/Omnibus-Type/Manuale)"
+  copyright: "Copyright 2019 The Manuale Project Authors (https://github.com/Omnibus-Type/Manuale)"
 }
 fonts {
   name: "Manuale"
@@ -19,7 +19,7 @@ fonts {
   filename: "Manuale-Italic[wght].ttf"
   post_script_name: "Manuale-Italic"
   full_name: "Manuale Italic"
-  copyright: "Copyright 2016 The Manuale Project Authors (https://github.com/Omnibus-Type/Manuale)"
+  copyright: "Copyright 2019 The Manuale Project Authors (https://github.com/Omnibus-Type/Manuale)"
 }
 subsets: "latin"
 subsets: "latin-ext"
@@ -27,6 +27,6 @@ subsets: "menu"
 subsets: "vietnamese"
 axes {
   tag: "wght"
-  min_value: 400.0
-  max_value: 700.0
+  min_value: 300.0
+  max_value: 800.0
 }


### PR DESCRIPTION
Corrected the METADATA file for Manuale to align with the variable font. 

Closes #3741