### PR TITLE
Agdasima: Version 2.002 added

### DIFF
--- a/ofl/agdasima/DESCRIPTION.en_us.html
+++ b/ofl/agdasima/DESCRIPTION.en_us.html
@@ -4,3 +4,7 @@
     XML documents. Agdasima is based on Big Shoulders, a condensed American Gothic
     sans-serif font family.
 </p>
+<p>
+    To contribute, please visit <a
+        href="https://github.com/docrepair-fonts/agdasima-fonts">github.com/docrepair-fonts/agdasima-fonts</a>.
+</p>

--- a/ofl/agdasima/METADATA.pb
+++ b/ofl/agdasima/METADATA.pb
@@ -26,5 +26,5 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/docrepair-fonts/agdasima-fonts"
-  commit: "affd96dca1cc5e00c8590669c74e7f21e8c35f0d"
+  commit: "d83c2c23b82cf160044b1afa1a789f720e72a4bb"
 }


### PR DESCRIPTION
 2350f57: [gftools-packager] Agdasima: Version 2.002 added

* Agdasima Version 2.002 taken from the upstream repo https://github.com/docrepair-fonts/agdasima-fonts at commit https://github.com/docrepair-fonts/agdasima-fonts/commit/d83c2c23b82cf160044b1afa1a789f720e72a4bb.