### PR TITLE
Sample text: acircumflexdotbelow in vietnamese specimen

### DIFF
--- a/lang/Lib/gflanguages/data/languages/vi_Latn.textproto
+++ b/lang/Lib/gflanguages/data/languages/vi_Latn.textproto
@@ -17,14 +17,14 @@ exemplar_chars {
 sample_text {
   masthead_full: "TtÂâ"
   masthead_partial: "Cc"
-  styles: "Việc thừa nhận nhân phẩm vốn có, các quyền"
+  styles: "Việc thừa nhận nhân phẩm vốn có, các quyền"
   tester: "Sự xâm phạm và coi thường nhân quyền đã dẫn đến những hành động"
   poster_sm: "Nhân quyền"
   poster_md: "Cần phải"
   poster_lg: "Tất"
   specimen_48: "Nhân dân các nước thành viên Liên Hợp Quốc trong bản Hiến chương"
   specimen_36: "Không ai phải làm nô lệ hay bị cưỡng bức làm việc như nô lệ; mọi hình thức nô lệ và buôn bán nô lệ đều bị ngăn cấm."
-  specimen_32: "Mọi người đều có quyền được các toà án quốc gia có thẩm quyền bênh vực theo pháp luật trước những hành vi vi phạm các quyền cơ bản do hiến pháp hay luật pháp quy định."
-  specimen_21: "Không ai bị bắt, giam giữ hay đày đi nơi khác một cách độc đoán.\nMọi người, với tư cách bình đẳng về mọi phương diện, đều có quyền được một toà án độc lập và vô tư phân xử công bằng và công khai để xác định quyền, nghĩa vụ hoặc bất cứ một lời buộc tội nào đối với người đó.\nMọi người đều có quyền nghỉ ngơi và giải trí, kể cả quyền được hạn chế hợp lý về số giờ làm việc và hưởng những ngày nghỉ định kỳ được trả lương."
-  specimen_16: "Mọi người đều có quyền được hưởng trật tự xã hội và trật tự quốc tế trong đó các quyền và tự do nêu trong Bản tuyên ngôn này có thể được thực hiện đầy đủ.\nKhông được phép diễn giải bất kỳ điều khoản nào trong Bản tuyên ngôn này theo hướng ngầm ý cho phép bất kỳ quốc gia, nhóm người hay cá nhân nào được quyền tham gia vào bất kỳ hoạt động nào hay thực hiện bất kỳ hành vi nào nhằm phá hoại bất kỳ quyền và tự do nào nêu trong Bản tuyên ngôn này.\nVới nhận thức rằng:\nViệc thừa nhận nhân phẩm vốn có, các quyền bình đẳng và không thể tách rời của mọi thành viên trong gia đình nhân loại là cơ sở cho tự do, công bằng và hoà bình trên thế giới,"
+  specimen_32: "Mọi người đều có quyền được các toà án quốc gia có thẩm quyền bênh vực theo pháp luật trước những hành vi vi phạm các quyền cơ bản do hiến pháp hay luật pháp quy định."
+  specimen_21: "Không ai bị bắt, giam giữ hay đày đi nơi khác một cách độc đoán.\nMọi người, với tư cách bình đẳng về mọi phương diện, đều có quyền được một toà án độc lập và vô tư phân xử công bằng và công khai để xác định quyền, nghĩa vụ hoặc bất cứ một lời buộc tội nào đối với người đó.\nMọi người đều có quyền nghỉ ngơi và giải trí, kể cả quyền được hạn chế hợp lý về số giờ làm việc và hưởng những ngày nghỉ định kỳ được trả lương."
+  specimen_16: "Mọi người đều có quyền được hưởng trật tự xã hội và trật tự quốc tế trong đó các quyền và tự do nêu trong Bản tuyên ngôn này có thể được thực hiện đầy đủ.\nKhông được phép diễn giải bất kỳ điều khoản nào trong Bản tuyên ngôn này theo hướng ngầm ý cho phép bất kỳ quốc gia, nhóm người hay cá nhân nào được quyền tham gia vào bất kỳ hoạt động nào hay thực hiện bất kỳ hành vi nào nhằm phá hoại bất kỳ quyền và tự do nào nêu trong Bản tuyên ngôn này.\nVới nhận thức rằng:\nViệc thừa nhận nhân phẩm vốn có, các quyền bình đẳng và không thể tách rời của mọi thành viên trong gia đình nhân loại là cơ sở cho tự do, công bằng và hoà bình trên thế giới,"
 }


### PR DESCRIPTION
Every fonts supporting vietnamese are displaying a fallback font instead of the actual `a circumflex dot below` (uni1EAD).
Indeed, looking into vi_Latn.textproto, the actual glyphs used is a ligature between `a circumflex` and `dotbelowcomb` (acircumflex_dotbelowcomb), and not an actual codepoint.

This in Pinyon Script in Sandbox, but you can find the same issue in a majority of fonts supporting vietnamese:
<img width="665" alt="Capture d’écran 2022-07-29 à 11 35 39" src="https://user-images.githubusercontent.com/12222436/181734061-33d0c4a1-3266-4312-9569-3de6723b7cf0.png">

This PR replaces the ligature glyphs by the encoded one.
