### PR TITLE
Sync axisregistry with googlefonts/axisregistry

### DIFF
--- a/axisregistry/Lib/axisregistry/__init__.py
+++ b/axisregistry/Lib/axisregistry/__init__.py
@@ -53,32 +53,6 @@ GF_STATIC_STYLES = OrderedDict(
 )
 
 
-    for axis in [
-        "casual.textproto",
-        "cursive.textproto",
-        "fill.textproto",
-        "flair.textproto",
-        "grade.textproto",
-        "italic.textproto",
-        "monospace.textproto",
-        "optical_size.textproto",
-        "slant.textproto",
-        "softness.textproto",
-        "volume.textproto",
-        "weight.textproto",
-        "width.textproto",
-        "wonky.textproto",
-        "x_opaque.textproto",
-        "x_transparent_figures.textproto",
-        "x_transparent.textproto",
-        "y_opaque.textproto",
-        "y_transparent_ascender.textproto",
-        "y_transparent_descender.textproto",
-        "y_transparent_figures.textproto",
-        "y_transparent_lowercase.textproto",
-        "y_transparent_uppercase.textproto",
-    ]:
-        append_AxisMessage(resource_filename("axisregistry", "data/" + axis))
 def load_protobuf(klass, path):
     message = klass()
     with open(path, "rb") as text_data:

--- a/axisregistry/README.md
+++ b/axisregistry/README.md
@@ -27,12 +27,13 @@ When the registry is updated here, a line like `axisregistry/axis_name.textproto
 *   `precision`
     *   Describes the specificity at which an axis position can be specified.
         For example, `0` means values must be specified as whole numbers while `-1` means values can be as precise as one decimal place.
-*   `fallback` (repeated)
+*   `fallback`
     *   Instance positions along the axis, such as wght 100,200,300,400,500,600,700,800,900.
     *   A cross-product of fallback positions along all supported axes is created to support legacy browsers that lack variable font support.
         For axes with CSS3 properties (such as [font-weight](https://drafts.csswg.org/css-fonts-3/#font-weight-prop)), the positions accessible
         to CSS3 should be specified. For axes lacking CSS3 properties a legacy browser is limited to a single position and that position must
         be at a fallback.
+        <br>In case an axis doesn't include predefined positions, it is mandatory to define at least one fallback position. It should be called `Default` and its value should correspond to the `default_value` position of the axis.
 *   `fallback_only`
     *   Describes whether to only use fallback values when presenting to users.
 *   `description`

--- a/axisregistry/tests/test_axisregistry_api.py
+++ b/axisregistry/tests/test_axisregistry_api.py
@@ -6,6 +6,7 @@ def test_AxisRegistry():
     assert "GRAD" in registry.keys()
     for axis_tag in registry.keys():
         assert len(axis_tag) == 4
+        assert len(registry[axis_tag].fallback) > 0
         for f in range(len(registry[axis_tag].fallback)):
             fallback = registry[axis_tag].fallback[f]
 

--- a/axisregistry/tox.ini
+++ b/axisregistry/tox.ini
@@ -17,8 +17,6 @@ deps =
     -r test_requirements.txt
 commands =
     black --check --diff --extend-exclude "_version.py" .
-    isort --check-only --diff .
-    flake8
 
 [testenv:coverage-report]
 skip_install = true


### PR DESCRIPTION
The sync was performed in two stages.  First we merged https://github.com/googlefonts/axisregistry/pull/75 into googlefonts/axisregistry to bring the textproto edits needed from google/fonts, then git subtree pulled in the changes here, resolving merge conflicts by taking only googlefonts/axisregistry side changes.   After we merge this branch, googlefonts/axisregistry and the google/fonts axisregistry directory will be in sync and we can begin to use git subtree pulls from googlefonts/axisregistry to update axis registration data in this repository.