### PR TITLE
Syne: Version 2.200 added

### DIFF
--- a/ofl/syne/METADATA.pb
+++ b/ofl/syne/METADATA.pb
@@ -24,7 +24,7 @@ axes {
 }
 source {
   repository_url: "https://gitlab.com/bonjour-monde/fonderie/syne-typeface"
-  commit: "d9098c0a72125d411dbb225a2e5a61dc15265ffc"
+  commit: "e536e8f1a8724bf282da74bbae410f91231ce94c"
 }
 languages: "aa_Latn"  # Afar
 languages: "ace_Latn"  # Achinese


### PR DESCRIPTION
 4395d57: [gftools-packager] Syne: Version 2.200 added

* Syne Version 2.200 taken from the upstream repo https://gitlab.com/bonjour-monde/fonderie/syne-typeface at commit e536e8f1a8724bf282da74bbae410f91231ce94c.