### PR TITLE
Exo 2: Version 2.001 added

### DIFF
--- a/ofl/exo2/METADATA.pb
+++ b/ofl/exo2/METADATA.pb
@@ -32,3 +32,7 @@ axes {
   min_value: 100.0
   max_value: 900.0
 }
+source {
+  repository_url: "https://github.com/NDISCOVER/Exo-2.0"
+  commit: "182060cd38adf3cde0d22add3f8009d30bd48cde"
+}

--- a/ofl/exo2/upstream.yaml
+++ b/ofl/exo2/upstream.yaml
@@ -1,0 +1,6 @@
+branch: master
+files:
+  OFL.txt: OFL.txt
+  fonts/variable/Exo2[wght].ttf: Exo2[wght].ttf
+  fonts/variable/Exo2-Italic[wght].ttf: Exo2-Italic[wght].ttf
+archive:


### PR DESCRIPTION
 07819a7: [gftools-packager] Exo 2: Version 2.001 added

* Exo 2 Version 2.001 taken from the upstream repo https://github.com/NDISCOVER/Exo-2.0 at commit https://github.com/NDISCOVER/Exo-2.0/commit/182060cd38adf3cde0d22add3f8009d30bd48cde.