### PR TITLE
Use sd_Sind, not sa_Sind, for Khudawadi

### DIFF
--- a/ofl/notosanskhudawadi/METADATA.pb
+++ b/ofl/notosanskhudawadi/METADATA.pb
@@ -21,6 +21,5 @@ source {
   archive_url: "https://github.com/notofonts/khudawadi/releases/download/NotoSansKhudawadi-v2.003/NotoSansKhudawadi-v2.003.zip"
 }
 is_noto: true
-languages: "sa_Sind"  # Sanskrit, Khudawadi
 languages: "sd_Sind"  # Sindhi, Khudawadi
 primary_script: "Sind"

--- a/ofl/notosanskhudawadi/METADATA.pb
+++ b/ofl/notosanskhudawadi/METADATA.pb
@@ -22,4 +22,5 @@ source {
 }
 is_noto: true
 languages: "sa_Sind"  # Sanskrit, Khudawadi
+languages: "sd_Sind"  # Sindhi, Khudawadi
 primary_script: "Sind"


### PR DESCRIPTION
We are deprecating the faux-Sanskrit language definitions beginning with `sa_...` and slowly replacing them with definitions using real language text instead. We recently got a definition for Sindhi in the Khudawadi Sindhi script (`sd_Sind`), so we want to stop using the old Sanskrit (`sa_Sind`). #6563 got this the wrong way around.