### PR TITLE
Add repository_url where implied by archive

### DIFF
--- a/apache/roboto/upstream.yaml
+++ b/apache/roboto/upstream.yaml
@@ -24,3 +24,4 @@ files:
   web/static/RobotoCondensed-Medium.ttf: static/RobotoCondensed-Medium.ttf
   web/static/RobotoCondensed-MediumItalic.ttf: static/RobotoCondensed-MediumItalic.ttf
   web/static/RobotoCondensed-Regular.ttf: static/RobotoCondensed-Regular.ttf
+repository_url: https://github.com/googlefonts/roboto-classic

--- a/ofl/abyssinicasil/upstream.yaml
+++ b/ofl/abyssinicasil/upstream.yaml
@@ -3,3 +3,4 @@ branch: master
 files:
   AbyssinicaSIL-2.200/OFL.txt: OFL.txt
   AbyssinicaSIL-2.200/AbyssinicaSIL-Regular.ttf: AbyssinicaSIL-Regular.ttf
+repository_url: https://github.com/silnrsi/font-abyssinica

--- a/ofl/alkalami/upstream.yaml
+++ b/ofl/alkalami/upstream.yaml
@@ -3,3 +3,4 @@ branch: master
 files:
   Alkalami-2.000/OFL.txt: OFL.txt
   Alkalami-2.000/Alkalami-Regular.ttf: Alkalami-Regular.ttf
+repository_url: https://github.com/silnrsi/font-alkalami

--- a/ofl/andika/upstream.yaml
+++ b/ofl/andika/upstream.yaml
@@ -6,3 +6,4 @@ files:
   Andika-6.101/Andika-Italic.ttf: Andika-Italic.ttf
   Andika-6.101/Andika-Bold.ttf: Andika-Bold.ttf
   Andika-6.101/Andika-BoldItalic.ttf: Andika-BoldItalic.ttf
+repository_url: https://github.com/silnrsi/font-andika

--- a/ofl/arefruqaaink/upstream.yaml
+++ b/ofl/arefruqaaink/upstream.yaml
@@ -4,3 +4,4 @@ files:
   ArefRuqaa-1.005/OFL.txt: OFL.txt
   ArefRuqaa-1.005/ttf/ArefRuqaaInk-Regular.ttf: ArefRuqaaInk-Regular.ttf
   ArefRuqaa-1.005/ttf/ArefRuqaaInk-Bold.ttf: ArefRuqaaInk-Bold.ttf
+repository_url: https://github.com/aliftype/aref-ruqaa

--- a/ofl/charissil/upstream.yaml
+++ b/ofl/charissil/upstream.yaml
@@ -6,3 +6,4 @@ files:
   CharisSIL-6.101/CharisSIL-Italic.ttf: CharisSIL-Italic.ttf
   CharisSIL-6.101/CharisSIL-Bold.ttf: CharisSIL-Bold.ttf
   CharisSIL-6.101/CharisSIL-BoldItalic.ttf: CharisSIL-BoldItalic.ttf
+repository_url: https://github.com/silnrsi/font-charis

--- a/ofl/foldit/upstream.yaml
+++ b/ofl/foldit/upstream.yaml
@@ -2,3 +2,4 @@ archive: https://github.com/SophiaDesign/Foldit/releases/download/1.003/Foldit-f
 branch: main
 files:
   Foldit-fonts/fonts/variable/Foldit[wght].ttf: Foldit[wght].ttf
+repository_url: https://github.com/SophiaDesign/Foldit

--- a/ofl/gentiumbookplus/upstream.yaml
+++ b/ofl/gentiumbookplus/upstream.yaml
@@ -6,3 +6,4 @@ files:
   GentiumPlus-6.101/GentiumBookPlus-Italic.ttf: GentiumBookPlus-Italic.ttf
   GentiumPlus-6.101/GentiumBookPlus-Bold.ttf: GentiumBookPlus-Bold.ttf
   GentiumPlus-6.101/GentiumBookPlus-BoldItalic.ttf: GentiumBookPlus-BoldItalic.ttf
+repository_url: https://github.com/silnrsi/font-gentium

--- a/ofl/gentiumplus/upstream.yaml
+++ b/ofl/gentiumplus/upstream.yaml
@@ -6,3 +6,4 @@ files:
   GentiumPlus-6.101/GentiumPlus-Italic.ttf: GentiumPlus-Italic.ttf
   GentiumPlus-6.101/GentiumPlus-Bold.ttf: GentiumPlus-Bold.ttf
   GentiumPlus-6.101/GentiumPlus-BoldItalic.ttf: GentiumPlus-BoldItalic.ttf
+repository_url: https://github.com/silnrsi/font-gentium

--- a/ofl/lateef/upstream.yaml
+++ b/ofl/lateef/upstream.yaml
@@ -9,3 +9,4 @@ files:
   Lateef-2.000/Lateef-SemiBold.ttf: Lateef-SemiBold.ttf
   Lateef-2.000/Lateef-Bold.ttf: Lateef-Bold.ttf
   Lateef-2.000/Lateef-ExtraBold.ttf: Lateef-ExtraBold.ttf
+repository_url: https://github.com/silnrsi/font-lateef

--- a/ofl/mingzat/upstream.yaml
+++ b/ofl/mingzat/upstream.yaml
@@ -3,3 +3,4 @@ branch: master
 files:
   Mingzat-1.100/OFL.txt: OFL.txt
   Mingzat-1.100/Mingzat-Regular.ttf: Mingzat-Regular.ttf
+repository_url: https://github.com/silnrsi/font-mingzat

--- a/ofl/nabla/upstream.yaml
+++ b/ofl/nabla/upstream.yaml
@@ -2,3 +2,4 @@ archive: https://github.com/justvanrossum/nabla/releases/download/v1.002/nabla-f
 branch: main
 files:
   nabla-fonts/Nabla[EDPT,EHLT].ttf: Nabla[EDPT,EHLT].ttf
+repository_url: https://github.com/justvanrossum/nabla

--- a/ofl/notocoloremoji/upstream.yaml
+++ b/ofl/notocoloremoji/upstream.yaml
@@ -2,3 +2,4 @@ branch: main
 archive: https://github.com/googlefonts/noto-emoji/archive/refs/heads/main.zip
 files:
   noto-emoji-main/fonts/Noto-COLRv1.ttf: NotoColorEmoji-Regular.ttf
+repository_url: https://github.com/googlefonts/noto-emoji

--- a/ofl/notomusic/upstream.yaml
+++ b/ofl/notomusic/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoMusic/googlefonts/ttf/NotoMusic-Regular.ttf: NotoMusic-Regular.ttf
+repository_url: https://github.com/notofonts/music

--- a/ofl/notonaskharabic/upstream.yaml
+++ b/ofl/notonaskharabic/upstream.yaml
@@ -5,3 +5,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoNaskhArabic/googlefonts/variable-ttf/NotoNaskhArabic[wght].ttf: NotoNaskhArabic[wght].ttf
+repository_url: https://github.com/notofonts/arabic

--- a/ofl/notonastaliqurdu/upstream.yaml
+++ b/ofl/notonastaliqurdu/upstream.yaml
@@ -5,3 +5,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoNastaliqUrdu/googlefonts/variable-ttf/NotoNastaliqUrdu[wght].ttf: NotoNastaliqUrdu[wght].ttf
+repository_url: https://github.com/notofonts/nastaliq

--- a/ofl/notorashihebrew/upstream.yaml
+++ b/ofl/notorashihebrew/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoRashiHebrew/googlefonts/variable-ttf/NotoRashiHebrew[wght].ttf: NotoRashiHebrew[wght].ttf
+repository_url: https://github.com/notofonts/hebrew

--- a/ofl/notosansadlam/upstream.yaml
+++ b/ofl/notosansadlam/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansAdlam/googlefonts/variable-ttf/NotoSansAdlam[wght].ttf: NotoSansAdlam[wght].ttf
+repository_url: https://github.com/notofonts/adlam

--- a/ofl/notosansadlamunjoined/upstream.yaml
+++ b/ofl/notosansadlamunjoined/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansAdlamUnjoined/googlefonts/variable-ttf/NotoSansAdlamUnjoined[wght].ttf: NotoSansAdlamUnjoined[wght].ttf
+repository_url: https://github.com/notofonts/adlam

--- a/ofl/notosansarmenian/upstream.yaml
+++ b/ofl/notosansarmenian/upstream.yaml
@@ -5,3 +5,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansArmenian/googlefonts/variable-ttf/NotoSansArmenian[wdth,wght].ttf: NotoSansArmenian[wdth,wght].ttf
+repository_url: https://github.com/notofonts/armenian

--- a/ofl/notosansavestan/upstream.yaml
+++ b/ofl/notosansavestan/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansAvestan/full/ttf/NotoSansAvestan-Regular.ttf: NotoSansAvestan-Regular.ttf
+repository_url: https://github.com/notofonts/avestan

--- a/ofl/notosansbalinese/upstream.yaml
+++ b/ofl/notosansbalinese/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansBalinese/googlefonts/variable-ttf/NotoSansBalinese[wght].ttf: NotoSansBalinese[wght].ttf
+repository_url: https://github.com/notofonts/balinese

--- a/ofl/notosansbamum/upstream.yaml
+++ b/ofl/notosansbamum/upstream.yaml
@@ -5,3 +5,4 @@ files:
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   OFL.txt: OFL.txt
   NotoSansBamum/googlefonts/variable-ttf/NotoSansBamum[wght].ttf: NotoSansBamum[wght].ttf
+repository_url: https://github.com/notofonts/bamum

--- a/ofl/notosansbassavah/upstream.yaml
+++ b/ofl/notosansbassavah/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansBassaVah/googlefonts/variable-ttf/NotoSansBassaVah[wght].ttf: NotoSansBassaVah[wght].ttf
+repository_url: https://github.com/notofonts/bassa-vah

--- a/ofl/notosansbatak/upstream.yaml
+++ b/ofl/notosansbatak/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansBatak/googlefonts/ttf/NotoSansBatak-Regular.ttf: NotoSansBatak-Regular.ttf
+repository_url: https://github.com/notofonts/batak

--- a/ofl/notosansbengali/upstream.yaml
+++ b/ofl/notosansbengali/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansBengali/googlefonts/variable-ttf/NotoSansBengali[wdth,wght].ttf: NotoSansBengali[wdth,wght].ttf
+repository_url: https://github.com/notofonts/bengali

--- a/ofl/notosansbuginese/upstream.yaml
+++ b/ofl/notosansbuginese/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansBuginese/googlefonts/ttf/NotoSansBuginese-Regular.ttf: NotoSansBuginese-Regular.ttf
+repository_url: https://github.com/notofonts/buginese

--- a/ofl/notosansbuhid/upstream.yaml
+++ b/ofl/notosansbuhid/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansBuhid/full/ttf/NotoSansBuhid-Regular.ttf: NotoSansBuhid-Regular.ttf
+repository_url: https://github.com/notofonts/buhid

--- a/ofl/notosanscanadianaboriginal/upstream.yaml
+++ b/ofl/notosanscanadianaboriginal/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansCanadianAboriginal/googlefonts/variable-ttf/NotoSansCanadianAboriginal[wght].ttf: NotoSansCanadianAboriginal[wght].ttf
+repository_url: https://github.com/notofonts/canadian-aboriginal

--- a/ofl/notosanschakma/upstream.yaml
+++ b/ofl/notosanschakma/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansChakma/googlefonts/ttf/NotoSansChakma-Regular.ttf: NotoSansChakma-Regular.ttf
+repository_url: https://github.com/notofonts/chakma

--- a/ofl/notosanscham/upstream.yaml
+++ b/ofl/notosanscham/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansCham/googlefonts/variable-ttf/NotoSansCham[wght].ttf: NotoSansCham[wght].ttf
+repository_url: https://github.com/notofonts/cham

--- a/ofl/notosanscherokee/upstream.yaml
+++ b/ofl/notosanscherokee/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansCherokee/googlefonts/variable-ttf/NotoSansCherokee[wght].ttf: NotoSansCherokee[wght].ttf
+repository_url: https://github.com/notofonts/cherokee

--- a/ofl/notosanscoptic/upstream.yaml
+++ b/ofl/notosanscoptic/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansCoptic/googlefonts/ttf/NotoSansCoptic-Regular.ttf: NotoSansCoptic-Regular.ttf
+repository_url: https://github.com/notofonts/coptic

--- a/ofl/notosansdevanagari/upstream.yaml
+++ b/ofl/notosansdevanagari/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansDevanagari/googlefonts/variable-ttf/NotoSansDevanagari[wdth,wght].ttf: NotoSansDevanagari[wdth,wght].ttf
+repository_url: https://github.com/notofonts/devanagari

--- a/ofl/notosansethiopic/upstream.yaml
+++ b/ofl/notosansethiopic/upstream.yaml
@@ -5,3 +5,4 @@ files:
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   OFL.txt: OFL.txt
   NotoSansEthiopic/googlefonts/variable-ttf/NotoSansEthiopic[wdth,wght].ttf: NotoSansEthiopic[wdth,wght].ttf
+repository_url: https://github.com/notofonts/ethiopic

--- a/ofl/notosansgeorgian/upstream.yaml
+++ b/ofl/notosansgeorgian/upstream.yaml
@@ -2,3 +2,4 @@ archive: https://github.com/notofonts/georgian/releases/download/NotoSansGeorgia
 branch: main
 files:
   NotoSansGeorgian/googlefonts/variable-ttf/NotoSansGeorgian[wdth,wght].ttf: NotoSansGeorgian[wdth,wght].ttf
+repository_url: https://github.com/notofonts/georgian

--- a/ofl/notosansgrantha/upstream.yaml
+++ b/ofl/notosansgrantha/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansGrantha/googlefonts/ttf/NotoSansGrantha-Regular.ttf: NotoSansGrantha-Regular.ttf
+repository_url: https://github.com/notofonts/grantha

--- a/ofl/notosansgujarati/upstream.yaml
+++ b/ofl/notosansgujarati/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansGujarati/googlefonts/variable-ttf/NotoSansGujarati[wdth,wght].ttf: NotoSansGujarati[wdth,wght].ttf
+repository_url: https://github.com/notofonts/gujarati

--- a/ofl/notosansgurmukhi/upstream.yaml
+++ b/ofl/notosansgurmukhi/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansGurmukhi/googlefonts/variable-ttf/NotoSansGurmukhi[wdth,wght].ttf: NotoSansGurmukhi[wdth,wght].ttf
+repository_url: https://github.com/notofonts/gurmukhi

--- a/ofl/notosanshanifirohingya/upstream.yaml
+++ b/ofl/notosanshanifirohingya/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansHanifiRohingya/googlefonts/variable-ttf/NotoSansHanifiRohingya[wght].ttf: NotoSansHanifiRohingya[wght].ttf
+repository_url: https://github.com/notofonts/hanifi-rohingya

--- a/ofl/notosanshanunoo/upstream.yaml
+++ b/ofl/notosanshanunoo/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansHanunoo/googlefonts/ttf/NotoSansHanunoo-Regular.ttf: NotoSansHanunoo-Regular.ttf
+repository_url: https://github.com/notofonts/hanunoo

--- a/ofl/notosanshebrew/upstream.yaml
+++ b/ofl/notosanshebrew/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansHebrew/googlefonts/variable-ttf/NotoSansHebrew[wdth,wght].ttf: NotoSansHebrew[wdth,wght].ttf
+repository_url: https://github.com/notofonts/hebrew

--- a/ofl/notosansjavanese/upstream.yaml
+++ b/ofl/notosansjavanese/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansJavanese/googlefonts/variable-ttf/NotoSansJavanese[wght].ttf: NotoSansJavanese[wght].ttf
+repository_url: https://github.com/notofonts/javanese

--- a/ofl/notosanskannada/upstream.yaml
+++ b/ofl/notosanskannada/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansKannada/googlefonts/variable-ttf/NotoSansKannada[wdth,wght].ttf: NotoSansKannada[wdth,wght].ttf
+repository_url: https://github.com/notofonts/kannada

--- a/ofl/notosanskayahli/upstream.yaml
+++ b/ofl/notosanskayahli/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansKayahLi/googlefonts/variable-ttf/NotoSansKayahLi[wght].ttf: NotoSansKayahLi[wght].ttf
+repository_url: https://github.com/notofonts/kayah-li

--- a/ofl/notosanskhmer/upstream.yaml
+++ b/ofl/notosanskhmer/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansKhmer/googlefonts/variable-ttf/NotoSansKhmer[wdth,wght].ttf: NotoSansKhmer[wdth,wght].ttf
+repository_url: https://github.com/notofonts/khmer

--- a/ofl/notosanskhojki/upstream.yaml
+++ b/ofl/notosanskhojki/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   OFL.txt: OFL.txt
   NotoSansKhojki/googlefonts/ttf/NotoSansKhojki-Regular.ttf: NotoSansKhojki-Regular.ttf
+repository_url: https://github.com/notofonts/khojki

--- a/ofl/notosanslao/upstream.yaml
+++ b/ofl/notosanslao/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansLao/googlefonts/variable-ttf/NotoSansLao[wdth,wght].ttf: NotoSansLao[wdth,wght].ttf
+repository_url: https://github.com/notofonts/lao

--- a/ofl/notosanslaolooped/upstream.yaml
+++ b/ofl/notosanslaolooped/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansLaoLooped/googlefonts/variable-ttf/NotoSansLaoLooped[wdth,wght].ttf: NotoSansLaoLooped[wdth,wght].ttf
+repository_url: https://github.com/notofonts/lao

--- a/ofl/notosanslepcha/upstream.yaml
+++ b/ofl/notosanslepcha/upstream.yaml
@@ -5,3 +5,4 @@ files:
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   OFL.txt: OFL.txt
   NotoSansLepcha/googlefonts/ttf/NotoSansLepcha-Regular.ttf: NotoSansLepcha-Regular.ttf
+repository_url: https://github.com/notofonts/lepcha

--- a/ofl/notosanslimbu/upstream.yaml
+++ b/ofl/notosanslimbu/upstream.yaml
@@ -4,3 +4,4 @@ files:
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   OFL.txt: OFL.txt
   NotoSansLimbu/googlefonts/ttf/NotoSansLimbu-Regular.ttf: NotoSansLimbu-Regular.ttf
+repository_url: https://github.com/notofonts/limbu

--- a/ofl/notosanslisu/upstream.yaml
+++ b/ofl/notosanslisu/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansLisu/googlefonts/variable-ttf/NotoSansLisu[wght].ttf: NotoSansLisu[wght].ttf
+repository_url: https://github.com/notofonts/lisu

--- a/ofl/notosansmalayalam/upstream.yaml
+++ b/ofl/notosansmalayalam/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansMalayalam/googlefonts/variable-ttf/NotoSansMalayalam[wdth,wght].ttf: NotoSansMalayalam[wdth,wght].ttf
+repository_url: https://github.com/notofonts/malayalam

--- a/ofl/notosansmasaramgondi/upstream.yaml
+++ b/ofl/notosansmasaramgondi/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansMasaramGondi/googlefonts/ttf/NotoSansMasaramGondi-Regular.ttf: NotoSansMasaramGondi-Regular.ttf
+repository_url: https://github.com/notofonts/masaram-gondi

--- a/ofl/notosansmedefaidrin/upstream.yaml
+++ b/ofl/notosansmedefaidrin/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansMedefaidrin/googlefonts/variable-ttf/NotoSansMedefaidrin[wght].ttf: NotoSansMedefaidrin[wght].ttf
+repository_url: https://github.com/notofonts/medefaidrin

--- a/ofl/notosansmeeteimayek/upstream.yaml
+++ b/ofl/notosansmeeteimayek/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansMeeteiMayek/googlefonts/variable-ttf/NotoSansMeeteiMayek[wght].ttf: NotoSansMeeteiMayek[wght].ttf
+repository_url: https://github.com/notofonts/meetei-mayek

--- a/ofl/notosansmendekikakui/upstream.yaml
+++ b/ofl/notosansmendekikakui/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansMendeKikakui/googlefonts/ttf/NotoSansMendeKikakui-Regular.ttf: NotoSansMendeKikakui-Regular.ttf
+repository_url: https://github.com/notofonts/mende-kikakui

--- a/ofl/notosansmiao/upstream.yaml
+++ b/ofl/notosansmiao/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansMiao/googlefonts/ttf/NotoSansMiao-Regular.ttf: NotoSansMiao-Regular.ttf
+repository_url: https://github.com/notofonts/miao

--- a/ofl/notosansmodi/upstream.yaml
+++ b/ofl/notosansmodi/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   OFL.txt: OFL.txt
   NotoSansModi/googlefonts/ttf/NotoSansModi-Regular.ttf: NotoSansModi-Regular.ttf
+repository_url: https://github.com/notofonts/modi

--- a/ofl/notosansmongolian/upstream.yaml
+++ b/ofl/notosansmongolian/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansMongolian/googlefonts/ttf/NotoSansMongolian-Regular.ttf: NotoSansMongolian-Regular.ttf
+repository_url: https://github.com/notofonts/mongolian

--- a/ofl/notosansmono/upstream.yaml
+++ b/ofl/notosansmono/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansMono/googlefonts/variable-ttf/NotoSansMono[wdth,wght].ttf: NotoSansMono[wdth,wght].ttf
+repository_url: https://github.com/notofonts/latin-greek-cyrillic

--- a/ofl/notosansmro/upstream.yaml
+++ b/ofl/notosansmro/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansMro/googlefonts/ttf/NotoSansMro-Regular.ttf: NotoSansMro-Regular.ttf
+repository_url: https://github.com/notofonts/mro

--- a/ofl/notosansmultani/upstream.yaml
+++ b/ofl/notosansmultani/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   OFL.txt: OFL.txt
   NotoSansMultani/googlefonts/ttf/NotoSansMultani-Regular.ttf: NotoSansMultani-Regular.ttf
+repository_url: https://github.com/notofonts/multani

--- a/ofl/notosansmyanmar/upstream.yaml
+++ b/ofl/notosansmyanmar/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansMyanmar/googlefonts/variable-ttf/NotoSansMyanmar[wdth,wght].ttf: NotoSansMyanmar[wdth,wght].ttf
+repository_url: https://github.com/notofonts/myanmar

--- a/ofl/notosansnewa/upstream.yaml
+++ b/ofl/notosansnewa/upstream.yaml
@@ -5,3 +5,4 @@ files:
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   OFL.txt: OFL.txt
   NotoSansNewa/googlefonts/ttf/NotoSansNewa-Regular.ttf: NotoSansNewa-Regular.ttf
+repository_url: https://github.com/notofonts/newa

--- a/ofl/notosansnewtailue/upstream.yaml
+++ b/ofl/notosansnewtailue/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansNewTaiLue/googlefonts/variable-ttf/NotoSansNewTaiLue[wght].ttf: NotoSansNewTaiLue[wght].ttf
+repository_url: https://github.com/notofonts/new-tai-lue

--- a/ofl/notosansnko/upstream.yaml
+++ b/ofl/notosansnko/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansNKo/googlefonts/ttf/NotoSansNKo-Regular.ttf: NotoSansNKo-Regular.ttf
+repository_url: https://github.com/notofonts/nko

--- a/ofl/notosansolchiki/upstream.yaml
+++ b/ofl/notosansolchiki/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansOlChiki/googlefonts/variable-ttf/NotoSansOlChiki[wght].ttf: NotoSansOlChiki[wght].ttf
+repository_url: https://github.com/notofonts/ol-chiki

--- a/ofl/notosansoriya/upstream.yaml
+++ b/ofl/notosansoriya/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansOriya/googlefonts/variable-ttf/NotoSansOriya[wdth,wght].ttf: NotoSansOriya[wdth,wght].ttf
+repository_url: https://github.com/notofonts/oriya

--- a/ofl/notosansosage/upstream.yaml
+++ b/ofl/notosansosage/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansOsage/googlefonts/ttf/NotoSansOsage-Regular.ttf: NotoSansOsage-Regular.ttf
+repository_url: https://github.com/notofonts/osage

--- a/ofl/notosansosmanya/upstream.yaml
+++ b/ofl/notosansosmanya/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansOsmanya/googlefonts/ttf/NotoSansOsmanya-Regular.ttf: NotoSansOsmanya-Regular.ttf
+repository_url: https://github.com/notofonts/osmanya

--- a/ofl/notosanspahawhhmong/upstream.yaml
+++ b/ofl/notosanspahawhhmong/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansPahawhHmong/googlefonts/ttf/NotoSansPahawhHmong-Regular.ttf: NotoSansPahawhHmong-Regular.ttf
+repository_url: https://github.com/notofonts/pahawh-hmong

--- a/ofl/notosanspaucinhau/upstream.yaml
+++ b/ofl/notosanspaucinhau/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansPauCinHau/googlefonts/ttf/NotoSansPauCinHau-Regular.ttf: NotoSansPauCinHau-Regular.ttf
+repository_url: https://github.com/notofonts/pau-cin-hau

--- a/ofl/notosansrejang/upstream.yaml
+++ b/ofl/notosansrejang/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansRejang/googlefonts/ttf/NotoSansRejang-Regular.ttf: NotoSansRejang-Regular.ttf
+repository_url: https://github.com/notofonts/rejang

--- a/ofl/notosanssaurashtra/upstream.yaml
+++ b/ofl/notosanssaurashtra/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   OFL.txt: OFL.txt
   NotoSansSaurashtra/googlefonts/ttf/NotoSansSaurashtra-Regular.ttf: NotoSansSaurashtra-Regular.ttf
+repository_url: https://github.com/notofonts/saurashtra

--- a/ofl/notosanssharada/upstream.yaml
+++ b/ofl/notosanssharada/upstream.yaml
@@ -5,3 +5,4 @@ files:
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   OFL.txt: OFL.txt
   NotoSansSharada/googlefonts/ttf/NotoSansSharada-Regular.ttf: NotoSansSharada-Regular.ttf
+repository_url: https://github.com/notofonts/sharada

--- a/ofl/notosanssiddham/upstream.yaml
+++ b/ofl/notosanssiddham/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   OFL.txt: OFL.txt
   NotoSansSiddham/googlefonts/ttf/NotoSansSiddham-Regular.ttf: NotoSansSiddham-Regular.ttf
+repository_url: https://github.com/notofonts/siddham

--- a/ofl/notosanssinhala/upstream.yaml
+++ b/ofl/notosanssinhala/upstream.yaml
@@ -5,3 +5,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansSinhala/googlefonts/variable-ttf/NotoSansSinhala[wdth,wght].ttf: NotoSansSinhala[wdth,wght].ttf
+repository_url: https://github.com/notofonts/sinhala

--- a/ofl/notosanssorasompeng/upstream.yaml
+++ b/ofl/notosanssorasompeng/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansSoraSompeng/googlefonts/variable-ttf/NotoSansSoraSompeng[wght].ttf: NotoSansSoraSompeng[wght].ttf
+repository_url: https://github.com/notofonts/sora-sompeng

--- a/ofl/notosanssundanese/upstream.yaml
+++ b/ofl/notosanssundanese/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   OFL.txt: OFL.txt
   NotoSansSundanese/googlefonts/variable-ttf/NotoSansSundanese[wght].ttf: NotoSansSundanese[wght].ttf
+repository_url: https://github.com/notofonts/sundanese

--- a/ofl/notosanssylotinagri/upstream.yaml
+++ b/ofl/notosanssylotinagri/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   OFL.txt: OFL.txt
   NotoSansSylotiNagri/googlefonts/ttf/NotoSansSylotiNagri-Regular.ttf: NotoSansSylotiNagri-Regular.ttf
+repository_url: https://github.com/notofonts/syloti-nagri

--- a/ofl/notosanssymbols/upstream.yaml
+++ b/ofl/notosanssymbols/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansSymbols/googlefonts/variable-ttf/NotoSansSymbols[wght].ttf: NotoSansSymbols[wght].ttf
+repository_url: https://github.com/notofonts/symbols

--- a/ofl/notosanssymbols2/upstream.yaml
+++ b/ofl/notosanssymbols2/upstream.yaml
@@ -5,3 +5,4 @@ files:
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   OFL.txt: OFL.txt
   NotoSansSymbols2/googlefonts/ttf/NotoSansSymbols2-Regular.ttf: NotoSansSymbols2-Regular.ttf
+repository_url: https://github.com/notofonts/symbols

--- a/ofl/notosanstagalog/upstream.yaml
+++ b/ofl/notosanstagalog/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansTagalog/googlefonts/ttf/NotoSansTagalog-Regular.ttf: NotoSansTagalog-Regular.ttf
+repository_url: https://github.com/notofonts/tagalog

--- a/ofl/notosanstagbanwa/upstream.yaml
+++ b/ofl/notosanstagbanwa/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansTagbanwa/googlefonts/ttf/NotoSansTagbanwa-Regular.ttf: NotoSansTagbanwa-Regular.ttf
+repository_url: https://github.com/notofonts/tagbanwa

--- a/ofl/notosanstaile/upstream.yaml
+++ b/ofl/notosanstaile/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansTaiLe/googlefonts/ttf/NotoSansTaiLe-Regular.ttf: NotoSansTaiLe-Regular.ttf
+repository_url: https://github.com/notofonts/tai-le

--- a/ofl/notosanstaitham/upstream.yaml
+++ b/ofl/notosanstaitham/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansTaiTham/googlefonts/variable-ttf/NotoSansTaiTham[wght].ttf: NotoSansTaiTham[wght].ttf
+repository_url: https://github.com/notofonts/tai-tham

--- a/ofl/notosanstaiviet/upstream.yaml
+++ b/ofl/notosanstaiviet/upstream.yaml
@@ -5,3 +5,4 @@ files:
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   OFL.txt: OFL.txt
   NotoSansTaiViet/googlefonts/ttf/NotoSansTaiViet-Regular.ttf: NotoSansTaiViet-Regular.ttf
+repository_url: https://github.com/notofonts/tai-viet

--- a/ofl/notosanstakri/upstream.yaml
+++ b/ofl/notosanstakri/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansTakri/googlefonts/ttf/NotoSansTakri-Regular.ttf: NotoSansTakri-Regular.ttf
+repository_url: https://github.com/notofonts/takri

--- a/ofl/notosanstamil/upstream.yaml
+++ b/ofl/notosanstamil/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansTamil/googlefonts/variable-ttf/NotoSansTamil[wdth,wght].ttf: NotoSansTamil[wdth,wght].ttf
+repository_url: https://github.com/notofonts/tamil

--- a/ofl/notosanstelugu/upstream.yaml
+++ b/ofl/notosanstelugu/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansTelugu/googlefonts/variable-ttf/NotoSansTelugu[wdth,wght].ttf: NotoSansTelugu[wdth,wght].ttf
+repository_url: https://github.com/notofonts/telugu

--- a/ofl/notosansthaana/upstream.yaml
+++ b/ofl/notosansthaana/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansThaana/googlefonts/variable-ttf/NotoSansThaana[wght].ttf: NotoSansThaana[wght].ttf
+repository_url: https://github.com/notofonts/thaana

--- a/ofl/notosansthai/upstream.yaml
+++ b/ofl/notosansthai/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSansThai/googlefonts/variable-ttf/NotoSansThai[wdth,wght].ttf: NotoSansThai[wdth,wght].ttf
+repository_url: https://github.com/notofonts/thai

--- a/ofl/notosansthailooped/upstream.yaml
+++ b/ofl/notosansthailooped/upstream.yaml
@@ -11,3 +11,4 @@ files:
   NotoSansThaiLooped/googlefonts/ttf/NotoSansThaiLooped-Bold.ttf: NotoSansThaiLooped-Bold.ttf
   NotoSansThaiLooped/googlefonts/ttf/NotoSansThaiLooped-Light.ttf: NotoSansThaiLooped-Light.ttf
   NotoSansThaiLooped/googlefonts/ttf/NotoSansThaiLooped-SemiBold.ttf: NotoSansThaiLooped-SemiBold.ttf
+repository_url: https://github.com/notofonts/thai

--- a/ofl/notosanstifinagh/upstream.yaml
+++ b/ofl/notosanstifinagh/upstream.yaml
@@ -5,3 +5,4 @@ files:
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   NotoSansTifinagh/googlefonts/ttf/NotoSansTifinagh-Regular.ttf: NotoSansTifinagh-Regular.ttf
+repository_url: https://github.com/notofonts/tifinagh

--- a/ofl/notosansvai/upstream.yaml
+++ b/ofl/notosansvai/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansVai/googlefonts/ttf/NotoSansVai-Regular.ttf: NotoSansVai-Regular.ttf
+repository_url: https://github.com/notofonts/vai

--- a/ofl/notosanswancho/upstream.yaml
+++ b/ofl/notosanswancho/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansWancho/googlefonts/ttf/NotoSansWancho-Regular.ttf: NotoSansWancho-Regular.ttf
+repository_url: https://github.com/notofonts/wancho

--- a/ofl/notosanswarangciti/upstream.yaml
+++ b/ofl/notosanswarangciti/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansWarangCiti/googlefonts/ttf/NotoSansWarangCiti-Regular.ttf: NotoSansWarangCiti-Regular.ttf
+repository_url: https://github.com/notofonts/warang-citi

--- a/ofl/notosansyi/upstream.yaml
+++ b/ofl/notosansyi/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSansYi/googlefonts/ttf/NotoSansYi-Regular.ttf: NotoSansYi-Regular.ttf
+repository_url: https://github.com/notofonts/yi

--- a/ofl/notosanszanabazarsquare/upstream.yaml
+++ b/ofl/notosanszanabazarsquare/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   OFL.txt: OFL.txt
   NotoSansZanabazarSquare/googlefonts/ttf/NotoSansZanabazarSquare-Regular.ttf: NotoSansZanabazarSquare-Regular.ttf
+repository_url: https://github.com/notofonts/zanabazar-square

--- a/ofl/notoserifahom/upstream.yaml
+++ b/ofl/notoserifahom/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifAhom/full/ttf/NotoSerifAhom-Regular.ttf: NotoSerifAhom-Regular.ttf
+repository_url: https://github.com/notofonts/ahom

--- a/ofl/notoserifarmenian/upstream.yaml
+++ b/ofl/notoserifarmenian/upstream.yaml
@@ -5,3 +5,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSerifArmenian/googlefonts/variable-ttf/NotoSerifArmenian[wdth,wght].ttf: NotoSerifArmenian[wdth,wght].ttf
+repository_url: https://github.com/notofonts/armenian

--- a/ofl/notoserifbalinese/upstream.yaml
+++ b/ofl/notoserifbalinese/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifBalinese/googlefonts/ttf/NotoSerifBalinese-Regular.ttf: NotoSerifBalinese-Regular.ttf
+repository_url: https://github.com/notofonts/balinese

--- a/ofl/notoserifbengali/upstream.yaml
+++ b/ofl/notoserifbengali/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifBengali/googlefonts/variable-ttf/NotoSerifBengali[wdth,wght].ttf: NotoSerifBengali[wdth,wght].ttf
+repository_url: https://github.com/notofonts/bengali

--- a/ofl/notoserifdevanagari/upstream.yaml
+++ b/ofl/notoserifdevanagari/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifDevanagari/googlefonts/variable-ttf/NotoSerifDevanagari[wdth,wght].ttf: NotoSerifDevanagari[wdth,wght].ttf
+repository_url: https://github.com/notofonts/devanagari

--- a/ofl/notoserifdogra/upstream.yaml
+++ b/ofl/notoserifdogra/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifDogra/full/ttf/NotoSerifDogra-Regular.ttf: NotoSerifDogra-Regular.ttf
+repository_url: https://github.com/notofonts/dogra

--- a/ofl/notoserifethiopic/upstream.yaml
+++ b/ofl/notoserifethiopic/upstream.yaml
@@ -5,3 +5,4 @@ files:
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   OFL.txt: OFL.txt
   NotoSerifEthiopic/googlefonts/variable-ttf/NotoSerifEthiopic[wdth,wght].ttf: NotoSerifEthiopic[wdth,wght].ttf
+repository_url: https://github.com/notofonts/ethiopic

--- a/ofl/notoserifgeorgian/upstream.yaml
+++ b/ofl/notoserifgeorgian/upstream.yaml
@@ -2,3 +2,4 @@ archive: https://github.com/notofonts/georgian/releases/download/NotoSerifGeorgi
 branch: main
 files:
   NotoSerifGeorgian/googlefonts/variable-ttf/NotoSerifGeorgian[wdth,wght].ttf: NotoSerifGeorgian[wdth,wght].ttf
+repository_url: https://github.com/notofonts/georgian

--- a/ofl/notoserifgrantha/upstream.yaml
+++ b/ofl/notoserifgrantha/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSerifGrantha/googlefonts/ttf/NotoSerifGrantha-Regular.ttf: NotoSerifGrantha-Regular.ttf
+repository_url: https://github.com/notofonts/grantha

--- a/ofl/notoserifgujarati/upstream.yaml
+++ b/ofl/notoserifgujarati/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifGujarati/googlefonts/variable-ttf/NotoSerifGujarati[wght].ttf: NotoSerifGujarati[wght].ttf
+repository_url: https://github.com/notofonts/gujarati

--- a/ofl/notoserifgurmukhi/upstream.yaml
+++ b/ofl/notoserifgurmukhi/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifGurmukhi/googlefonts/variable-ttf/NotoSerifGurmukhi[wght].ttf: NotoSerifGurmukhi[wght].ttf
+repository_url: https://github.com/notofonts/gurmukhi

--- a/ofl/notoserifhebrew/upstream.yaml
+++ b/ofl/notoserifhebrew/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifHebrew/googlefonts/variable-ttf/NotoSerifHebrew[wdth,wght].ttf: NotoSerifHebrew[wdth,wght].ttf
+repository_url: https://github.com/notofonts/hebrew

--- a/ofl/notoserifkannada/upstream.yaml
+++ b/ofl/notoserifkannada/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifKannada/googlefonts/variable-ttf/NotoSerifKannada[wght].ttf: NotoSerifKannada[wght].ttf
+repository_url: https://github.com/notofonts/kannada

--- a/ofl/notoserifkhmer/upstream.yaml
+++ b/ofl/notoserifkhmer/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifKhmer/googlefonts/variable-ttf/NotoSerifKhmer[wdth,wght].ttf: NotoSerifKhmer[wdth,wght].ttf
+repository_url: https://github.com/notofonts/khmer

--- a/ofl/notoserifkhojki/upstream.yaml
+++ b/ofl/notoserifkhojki/upstream.yaml
@@ -5,3 +5,4 @@ files:
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   OFL.txt: OFL.txt
   NotoSerifKhojki/googlefonts/variable-ttf/NotoSerifKhojki[wght].ttf: NotoSerifKhojki[wght].ttf
+repository_url: https://github.com/notofonts/khojki

--- a/ofl/notoseriflao/upstream.yaml
+++ b/ofl/notoseriflao/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifLao/googlefonts/variable-ttf/NotoSerifLao[wdth,wght].ttf: NotoSerifLao[wdth,wght].ttf
+repository_url: https://github.com/notofonts/lao

--- a/ofl/notoserifmalayalam/upstream.yaml
+++ b/ofl/notoserifmalayalam/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifMalayalam/googlefonts/variable-ttf/NotoSerifMalayalam[wght].ttf: NotoSerifMalayalam[wght].ttf
+repository_url: https://github.com/notofonts/malayalam

--- a/ofl/notoseriforiya/upstream.yaml
+++ b/ofl/notoseriforiya/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifOriya/googlefonts/variable-ttf/NotoSerifOriya[wght].ttf: NotoSerifOriya[wght].ttf
+repository_url: https://github.com/notofonts/oriya

--- a/ofl/notoserifsinhala/upstream.yaml
+++ b/ofl/notoserifsinhala/upstream.yaml
@@ -5,3 +5,4 @@ files:
   OFL.txt: OFL.txt
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSerifSinhala/googlefonts/variable-ttf/NotoSerifSinhala[wdth,wght].ttf: NotoSerifSinhala[wdth,wght].ttf
+repository_url: https://github.com/notofonts/sinhala

--- a/ofl/notoseriftamil/upstream.yaml
+++ b/ofl/notoseriftamil/upstream.yaml
@@ -4,3 +4,4 @@ files:
   OFL.txt: OFL.txt
   NotoSerifTamil/googlefonts/variable-ttf/NotoSerifTamil[wdth,wght].ttf: NotoSerifTamil[wdth,wght].ttf
   NotoSerifTamil/googlefonts/variable-ttf/NotoSerifTamil-Italic[wdth,wght].ttf: NotoSerifTamil-Italic[wdth,wght].ttf
+repository_url: https://github.com/notofonts/tamil

--- a/ofl/notoseriftelugu/upstream.yaml
+++ b/ofl/notoseriftelugu/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifTelugu/googlefonts/variable-ttf/NotoSerifTelugu[wght].ttf: NotoSerifTelugu[wght].ttf
+repository_url: https://github.com/notofonts/telugu

--- a/ofl/notoserifthai/upstream.yaml
+++ b/ofl/notoserifthai/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   OFL.txt: OFL.txt
   NotoSerifThai/googlefonts/variable-ttf/NotoSerifThai[wdth,wght].ttf: NotoSerifThai[wdth,wght].ttf
+repository_url: https://github.com/notofonts/thai

--- a/ofl/notoseriftibetan/upstream.yaml
+++ b/ofl/notoseriftibetan/upstream.yaml
@@ -5,3 +5,4 @@ files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html
   DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
   NotoSerifTibetan/googlefonts/variable-ttf/NotoSerifTibetan[wght].ttf: NotoSerifTibetan[wght].ttf
+repository_url: https://github.com/notofonts/tibetan

--- a/ofl/nuosusil/upstream.yaml
+++ b/ofl/nuosusil/upstream.yaml
@@ -3,3 +3,4 @@ branch: master
 files:
   NuosuSIL-2.200/OFL.txt: OFL.txt
   NuosuSIL-2.200/NuosuSIL-Regular.ttf: NuosuSIL-Regular.ttf
+repository_url: https://github.com/silnrsi/font-nuosu

--- a/ofl/padauk/upstream.yaml
+++ b/ofl/padauk/upstream.yaml
@@ -4,3 +4,4 @@ files:
   Padauk-5.001/OFL.txt: OFL.txt
   Padauk-5.001/Padauk-Regular.ttf: Padauk-Regular.ttf
   Padauk-5.001/Padauk-Bold.ttf: Padauk-Bold.ttf
+repository_url: https://github.com/silnrsi/font-padauk

--- a/ofl/reemkufi/upstream.yaml
+++ b/ofl/reemkufi/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   ReemKufi-1.6/OFL.txt: OFL.txt
   ReemKufi-1.6/ttf/ReemKufi.ttf: ReemKufi[wght].ttf
+repository_url: https://github.com/aliftype/reem-kufi

--- a/ofl/reemkufifun/upstream.yaml
+++ b/ofl/reemkufifun/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   ReemKufi-1.5/OFL.txt: OFL.txt
   ReemKufi-1.5/ttf/ReemKufiFun.ttf: ReemKufiFun[wght].ttf
+repository_url: https://github.com/aliftype/reem-kufi

--- a/ofl/reemkufiink/upstream.yaml
+++ b/ofl/reemkufiink/upstream.yaml
@@ -3,3 +3,4 @@ branch: main
 files:
   ReemKufi-1.7/OFL.txt: OFL.txt
   ReemKufi-1.7/ttf/ReemKufiInk-Regular.ttf: ReemKufiInk-Regular.ttf
+repository_url: https://github.com/aliftype/reem-kufi

--- a/ofl/robotoflex/upstream.yaml
+++ b/ofl/robotoflex/upstream.yaml
@@ -2,3 +2,4 @@ archive: https://github.com/googlefonts/roboto-flex/releases/download/3.100/robo
 branch: main
 files:
   roboto-flex-fonts/fonts/variable/RobotoFlex[GRAD,XOPQ,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght].ttf: RobotoFlex[GRAD,XOPQ,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght].ttf
+repository_url: https://github.com/googlefonts/roboto-flex

--- a/ofl/scheherazadenew/upstream.yaml
+++ b/ofl/scheherazadenew/upstream.yaml
@@ -4,3 +4,4 @@ files:
   ScheherazadeNew-3.300/OFL.txt: OFL.txt
   ScheherazadeNew-3.300/ScheherazadeNew-Regular.ttf: ScheherazadeNew-Regular.ttf
   ScheherazadeNew-3.300/ScheherazadeNew-Bold.ttf: ScheherazadeNew-Bold.ttf
+repository_url: https://github.com/silnrsi/font-scheherazade

--- a/ofl/taiheritagepro/upstream.yaml
+++ b/ofl/taiheritagepro/upstream.yaml
@@ -4,3 +4,4 @@ files:
   TaiHeritagePro-2.600/OFL.txt: OFL.txt
   TaiHeritagePro-2.600/TaiHeritagePro-Regular.ttf: TaiHeritagePro-Regular.ttf
   TaiHeritagePro-2.600/TaiHeritagePro-Bold.ttf: TaiHeritagePro-Bold.ttf
+repository_url: https://github.com/silnrsi/font-taiheritagepro


### PR DESCRIPTION
Add repo_url where missing and implied by archive as suggested in https://github.com/google/fonts/issues/4773#issuecomment-1328101047.

Changes generated by https://github.com/rsheeter/google_fonts_sources/blob/main/add_missing_repo_urls.py.