### PR TITLE
Hahmlet: Version 1.002 added

### DIFF
--- a/ofl/hahmlet/METADATA.pb
+++ b/ofl/hahmlet/METADATA.pb
@@ -9,7 +9,7 @@ fonts {
   weight: 400
   filename: "Hahmlet[wght].ttf"
   post_script_name: "Hahmlet-Regular"
-  full_name: "Hahmlet"
+  full_name: "Hahmlet Regular"
   copyright: "Copyright 2020 The Hahmlet Project Authors (https://github.com/hyper-type/hahmlet)"
 }
 subsets: "korean"
@@ -24,5 +24,5 @@ axes {
 }
 source {
   repository_url: "https://github.com/hyper-type/hahmlet"
-  commit: "98a376949035fe079839c17ad95db7917ec35ef4"
+  commit: "106541144954a9b7037b8d3837097ba660312655"
 }

--- a/ofl/hahmlet/METADATA.pb
+++ b/ofl/hahmlet/METADATA.pb
@@ -22,7 +22,3 @@ axes {
   min_value: 100.0
   max_value: 900.0
 }
-source {
-  repository_url: "https://github.com/hyper-type/hahmlet"
-  commit: "106541144954a9b7037b8d3837097ba660312655"
-}

--- a/ofl/hahmlet/upstream.yaml
+++ b/ofl/hahmlet/upstream.yaml
@@ -1,14 +1,5 @@
 branch: master
 files:
-  fonts/ttf/Hahmlet-Thin.ttf: static/Hahmlet-Thin.ttf
-  fonts/ttf/Hahmlet-ExtraLight.ttf: static/Hahmlet-ExtraLight.ttf
-  fonts/ttf/Hahmlet-Light.ttf: static/Hahmlet-Light.ttf
-  fonts/ttf/Hahmlet-Regular.ttf: static/Hahmlet-Regular.ttf
-  fonts/ttf/Hahmlet-Medium.ttf: static/Hahmlet-Medium.ttf
-  fonts/ttf/Hahmlet-SemiBold.ttf: static/Hahmlet-SemiBold.ttf
-  fonts/ttf/Hahmlet-Bold.ttf: static/Hahmlet-Bold.ttf
-  fonts/ttf/Hahmlet-ExtraBold.ttf: static/Hahmlet-ExtraBold.ttf
-  fonts/ttf/Hahmlet-Black.ttf: static/Hahmlet-Black.ttf
   fonts/variable/Hahmlet[wght].ttf: Hahmlet[wght].ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html

--- a/ofl/hahmlet/upstream.yaml
+++ b/ofl/hahmlet/upstream.yaml
@@ -3,3 +3,4 @@ files:
   fonts/variable/Hahmlet[wght].ttf: Hahmlet[wght].ttf
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
+repository_url: https://github.com/hyper-type/hahmlet/


### PR DESCRIPTION
 7b68803: [gftools-packager] Hahmlet: Version 1.002 added

* Hahmlet Version 1.002 taken from the upstream repo https://github.com/hyper-type/hahmlet at commit https://github.com/hyper-type/hahmlet/commit/106541144954a9b7037b8d3837097ba660312655.