### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: ['**']
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   test_server_files:
     runs-on: ubuntu-latest

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -9,8 +9,13 @@ on:
     #- cron: '1/5 * * * *'
 
 
+permissions: {}
 jobs:
   gen_report:
+    permissions:
+      contents: write # to push pages branch (peaceiris/actions-gh-pages)
+      issues: read # to list issues for report
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,9 +7,16 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
 
   build:
+    permissions:
+      actions: write # to cancel/stop running workflows (styfle/cancel-workflow-action)
+      contents: read # to fetch code (actions/checkout)
+
     name: Build Google Fonts
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.