### PR TITLE
Fix Gondi Metadata

### DIFF
--- a/ofl/narnoor/METADATA.pb
+++ b/ofl/narnoor/METADATA.pb
@@ -12,6 +12,7 @@ fonts {
   full_name: "Narnoor"
   copyright: "Original font copyright (c) 2014-2017 CDAST, University of Hyderabad, Hyderabad (cdast@uohyd.ernet.in).\nAdditions and modifications copyright (c) 2015-2023 SIL International (http://www.sil.org/).\nLatin glyphs copyright (c) 2010, 2012, 2014, 2021 Adobe Systems Incorporated\n(http://www.adobe.com/), with Reserved Font Name \'Source\'."
 }
+subsets: "gunjala-gondi"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"

--- a/ofl/notosansgunjalagondi/METADATA.pb
+++ b/ofl/notosansgunjalagondi/METADATA.pb
@@ -12,8 +12,8 @@ fonts {
   full_name: "Noto Sans Gunjala Gondi Regular"
   copyright: "Copyright 2019 Google LLC. All Rights Reserved."
 }
-subsets: "menu"
 subsets: "gunjala-gondi"
+subsets: "menu"
 is_noto: true
 languages: "gon_Gong"  # Gondi, Gunjala Gondi
-languages: "sa_Gong"  # Sanskrit, Gunjala Gondi
+languages: "wsg_Gong"  # Adilabad Gondi, Gunjala Gondi


### PR DESCRIPTION
1) Narnoor needed a gunjala-gondi subset (See https://github.com/googlefonts/lang/issues/64)
2) And because we got a new language sample for Adilabad Gondi (and removed the dummy Sanskrit sample) we need to update Noto Sans Gunjala Gondi's language metadata too.