### PR TITLE
Use the usual name for CI, show a badge for CI on root readme

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,12 @@
 # Check to_sandbox.txt and to_production.txt do not contain typos
-name: Google Fonts Test Server Files
+name: Continuous Test + Deploy
 
 on:
   push:
     branches: [main]
+    tags: ["v*.*.*"]
   pull_request:
-    branches: [main]
+    branches: ['**']
 
 jobs:
   test_server_files:
@@ -16,8 +17,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.8"
-    - name: Install dependencies
+
+    # Check to_sandbox.txt and to_production.txt do not contain typos
+    - name: Install gftools
       run: pip install gftools[qa]
-    - name: Check server files
+    - name: Lint server files
       run: gftools push-status . --lint
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![CI Status](https://github.com/google/fonts/workflows/Continuous%20Test%20+%20Deploy/badge.svg?branch=main)](https://github.com/google/fonts/actions/workflows/ci.yml?query=workflow%3ATest+branch%3Amain)
+
+
 # Google Fonts Files
 
 This project mainly contains the binary font files served by Google Fonts ([fonts.google.com](https://fonts.google.com))

--- a/to_sandbox.txt
+++ b/to_sandbox.txt
@@ -1,5 +1,5 @@
 # Knowledge: just push it all
-knowledge/
+cc-by-sa/knowledge
 
 # HELD
 # ofl/opensans


### PR DESCRIPTION
Precursor to adding additional checks