### PR TITLE
Removed fake sanskrit sample texts

### DIFF
--- a/ofl/mingzat/METADATA.pb
+++ b/ofl/mingzat/METADATA.pb
@@ -22,4 +22,3 @@ source {
 }
 primary_script: "Lepc"
 languages: "lep_Lepc"  # Lepcha
-languages: "sa_Lepc"  # Sanskrit, Lepcha

--- a/ofl/notosansavestan/METADATA.pb
+++ b/ofl/notosansavestan/METADATA.pb
@@ -22,5 +22,4 @@ source {
 }
 is_noto: true
 languages: "ae_Avst"  # Avestan
-languages: "sa_Avst"  # Sanskrit, Avestan
 primary_script: "Avst"

--- a/ofl/notosansbatak/METADATA.pb
+++ b/ofl/notosansbatak/METADATA.pb
@@ -22,5 +22,4 @@ source {
 }
 is_noto: true
 languages: "bbc_Batk"  # Batak Toba, Batak
-languages: "sa_Batk"  # Sanskrit, Batak
 primary_script: "Batk"

--- a/ofl/notosansbuhid/METADATA.pb
+++ b/ofl/notosansbuhid/METADATA.pb
@@ -22,5 +22,4 @@ source {
 }
 is_noto: true
 languages: "bku_Buhd"  # Buhid, Buhid
-languages: "sa_Buhd"  # Sanskrit, Buhid
 primary_script: "Buhd"

--- a/ofl/notosanskaithi/METADATA.pb
+++ b/ofl/notosanskaithi/METADATA.pb
@@ -22,5 +22,4 @@ source {
 }
 is_noto: true
 languages: "bho_Kthi"  # Bhojpuri, Kaithi
-languages: "sa_Kthi"  # Sanskrit, Kaithi
 primary_script: "Kthi"

--- a/ofl/notosanslepcha/METADATA.pb
+++ b/ofl/notosanslepcha/METADATA.pb
@@ -22,5 +22,4 @@ source {
 }
 is_noto: true
 languages: "lep_Lepc"  # Lepcha
-languages: "sa_Lepc"  # Sanskrit, Lepcha
 primary_script: "Lepc"

--- a/ofl/notosansmahajani/METADATA.pb
+++ b/ofl/notosansmahajani/METADATA.pb
@@ -22,5 +22,4 @@ source {
 }
 is_noto: true
 languages: "hi_Mahj"  # Hindi, Mahajani
-languages: "sa_Mahj"  # Sanskrit, Mahajani
 primary_script: "Mahj"

--- a/ofl/notosansolchiki/METADATA.pb
+++ b/ofl/notosansolchiki/METADATA.pb
@@ -26,6 +26,5 @@ source {
   archive_url: "https://github.com/notofonts/ol-chiki/releases/download/NotoSansOlChiki-v2.003/NotoSansOlChiki-v2.003.zip"
 }
 is_noto: true
-languages: "sa_Olck"  # Sanskrit, Ol Chiki
 languages: "sat_Olck"  # Santali
 primary_script: "Olck"

--- a/ofl/notosanssaurashtra/METADATA.pb
+++ b/ofl/notosanssaurashtra/METADATA.pb
@@ -21,6 +21,5 @@ source {
   archive_url: "https://github.com/notofonts/saurashtra/releases/download/NotoSansSaurashtra-v2.002/NotoSansSaurashtra-v2.002.zip"
 }
 is_noto: true
-languages: "sa_Saur"  # Sanskrit, Saurashtra
 languages: "saz_Saur"  # Saurashtra
 primary_script: "Saur"


### PR DESCRIPTION
to merge after #6573 

list of font affected in this PR:
 Mingzat
 Noto Sans Avestan
 Noto Sans Batak
 Noto Sans Buhid
 Noto Sans Kaithi
 Noto Sans Lepcha
 Noto Sans Mahajani
 Noto Sans Ol Chiki
 Noto Sans Saurashtra

should also be merged after:
#6418 
#6427 
#6426 
#6409 
#5377 
