### PR TITLE
Fredoka: updated metadata and description

### DIFF
--- a/ofl/fredoka/DESCRIPTION.en_us.html
+++ b/ofl/fredoka/DESCRIPTION.en_us.html
@@ -1,8 +1,11 @@
 <p>
-Fredoka One is a big, round, bold font that is perfect for adding a little fun to any headline or large text.
+Fredoka is a big, round, bold font that is perfect for adding a little fun to any headline or large text.
 </p>
 <p>
 The initial Latin component was designed by Milena Brandão. The later Hebrew component was designed by Ben Nathan.
+</p>
+<p>
+This font is the upgrade to variable font (with a width and weight axes) of <a href="https://fonts.google.com/specimen/Fredoka+One">Fredoka One</a>.
 </p>
 <p>
 The Fredoka project is led by Ben Nathan, a typeer design foundry based in Israel. To contribute, see <a href="https://github.com/hafontia-zz/Fredoka-One">github.com/hafontia/Fredoka-One</a>.

--- a/ofl/fredoka/METADATA.pb
+++ b/ofl/fredoka/METADATA.pb
@@ -26,7 +26,152 @@ axes {
   min_value: 300.0
   max_value: 700.0
 }
-source {
-  repository_url: "https://github.com/hafontia-zz/Fredoka-One"
-  commit: "04d5e5545f807f1c4e80404e29e0b38d6775a996"
-}
+languages: "aa_Latn"  # Afar
+languages: "ace_Latn"  # Achinese
+languages: "af_Latn"  # Afrikaans
+languages: "aln_Latn"  # Gheg Albanian
+languages: "an_Latn"  # Aragonese
+languages: "aoz_Latn"  # Uab Meto
+languages: "arn_Latn"  # Mapuche
+languages: "asa_Latn"  # Asu
+languages: "ay_Latn"  # Aymara
+languages: "ban_Latn"  # Balinese
+languages: "bbc_Latn"  # Batak Toba
+languages: "bem_Latn"  # Bemba
+languages: "bez_Latn"  # Bena
+languages: "bi_Latn"  # Bislama
+languages: "bik_Latn"  # Bikol
+languages: "bto_Latn"  # Rinconada Bikol
+languages: "ca_Latn"  # Catalan
+languages: "ceb_Latn"  # Cebuano
+languages: "cgg_Latn"  # Chiga
+languages: "ch_Latn"  # Chamorro
+languages: "chk_Latn"  # Chuukese
+languages: "co_Latn"  # Corsican
+languages: "crs_Latn"  # Seselwa Creole French
+languages: "ctd_Latn"  # Tedim Chin
+languages: "da_Latn"  # Danish
+languages: "dav_Latn"  # Taita
+languages: "de_Latn"  # German
+languages: "en_Latn"  # English
+languages: "es_Latn"  # Spanish
+languages: "et_Latn"  # Estonian
+languages: "eu_Latn"  # Basque
+languages: "fbl_Latn"  # West Albay Bikol
+languages: "fi_Latn"  # Finnish
+languages: "fil_Latn"  # Filipino
+languages: "fj_Latn"  # Fijian
+languages: "fo_Latn"  # Faroese
+languages: "fr_Latn"  # French
+languages: "fur_Latn"  # Friulian
+languages: "ga_Latn"  # Irish
+languages: "gd_Latn"  # Scottish Gaelic
+languages: "gil_Latn"  # Gilbertese
+languages: "gl_Latn"  # Galician
+languages: "gsw_Latn"  # Swiss German
+languages: "guc_Latn"  # Wayuu
+languages: "guz_Latn"  # Gusii
+languages: "gv_Latn"  # Manx
+languages: "he_Hebr"  # Hebrew
+languages: "hil_Latn"  # Hiligaynon
+languages: "hmn_Latn"  # Hmong
+languages: "hop_Latn"  # Hopi
+languages: "ht_Latn"  # Haitian Creole
+languages: "ia_Latn"  # Interlingua
+languages: "id_Latn"  # Indonesian
+languages: "ilo_Latn"  # Iloko
+languages: "is_Latn"  # Icelandic
+languages: "it_Latn"  # Italian
+languages: "jam_Latn"  # Jamaican Creole English
+languages: "jmc_Latn"  # Machame
+languages: "jv_Latn"  # Javanese
+languages: "kde_Latn"  # Makonde
+languages: "kea_Latn"  # Kabuverdianu
+languages: "kg_Latn"  # Kongo
+languages: "kha_Latn"  # Khasi
+languages: "kj_Latn"  # Kuanyama
+languages: "kl_Latn"  # Kalaallisut
+languages: "kln_Latn"  # Kalenjin
+languages: "kmb_Latn"  # Kimbundu
+languages: "ksb_Latn"  # Shambala
+languages: "kw_Latn"  # Cornish
+languages: "la_Latn"  # Latin
+languages: "lad_Hebr"  # Ladino
+languages: "lb_Latn"  # Luxembourgish
+languages: "lij_Latn"  # Ligurian
+languages: "lmo_Latn"  # Lombard
+languages: "lua_Latn"  # Luba-Lulua
+languages: "luo_Latn"  # Luo
+languages: "luy_Latn"  # Luyia
+languages: "mfe_Latn"  # Morisyen
+languages: "mg_Latn"  # Malagasy
+languages: "mgh_Latn"  # Makhuwa-Meetto
+languages: "min_Latn"  # Minangkabau
+languages: "moe_Latn"  # Innu
+languages: "moh_Latn"  # Mohawk
+languages: "ms_Latn"  # Malay
+languages: "nap_Latn"  # Neapolitan
+languages: "nd_Latn"  # North Ndebele
+languages: "nds_Latn"  # Low German
+languages: "ng_Latn"  # Ndonga
+languages: "njo_Latn"  # Ao Naga
+languages: "no_Latn"  # Norwegian
+languages: "nov_Latn"  # Novial
+languages: "nr_Latn"  # South Ndebele
+languages: "nso_Latn"  # Northern Sotho
+languages: "nyn_Latn"  # Nyankole
+languages: "oc_Latn"  # Occitan
+languages: "om_Latn"  # Oromo
+languages: "pam_Latn"  # Pampanga
+languages: "pap_Latn"  # Papiamento
+languages: "pko_Latn"  # Pökoot
+languages: "pms_Latn"  # Piedmontese
+languages: "pon_Latn"  # Pohnpeian
+languages: "pt_Latn"  # Portuguese
+languages: "quc_Latn"  # Kʼicheʼ
+languages: "qug_Latn"  # Chimborazo Highland Quichua
+languages: "rm_Latn"  # Romansh
+languages: "rn_Latn"  # Rundi
+languages: "rof_Latn"  # Rombo
+languages: "rw_Latn"  # Kinyarwanda
+languages: "rwk_Latn"  # Rwa
+languages: "saq_Latn"  # Samburu
+languages: "sbp_Latn"  # Sangu
+languages: "sc_Latn"  # Sardinian
+languages: "scn_Latn"  # Sicilian
+languages: "sdc_Latn"  # Sassarese Sardinian
+languages: "seh_Latn"  # Sena
+languages: "sei_Latn"  # Seri
+languages: "sg_Latn"  # Sango
+languages: "sma_Latn"  # Southern Sami
+languages: "sn_Latn"  # Shona
+languages: "snk_Latn"  # Soninke
+languages: "so_Latn"  # Somali
+languages: "sq_Latn"  # Albanian
+languages: "srn_Latn"  # Sranan Tongo
+languages: "ss_Latn"  # Swati
+languages: "su_Latn"  # Sundanese
+languages: "sv_Latn"  # Swedish
+languages: "sw_Latn"  # Swahili
+languages: "swb_Latn"  # Comorian, Latin
+languages: "teo_Latn"  # Teso
+languages: "tet_Latn"  # Tetum
+languages: "tiv_Latn"  # Tiv
+languages: "tn_Latn"  # Tswana
+languages: "tpi_Latn"  # Tok Pisin
+languages: "ts_Latn"  # Tsonga
+languages: "tum_Latn"  # Tumbuka
+languages: "ug_Latn"  # Uyghur, Latin
+languages: "vec_Latn"  # Venetian
+languages: "vmw_Latn"  # Makhuwa
+languages: "vo_Latn"  # Volapük
+languages: "vro_Latn"  # Võro
+languages: "vun_Latn"  # Vunjo
+languages: "wa_Latn"  # Walloon
+languages: "war_Latn"  # Waray
+languages: "wbp_Latn"  # Warlpiri
+languages: "xh_Latn"  # Xhosa
+languages: "xog_Latn"  # Soga
+languages: "yap_Latn"  # Yapese
+languages: "yua_Latn"  # Yucateco
+languages: "zu_Latn"  # Zulu


### PR DESCRIPTION
Sandbox is in construction and doesn't seem to display fonts with missing languages in metadata.pd. I run add-font on Fredoka to trigger them + updated description.

Unblock #4170 