### PR TITLE
Update method of installing FontBakery

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,7 +88,7 @@ jobs:
         # and benefit from its newest checks:
         run: |
           pip install --upgrade pip
-          pip install --pre fontbakery
+          pip install --pre fontbakery[googlefonts]
           pip install gftools[qa] pytest
         shell: bash
 


### PR DESCRIPTION
FontBakery now (starting at version 0.9.0a1) requires the name of the desired profile to be passed as an extra when installing it. For google/fonts, we run the `Google Fonts` profile, so the installation is done with `pip install --pre fontbakery[googlefonts]`

Without passing extras, only the dependencies needed by the Universal and OpenType profiles (and any vendor-specific profile not requiring additional deps) are installed.