### PR TITLE
Fix typo in Hangeul Knowledge Lesson

### DIFF
--- a/cc-by-sa/knowledge/modules/designing_hangeul/lessons/an_introduction_to_hangeul/content.md
+++ b/cc-by-sa/knowledge/modules/designing_hangeul/lessons/an_introduction_to_hangeul/content.md
@@ -46,7 +46,7 @@ But King Sejong knew that his intended audience of common people had little time
 
 Thus, to realize his grand and radical vision of bringing literacy to the masses, he knew that he would need to devise an alphabet unlike any other—one that put the needs of the user first.
 
-In [the next article](/lesson/designing_for_learnability), we’ll explore how rose to meet this challenge.
+In [the next article](/lesson/designing_for_learnability), we’ll explore how he rose to meet this challenge.
 
 ## A note about terminology
 


### PR DESCRIPTION
There was a missing word in the "An Introduction to Hangeoul" lesson.

`how rose` ==> `how he rose`