### PR TITLE
Andika: Version 6.101 added

### DIFF
--- a/ofl/andika/DESCRIPTION.en_us.html
+++ b/ofl/andika/DESCRIPTION.en_us.html
@@ -18,3 +18,4 @@ The font has been upgraded in May 2022. This upgrade gives additional weight sty
 <p>
 Read more at <a href="http://software.sil.org/andika/">software.sil.org/andika</a>
 </p>
+<p>To contribute, see <a href="https://github.com/silnrsi/font-andika">github.com/silnrsi/font-andika</a>.</p>

--- a/ofl/andika/METADATA.pb
+++ b/ofl/andika/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Andika"
-designer: "SIL International, Victor Gaultney, Annie Olsen, Julie Remington, Don Collingsworth, Eric Hays, Becca Hirsbrunner"
+designer: "SIL International"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2011-08-10"


### PR DESCRIPTION
 fb97b6c: [gftools-packager] Andika: Version 6.101 added

* Andika Version 6.101 taken from the upstream repo https://github.com/silnrsi/font-andika at commit https://github.com/silnrsi/font-andika/commit/.