### PR TITLE
Use the --pre flag for installing Font Bakery on Github Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,9 +26,12 @@ jobs:
           python-version: 3.8
 
       - name: Install dependencies
+        # The --pre flag below will ensure we use the latest Font Bakery pre-releases
+        # and benefit from its newest checks:
         run: |
           sudo apt install libharfbuzz-dev libharfbuzz-bin libfreetype6-dev libglib2.0-dev libcairo2-dev
           python -m pip install --upgrade pip
+          pip install --pre fontbakery
           pip install gftools[qa] pytest
           
       - name: Check fonts


### PR DESCRIPTION
Use the --pre flag for installing Font Bakery on Github Actions, so that we can benefit from the newest checks introduced in its more frequent pre-releases such as v0.8.11a2 released today:
https://pypi.org/project/fontbakery/#history