### PR TITLE
Handjet: override ELSH default

### DIFF
--- a/ofl/handjet/METADATA.pb
+++ b/ofl/handjet/METADATA.pb
@@ -37,6 +37,10 @@ axes {
   min_value: 100.0
   max_value: 900.0
 }
+registry_default_overrides {
+  key: "ELSH"
+  value: 2.0
+}
 source {
   repository_url: "https://github.com/rosettatype/handjet"
   commit: "3918b7798e06c81da6bc558e88dfddd5a6b49807"


### PR DESCRIPTION
In dev-sandbox, it became obvious that 0 for element shape was displaying nothing, so moving to designer's default value which is 2.

This corrects a PR #5376 that is not yet in sandbox.