### PR TITLE
4628 review removed links

### DIFF
--- a/cc-by-sa/knowledge/glossary/terms/contrast/content.md
+++ b/cc-by-sa/knowledge/glossary/terms/contrast/content.md
@@ -9,4 +9,4 @@ Contrast is the difference between the thick and thin parts of a [letterform](/g
 
 [Serif](/glossary/serif) typefaces tend to have higher contrast strokes than [sans serif](/glossary/sans_serif) designs.
 
-Contrast can be controlled and fine-tuned in [variable fonts](/glossary/variable_fonts) with parametric axes that adjust [thick strokes (XOPQ)](/glossary/xopq_axis) and [thin strokes (YOPQ)](/glossary/yopq_axis) independently.
+Contrast can be controlled and fine-tuned in [variable fonts](/glossary/variable_fonts) with [parametric axes](/glossary/parametric_axis) that adjust [thick strokes (XOPQ)](/glossary/xopq_axis) and [thin strokes (YOPQ)](/glossary/yopq_axis) independently.

--- a/cc-by-sa/knowledge/glossary/terms/grade_axis/content.md
+++ b/cc-by-sa/knowledge/glossary/terms/grade_axis/content.md
@@ -1,5 +1,5 @@
 
-“Grade” (`GRAD` in CSS) is an [axis](/glossary/axis_in_variable_fonts) found in some [variable fonts](/glossary/variable_fonts) that can be used to alter [stroke](/glossary/stroke) thicknesses (or other forms) without affecting the [type](/glossary/type)’s overall [width](/glossary/width), inter-letter spacing, or kerning—unlike altering [weight](/glossary/weight). This means there are no changes to line breaks or page layout.
+“Grade” (`GRAD` in CSS) is an [axis](/glossary/axis_in_variable_fonts) found in some [variable fonts](/glossary/variable_fonts) that can be used to alter [stroke](/glossary/stroke) thicknesses (or other forms) without affecting the [type](/glossary/type)’s overall [width](/glossary/width), inter-letter spacing, or [kerning](/glossary/kerning_kerning_pairs)—unlike altering [weight](/glossary/weight). This means there are no changes to line breaks or page layout.
 
 The [Google Fonts CSS v2 API ](https://developers.google.com/fonts/docs/css2) defines the axis as:
 


### PR DESCRIPTION
Correct URLs are now in there that were removed in https://github.com/google/fonts/issues/4628