### PR TITLE
Update METADATA.pb for Nokora to fix license value

### DIFF
--- a/ofl/nokora/METADATA.pb
+++ b/ofl/nokora/METADATA.pb
@@ -1,6 +1,6 @@
 name: "Nokora"
 designer: "Danh Hong"
-license: "APACHE2"
+license: "OFL"
 category: "SANS_SERIF"
 date_added: "2011-11-09"
 fonts {


### PR DESCRIPTION
@yanone @RosaWagner note that "APACHE" and "OFL" are the allowed values for the license key, I'm curious how this slipped through, but I'd like to move this to OFL in any case.