### PR TITLE
ci: add render command

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -24,7 +24,7 @@ do
 		then
 			echo "Fonts have been modified. Checking fonts with all tools"
 			if [ "$SCREENSHOTS" = true ]; then
-				gftools qa -f $dir*.ttf -gfb --diffbrowsers --imgs -o $OUT/$(basename $dir)_qa
+				gftools qa -f $dir*.ttf -gfb --render --imgs -o $OUT/$(basename $dir)_qa
 			else
 				gftools qa -f $dir*.ttf -gfb --diffenator --fontbakery -o $OUT/$(basename $dir)_qa --out-url $PR_URL
 			fi


### PR DESCRIPTION
CI currently fails when testing a family which doesn't exist on Google fonts yet e.g https://github.com/google/fonts/actions/runs/3891938504

In order to fix this, I've called the render method in gftools.qa, which will generate html proofs if the font isn't on Google Fonts. If it does exist on GF, it will call diffbrowsers instead.

cc @simoncozens 

