### PR TITLE
inconsolata/METADATA.pb Add 2nd sans category

### DIFF
--- a/ofl/inconsolata/METADATA.pb
+++ b/ofl/inconsolata/METADATA.pb
@@ -1,8 +1,8 @@
 name: "Inconsolata"
 designer: "Raph Levien"
 license: "OFL"
+category: "SANS_SERIF"
 category: "MONOSPACE"
-# category: "SANS_SERIF"
 date_added: "2010-02-19"
 fonts {
   name: "Inconsolata"

--- a/ofl/inconsolata/METADATA.pb
+++ b/ofl/inconsolata/METADATA.pb
@@ -2,6 +2,7 @@ name: "Inconsolata"
 designer: "Raph Levien"
 license: "OFL"
 category: "MONOSPACE"
+# category: "SANS_SERIF"
 date_added: "2010-02-19"
 fonts {
   name: "Inconsolata"


### PR DESCRIPTION
This is how I expect we'll add more than 1 category to metadata; the 2nd+ category keys MUST be commented out for now, but we can start adding the data we have to new PRs this way, and then uncomment them when downstream is ready