### PR TITLE
Manrope: subsets added to metadata

### DIFF
--- a/ofl/manrope/METADATA.pb
+++ b/ofl/manrope/METADATA.pb
@@ -13,10 +13,12 @@ fonts {
   copyright: "Copyright 2019 The Manrope Project Authors (https://github.com/sharanda/manrope)"
 }
 subsets: "cyrillic"
+subsets: "cyrillic-ext"
 subsets: "greek"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
+subsets: "vietnamese"
 axes {
   tag: "wght"
   min_value: 200.0


### PR DESCRIPTION
run add-font on Manrope to fix #3863 
