### PR TITLE
ci: ensure designer filenames are ascii

### DIFF
--- a/.ci/test_profiles.py
+++ b/.ci/test_profiles.py
@@ -43,6 +43,16 @@ def test_profile_dir_exists(profile_dir):
     assert os.path.exists(profile_dir)
 
 
+def test_profile_filenames_are_acscii(profile_dir):
+    failed = []
+    for filename in os.listdir(profile_dir) + [profile_dir]:
+        try:
+            filename.encode("ascii")
+        except:
+            failed.append(filename)
+    assert not failed, f"filenames {failed} must be ascii"
+
+
 def test_profile_dir_has_bio(profile_dir):
     assert "bio.html" in os.listdir(profile_dir), "bio.html is missing"
 


### PR DESCRIPTION
This PR partially fixes #4262 by checking whether the filenames in designer dirs are ascii. Fontbakery https://github.com/googlefonts/fontbakery/issues/3578 will check the fonts and other metadata files.