### PR TITLE
Estonia: Version 1.014; ttfautohint (v1.8.3) added

### DIFF
--- a/ofl/estonia/METADATA.pb
+++ b/ofl/estonia/METADATA.pb
@@ -16,7 +16,3 @@ subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
-source {
-  repository_url: "https://github.com/googlefonts/estonia"
-  commit: "d4ee6f0558f9af9ad0cc950e740a81eb95b36526"
-}

--- a/ofl/estonia/upstream.yaml
+++ b/ofl/estonia/upstream.yaml
@@ -3,3 +3,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   fonts/ttf/Estonia-Regular.ttf: Estonia-Regular.ttf
+repository_url: https://github.com/googlefonts/estonia


### PR DESCRIPTION
 79fb7cd: [gftools-packager] Estonia: Version 1.014; ttfautohint (v1.8.3) added

* Estonia Version 1.014; ttfautohint (v1.8.3) taken from the upstream repo https://github.com/googlefonts/estonia at commit https://github.com/googlefonts/estonia/commit/d4ee6f0558f9af9ad0cc950e740a81eb95b36526.

 d1bc3ed: [gftools-packager] ofl/estonia remove METADATA "source".  google/fonts#2587

fixes #3039