### PR TITLE
Fix typos in ofl/zenkakugothicantique description

### DIFF
--- a/ofl/zenkakugothicantique/DESCRIPTION.en_us.html
+++ b/ofl/zenkakugothicantique/DESCRIPTION.en_us.html
@@ -19,5 +19,5 @@
 </p>
 <p>
     To learn more, read <a href="https://fonts.googleblog.com/2021/10/say-hello-to-our-big-new-japanese.html">Say Hello to our big new Japanese collection with Zen Fonts</a>(English), <a href="https://fonts.googleblog.com/2021/10/the-story-of-zen-fonts-interview-with.html">The Story of Zen Fonts - interview with Yoshimichi Ohira</a>(English),
-    <a href="https://fonts.googleblog.com/2021/10/zen_0361327225.html ">Zenフォント: 新しい日本語フォントコレクションの登場 - 日本語フォントの複雑な美しさについて -</a>(Japanese), and <a href="https://fonts.googleblog.com/2021/10/Japaneseinterview.html " ">Zenフォントのおはなし：大平善道さんとのインタビュー</a>(Japanese).
+    <a href="https://fonts.googleblog.com/2021/10/zen_0361327225.html">Zenフォント: 新しい日本語フォントコレクションの登場 - 日本語フォントの複雑な美しさについて -</a>(Japanese), and <a href="https://fonts.googleblog.com/2021/10/Japaneseinterview.html">Zenフォントのおはなし：大平善道さんとのインタビュー</a>(Japanese).
 </p>


### PR DESCRIPTION
There was a hanging double quote and a trailing space in a couple of the `a` tags.