### PR TITLE
Noto sans et serif display: reverse primary categories in metadata.pb

### DIFF
--- a/ofl/notosansdisplay/METADATA.pb
+++ b/ofl/notosansdisplay/METADATA.pb
@@ -1,8 +1,8 @@
 name: "Noto Sans Display"
 designer: "Google"
 license: "OFL"
-category: "SANS_SERIF"
 category: "DISPLAY"
+category: "SANS_SERIF"
 date_added: "2020-11-19"
 fonts {
   name: "Noto Sans Display"

--- a/ofl/notoserifdisplay/METADATA.pb
+++ b/ofl/notoserifdisplay/METADATA.pb
@@ -1,8 +1,8 @@
 name: "Noto Serif Display"
 designer: "Google"
 license: "OFL"
-category: "SERIF"
 category: "DISPLAY"
+category: "SERIF"
 date_added: "2020-11-19"
 fonts {
   name: "Noto Serif Display"


### PR DESCRIPTION
Unblock #4232 
Move display as secondary category.