### PR TITLE
Noto Serif Tangut: Version 2.169; ttfautohint (v1.8.4.7-5d5b) added

### DIFF
--- a/ofl/notoseriftangut/METADATA.pb
+++ b/ofl/notoseriftangut/METADATA.pb
@@ -10,9 +10,15 @@ fonts {
   filename: "NotoSerifTangut-Regular.ttf"
   post_script_name: "NotoSerifTangut-Regular"
   full_name: "Noto Serif Tangut Regular"
-  copyright: "Copyright 2019 Google LLC. All Rights Reserved."
+  copyright: "Copyright 2022 The Noto Project Authors (https://github.com/notofonts/tangut)"
 }
+subsets: "latin"
+subsets: "latin-ext"
 subsets: "menu"
 subsets: "tangut"
+source {
+  repository_url: "https://github.com/notofonts/tangut.git"
+  archive_url: "https://github.com/notofonts/tangut/releases/download/NotoSerifTangut-v2.169/NotoSerifTangut-v2.169.zip"
+}
 is_noto: true
 languages: "txg_Tang"  # Tangut

--- a/ofl/notoseriftangut/METADATA.pb
+++ b/ofl/notoseriftangut/METADATA.pb
@@ -22,3 +22,4 @@ source {
 }
 is_noto: true
 languages: "txg_Tang"  # Tangut
+primary_script: "Tang"

--- a/ofl/notoseriftangut/OFL.txt
+++ b/ofl/notoseriftangut/OFL.txt
@@ -1,10 +1,9 @@
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2022 The Noto Project Authors (https://github.com/notofonts/tangut)
 
-This Font Software is licensed under the SIL Open Font License,
-Version 1.1.
-
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
-http://scripts.sil.org/OFL
+https://scripts.sil.org/OFL
+
 
 -----------------------------------------------------------
 SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
@@ -12,19 +11,19 @@ SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
 
 PREAMBLE
 The goals of the Open Font License (OFL) are to stimulate worldwide
-development of collaborative font projects, to support the font
-creation efforts of academic and linguistic communities, and to
-provide a free and open framework in which fonts may be shared and
-improved in partnership with others.
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
 
 The OFL allows the licensed fonts to be used, studied, modified and
 redistributed freely as long as they are not sold by themselves. The
-fonts, including any derivative works, can be bundled, embedded,
+fonts, including any derivative works, can be bundled, embedded, 
 redistributed and/or sold with any software provided that any reserved
 names are not used by derivative works. The fonts and derivatives,
 however, cannot be released under any other type of license. The
-requirement for fonts to remain under this license does not apply to
-any document created using the fonts or their derivatives.
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
 
 DEFINITIONS
 "Font Software" refers to the set of files released by the Copyright
@@ -34,25 +33,25 @@ include source files, build scripts and documentation.
 "Reserved Font Name" refers to any names specified as such after the
 copyright statement(s).
 
-"Original Version" refers to the collection of Font Software
-components as distributed by the Copyright Holder(s).
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
 
-"Modified Version" refers to any derivative made by adding to,
-deleting, or substituting -- in part or in whole -- any of the
-components of the Original Version, by changing formats or by porting
-the Font Software to a new environment.
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
 
 "Author" refers to any designer, engineer, programmer, technical
 writer or other person who contributed to the Font Software.
 
 PERMISSION & CONDITIONS
 Permission is hereby granted, free of charge, to any person obtaining
-a copy of the Font Software, to use, study, copy, merge, embed,
-modify, redistribute, and sell modified and unmodified copies of the
-Font Software, subject to the following conditions:
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
 
-1) Neither the Font Software nor any of its individual components, in
-Original or Modified Versions, may be sold by itself.
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
 
 2) Original or Modified Versions of the Font Software may be bundled,
 redistributed and/or sold with any software, provided that each copy
@@ -62,9 +61,9 @@ in the appropriate machine-readable metadata fields within text or
 binary files as long as those fields can be easily viewed by the user.
 
 3) No Modified Version of the Font Software may use the Reserved Font
-Name(s) unless explicit written permission is granted by the
-corresponding Copyright Holder. This restriction only applies to the
-primary font name as presented to the users.
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
 
 4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
 Software shall not be used to promote, endorse or advertise any
@@ -75,8 +74,8 @@ permission.
 5) The Font Software, modified or unmodified, in part or in whole,
 must be distributed entirely under this license, and must not be
 distributed under any other license. The requirement for fonts to
-remain under this license does not apply to any document created using
-the Font Software.
+remain under this license does not apply to any document created
+using the Font Software.
 
 TERMINATION
 This license becomes null and void if any of the above conditions are

--- a/ofl/notoseriftangut/upstream.yaml
+++ b/ofl/notoseriftangut/upstream.yaml
@@ -1,0 +1,7 @@
+archive: https://github.com/notofonts/tangut/releases/download/NotoSerifTangut-v2.169/NotoSerifTangut-v2.169.zip
+branch: main
+files:
+  DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
+  ARTICLE.en_us.html: article/ARTICLE.en_us.html
+  OFL.txt: OFL.txt
+  NotoSerifTangut/googlefonts/ttf/NotoSerifTangut-Regular.ttf: NotoSerifTangut-Regular.ttf


### PR DESCRIPTION
 46eaf00: [gftools-packager] Noto Serif Tangut: Version 2.169; ttfautohint (v1.8.4.7-5d5b) added

* Noto Serif Tangut Version 2.169; ttfautohint (v1.8.4.7-5d5b) taken from the upstream repo https://github.com/notofonts/tangut.git at commit https://github.com/notofonts/tangut/commit/.