### PR TITLE
Redacted: version 1.000 metadata updated

### DIFF
--- a/ofl/redacted/METADATA.pb
+++ b/ofl/redacted/METADATA.pb
@@ -10,7 +10,8 @@ fonts {
   filename: "Redacted-Regular.ttf"
   post_script_name: "RedactedRegular"
   full_name: "Redacted Regular"
-  copyright: "Copyright (c) 2013, Christian Naths (christiannaths@gmail.com christiannaths.com)"
+  copyright: "Copyright © 2013 Christian Naths. All rights reserved."
 }
-subsets: "menu"
 subsets: "latin"
+subsets: "latin-ext"
+subsets: "menu"


### PR DESCRIPTION
To fix #3888 
I just run `add-font` to trigger gh-action +  inspect and correct metadada.pb.

>When emailing the gf eng team we'll need to note the menu subset needs to be made from Roboto

@davelab6 do you mean all of this whatever the font actually contains?

```
subsets: "cyrillic"
subsets: "cyrillic-ext"
subsets: "greek"
subsets: "greek-ext"
subsets: "latin"
subsets: "latin-ext"
subsets: "menu"
subsets: "vietnamese"
```
