### PR TITLE
Quick fix for ZCOOL repo link

### DIFF
--- a/ofl/zcoolxiaowei/OFL.txt
+++ b/ofl/zcoolxiaowei/OFL.txt
@@ -1,4 +1,4 @@
-Copyright 2018 The ZCOOL XiaoWei Project Authors (https://www.github.com/googlefonts/xiaowei)
+Copyright 2018 The ZCOOL XiaoWei Project Authors (https://github.com/googlefonts/zcool-xiaowei/)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:


### PR DESCRIPTION
Fixes link to correct Google Font repo. Closes [#2698](https://github.com/google/fonts/issues/2698).