### PR TITLE
Fix mistune create_markdown to work with mistune 3

### DIFF
--- a/.github/workflows/knowledge_graph.py
+++ b/.github/workflows/knowledge_graph.py
@@ -120,7 +120,7 @@ class KnowledgeContent(NamedTuple):
 
 
 def _markdown_ast(md_file: Path) -> List[MdValue]:
-    return mistune.create_markdown(renderer=mistune.AstRenderer())(md_file.read_text())
+    return mistune.create_markdown(renderer='ast')(md_file.read_text())
 
 
 def _ast_iter(root: List[MdValue], filter_fn: Callable[[MdValue], bool]) -> Iterable[MdValue]:


### PR DESCRIPTION
We don't pin mistune's version; v3 altered the way you ask for an ast renderer per https://mistune.lepture.com/en/latest/upgrade.html#astrenderer.

CI should be green again.