### PR TITLE
Fix typo in `add font issue template` header

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_add-font.md
+++ b/.github/ISSUE_TEMPLATE/1_add-font.md
@@ -1,6 +1,6 @@
 ---
 name: Add Font
-about: Submit on OFL font to Google Fonts
+about: Submit an OFL font to Google Fonts
 title: 'Add [Font Name]'
 labels: 'II New Font, > Submission'
 assignees: ''


### PR DESCRIPTION
A small typo fix, but this line gets used in the GitHub UI in a few different ways, so it's worth fixing.
<img width="391" alt="Screen Shot 2022-02-17 at 7 02 01 PM" src="https://user-images.githubusercontent.com/5162664/154621162-78f3a986-a7bc-4729-abeb-2e939d69891f.png">
<img width="303" alt="Screen Shot 2022-02-17 at 7 07 52 PM" src="https://user-images.githubusercontent.com/5162664/154621220-c4402b38-f0f8-44b2-8a3c-407aa852fef2.png">


