### PR TITLE
Noto Sans Symbols 2: Restore sample text

### DIFF
--- a/ofl/notosanssymbols2/METADATA.pb
+++ b/ofl/notosanssymbols2/METADATA.pb
@@ -21,3 +21,12 @@ source {
   archive_url: "https://github.com/notofonts/symbols/releases/download/NotoSansSymbols2-v2.006/NotoSansSymbols2-v2.006.zip"
 }
 is_noto: true
+sample_text {
+  masthead_full: "♠🖫🙥👍"
+  masthead_partial: "🏆🡽"
+  styles: "🌍✄✎ 🏔🏕🏌🏍🎭🎮 🯅🯆🯇🯉 🡢🡭🡱🡼 🯱🯲🯳🯴🯵🯶 🂮🂱🂲🂳"
+  tester: "✷✺✻✽ ⯮⮊⮫⬈⇨🡲 ♠♣🖪🖫 🨀🨁🨂🨃🨄🨅 🗪🗮🗰 ⯞⯟⯠⬥⬦⬧ ⢈⢉⢊⢋⣋⣌⣍ ◻◼🞔🞕🞖 𐇠𐇡𐇢𐇣𐇤𐇗𐇘"
+  poster_sm: "🡢🡱🏠💻🐿👁📽"
+  poster_md: "⌚✋⯧☔🛪🏟⛅🞽🕖🚲"
+  poster_lg: "🡽🨄"
+}


### PR DESCRIPTION
As noted in https://github.com/google/fonts/pull/6053, the sample text metadata was removed from Noto Sans Symbols 2. This restores it.