### PR TITLE
Sandbox update: element grid Axis registry added

### DIFF
--- a/to_sandbox.txt
+++ b/to_sandbox.txt
@@ -21,6 +21,7 @@ ofl/recursive # https://github.com/google/fonts/pull/4988
 ofl/notokufiarabic # https://github.com/google/fonts/pull/4560
 
 # API Stuff
+axisregistry/Lib/axisregistry/data/element_grid.textproto # https://github.com/google/fonts/pull/5094
 lang/languages/hak_Hant.textproto # https://github.com/google/fonts/pull/5088
 lang/languages/lzh_Hant.textproto # https://github.com/google/fonts/pull/5088
 lang/languages/yue_Hant.textproto # https://github.com/google/fonts/pull/5088


### PR DESCRIPTION
@nathan-williams I've used a different path to include the .textproto for the axis since the suggested path in the chat `axisregistry/element_grid.textproto` was reporting this:
```
ValueError: to_sandbox.txt: Following paths are not valid:
axisregistry/element_grid.textproto
```
The path used now is not reporting any issue. Would you mind reviewing this and if it's ok to merge the PR?
