### PR TITLE
Use the --pre flag for installing Font Bakery

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,8 +80,11 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install packages
+        # The --pre flag below will ensure we use the latest Font Bakery pre-releases
+        # and benefit from its newest checks:
         run: |
           pip install --upgrade pip
+          pip install --pre fontbakery
           pip install gftools[qa] pytest
         shell: bash
 


### PR DESCRIPTION
on Github Actions so that we can benefit from the newest checks introduced in its more frequent pre-releases such as `v0.8.11a8`, `v0.8.11a9`, `v0.8.11b0`, etc

https://pypi.org/project/fontbakery/#history
![Screenshot from 2023-03-04 10-31-15](https://user-images.githubusercontent.com/213676/222896623-844c5447-723d-4a13-8fc2-691f2f065910.png)
