### PR TITLE
CJK metadata fixes

### DIFF
--- a/ofl/notosanshk/METADATA.pb
+++ b/ofl/notosanshk/METADATA.pb
@@ -21,15 +21,20 @@ subsets: "korean"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
-is_noto: true
 subsets: "vietnamese"
 axes {
   tag: "wght"
   min_value: 100.0
   max_value: 900.0
 }
+is_noto: true
+languages: "cjy_Hant"  # Chinese, Jinyu
+languages: "gan_Hant"  # Gan Chinese
 languages: "hak_Hant"  # Hakka Chinese, Traditional
+languages: "hsn_Hant"  # Xiang Chinese
 languages: "lzh_Hant"  # Literary Chinese, Traditional
 languages: "nan_Hant"  # Min Nan Chinese, Traditional
+languages: "wuu_Hant"  # Wu Chinese
+languages: "yue_Hant"  # Cantonese
 languages: "zh_Hant"  # Chinese (Traditional)
 display_name: "Noto Sans Hong Kong"

--- a/ofl/notosansjp/METADATA.pb
+++ b/ofl/notosansjp/METADATA.pb
@@ -12,20 +12,25 @@ fonts {
   full_name: "Noto Sans JP"
   copyright: "(c) 2014-2021 Adobe (http://www.adobe.com/), with Reserved Font Name \'Source\'."
 }
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "japanese"
+subsets: "korean"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
-is_noto: true
 axes {
   tag: "wght"
   min_value: 100.0
   max_value: 900.0
 }
+is_noto: true
 languages: "ain_Kana"  # Ainu
 languages: "ja_Jpan"  # Japanese
+languages: "ja_Hira"  # Japanese, Hiragana
 languages: "ja_Kana"  # Japanese, Katakana
 languages: "ryu_Jpan"  # Central Okinawan, Japanese
 languages: "ryu_Kana"  # Central Okinawan
+display_name: "Noto Sans Japanese"

--- a/ofl/notosanskr/METADATA.pb
+++ b/ofl/notosanskr/METADATA.pb
@@ -12,16 +12,20 @@ fonts {
   full_name: "Noto Sans KR"
   copyright: "(c) 2014-2021 Adobe (http://www.adobe.com/), with Reserved Font Name \'Source\'."
 }
+subsets: "chinese-simplified"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
+subsets: "japanese"
 subsets: "korean"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
-is_noto: true
 axes {
   tag: "wght"
   min_value: 100.0
   max_value: 900.0
 }
+is_noto: true
 languages: "ko_Kore"  # Korean
+display_name: "Noto Sans Korean"


### PR DESCRIPTION
This fixes the metadata for Noto CJK serif fonts:

* Use `gftools-add-font` to detect all displayable subsets instead of trying to worry about the "best" subsets for the font.
* Restores the missing `display_name` fields.
* Adds some new languages added in acc2662.