### PR TITLE
Yuji Hentaigana Akira+Akebono : japanese subset added to metadata.pb

### DIFF
--- a/ofl/cherrybomb/METADATA.pb
+++ b/ofl/cherrybomb/METADATA.pb
@@ -12,8 +12,8 @@ fonts {
   full_name: "Cherry Bomb Regular"
   copyright: "Copyright 2019 The Cherry Bomb Project Authors (https://github.com/satsuyako/CherryBomb)"
 }
+subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
-subsets: "japanese"
 subsets: "vietnamese"

--- a/ofl/cherrybomb/METADATA.pb
+++ b/ofl/cherrybomb/METADATA.pb
@@ -12,8 +12,8 @@ fonts {
   full_name: "Cherry Bomb Regular"
   copyright: "Copyright 2019 The Cherry Bomb Project Authors (https://github.com/satsuyako/CherryBomb)"
 }
-subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+subsets: "japanese"
 subsets: "vietnamese"

--- a/ofl/yujihentaiganaakari/METADATA.pb
+++ b/ofl/yujihentaiganaakari/METADATA.pb
@@ -12,6 +12,7 @@ fonts {
   full_name: "Yuji Hentaigana Akari Regular"
   copyright: "Copyright 2021 The Yuji Project Authors (https://github.com/Kinutafontfactory/Yuji)"
 }
+subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"

--- a/ofl/yujihentaiganaakebono/METADATA.pb
+++ b/ofl/yujihentaiganaakebono/METADATA.pb
@@ -12,6 +12,7 @@ fonts {
   full_name: "Yuji Hentaigana Akebono Regular"
   copyright: "Copyright 2021 The Yuji Project Authors (https://github.com/Kinutafontfactory/Yuji)"
 }
+subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"


### PR DESCRIPTION
As the packager doesn't automatically add the Japanese subset to the Yuji fonts (due to their limited Japanese character set), I've manually re-added the subset.

Additionally, while checking the other Kana-only fonts, I found that cherry bomb's is mis-ordered (should be alphabetical) and corrected that.