### PR TITLE
Subtree pull Axis Registry introducing `YELA`

### DIFF
--- a/axisregistry/Lib/axisregistry/data/y_alignment.textproto
+++ b/axisregistry/Lib/axisregistry/data/y_alignment.textproto
@@ -1,0 +1,16 @@
+#YALN based on [Wavefont](https://github.com/dy/wavefont)
+tag: "YALN"
+display_name: "Y Alignment"
+min_value: -100
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description:
+  "Align glyphs from their default position (0%),"
+  " usually the baseline, to an upper (100%)"
+  " or lower (-100%) position."

--- a/axisregistry/Lib/axisregistry/data/y_element_alignment.textproto
+++ b/axisregistry/Lib/axisregistry/data/y_element_alignment.textproto
@@ -1,6 +1,6 @@
 #YALN based on [Wavefont](https://github.com/dy/wavefont)
-tag: "YALN"
-display_name: "Y Alignment"
+tag: "YELA"
+display_name: "Vertical Element Alignment"
 min_value: -100
 default_value: 0
 max_value: 100

--- a/axisregistry/Lib/axisregistry/data/y_element_alignment.textproto
+++ b/axisregistry/Lib/axisregistry/data/y_element_alignment.textproto
@@ -1,4 +1,4 @@
-#YALN based on [Wavefont](https://github.com/dy/wavefont)
+#YELA based on [Wavefont](https://github.com/dy/wavefont)
 tag: "YELA"
 display_name: "Vertical Element Alignment"
 min_value: -100


### PR DESCRIPTION
- [x] Includes `YALN - Vertical Alignment` axis required by Wavefont

This PR should navigate through the pipeline simultaneously with #6185 