### PR TITLE
Noto Sans SignWriting: Version 2.005; ttfautohint (v1.8.4.7-5d5b) added

### DIFF
--- a/ofl/notosanssignwriting/METADATA.pb
+++ b/ofl/notosanssignwriting/METADATA.pb
@@ -18,15 +18,6 @@ subsets: "menu"
 subsets: "signwriting"
 source {
   repository_url: "https://github.com/notofonts/sign-writing.git"
-  archive_url: "https://github.com/notofonts/sign-writing/releases/download/NotoSansSignWriting-v2.004/NotoSansSignWriting-v2.004.zip"
+  archive_url: "https://github.com/notofonts/sign-writing/releases/download/NotoSansSignWriting-v2.005/NotoSansSignWriting-v2.005.zip"
 }
 is_noto: true
-sample_text {
-  masthead_full: "𝡝𝪩𝡝𝪡𝤅"
-  masthead_partial: "𝧿𝨔"
-  styles: "𝧿𝨊𝡝𝪜𝦦𝪬𝡝𝪩𝡝𝪡𝤅"
-  tester: "𝧿𝨊𝡝𝪜𝦦𝪬𝡝𝪩𝡝𝪡𝤅"
-  poster_sm: "𝧿𝨊𝡝𝪜𝦦𝪬𝡝𝪩𝡝𝪡𝤅"
-  poster_md: "𝡝𝪜𝦦𝪬"
-  poster_lg: "𝡝𝪩𝡝𝪡𝤅"
-}

--- a/ofl/notosanssignwriting/METADATA.pb
+++ b/ofl/notosanssignwriting/METADATA.pb
@@ -21,3 +21,12 @@ source {
   archive_url: "https://github.com/notofonts/sign-writing/releases/download/NotoSansSignWriting-v2.005/NotoSansSignWriting-v2.005.zip"
 }
 is_noto: true
+sample_text {
+  masthead_full: "𝡝𝪩𝡝𝪡𝤅"
+  masthead_partial: "𝧿𝨔"
+  styles: "𝧿𝨊𝡝𝪜𝦦𝪬𝡝𝪩𝡝𝪡𝤅"
+  tester: "𝧿𝨊𝡝𝪜𝦦𝪬𝡝𝪩𝡝𝪡𝤅"
+  poster_sm: "𝧿𝨊𝡝𝪜𝦦𝪬𝡝𝪩𝡝𝪡𝤅"
+  poster_md: "𝡝𝪜𝦦𝪬"
+  poster_lg: "𝡝𝪩𝡝𝪡𝤅"
+}

--- a/ofl/notosanssignwriting/upstream.yaml
+++ b/ofl/notosanssignwriting/upstream.yaml
@@ -1,4 +1,4 @@
-archive: https://github.com/notofonts/sign-writing/releases/download/NotoSansSignWriting-v2.004/NotoSansSignWriting-v2.004.zip
+archive: https://github.com/notofonts/sign-writing/releases/download/NotoSansSignWriting-v2.005/NotoSansSignWriting-v2.005.zip
 branch: main
 files:
   ARTICLE.en_us.html: article/ARTICLE.en_us.html


### PR DESCRIPTION
 a31b2cc: [gftools-packager] Noto Sans SignWriting: Version 2.005; ttfautohint (v1.8.4.7-5d5b) added

* Noto Sans SignWriting Version 2.005; ttfautohint (v1.8.4.7-5d5b) taken from the upstream repo https://github.com/notofonts/sign-writing.git at commit https://github.com/notofonts/sign-writing/commit/.