### PR TITLE
Update readme to reflect size of ZIP file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For Linux, macOS, FreeBSD, or HaikuOS you can also use [fnt](https://github.com/
 
 ## Download All Google Fonts
 
-You can download all Google Fonts in a simple ZIP snapshot (over 600MB) from <https://github.com/google/fonts/archive/main.zip>
+You can download all Google Fonts in a simple ZIP snapshot (over 1GB) from <https://github.com/google/fonts/archive/main.zip>
 
 #### Sync With Git
 


### PR DESCRIPTION
Today's size of the ZIP file is 1.053.418.669 bytes (1,06 GB on disk).