### PR TITLE
Subtree pull Axis Registry introducing `ZROT`

### DIFF
--- a/axisregistry/Lib/axisregistry/data/z_rotation.textproto
+++ b/axisregistry/Lib/axisregistry/data/z_rotation.textproto
@@ -1,0 +1,14 @@
+# Rotation in Z, based on a private project
+tag: "ZROT"
+display_name: "Rotation in Z"
+min_value: -180
+default_value: 0
+max_value: 180
+precision: 0
+fallback {
+  name: "Default"
+  value: 0.0
+}
+description: 
+  "Glyphs rotate left and right, negative values to the left"
+  " and positive values to the right, in the Z dimension."


### PR DESCRIPTION
Includes `ZROT - Rotation in Z` axis.

This PR should navigate through the pipeline independently of the font.