### PR TITLE
Space Mono: Designer name in Metadata 

### DIFF
--- a/ofl/spacemono/METADATA.pb
+++ b/ofl/spacemono/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Space Mono"
-designer: "Colophon"
+designer: "Colophon Foundry"
 license: "OFL"
 category: "MONOSPACE"
 date_added: "2016-06-20"


### PR DESCRIPTION
Colophon became Colophon Foundry (appears twice in the catalog)