### PR TITLE
Update to_prod & to_sand lists for fri aug 11th

### DIFF
--- a/to_production.txt
+++ b/to_production.txt
@@ -1,12 +1,25 @@
 # New
-ofl/ruwudu # https://github.com/google/fonts/pull/6549
+ofl/adlamdisplay # https://github.com/google/fonts/pull/6522
 
 # Upgrade
 ofl/bricolagegrotesque # https://github.com/google/fonts/pull/6523
 ofl/notosans # https://github.com/google/fonts/pull/5789
-ofl/notosansimperialaramaic # https://github.com/google/fonts/pull/5284
-ofl/notosansmandaic # https://github.com/google/fonts/pull/5282
+ofl/notosanshk # https://github.com/google/fonts/pull/5531
+ofl/notosansindicsiyaqnumbers # https://github.com/google/fonts/pull/5285
+ofl/notosansinscriptionalpahlavi # https://github.com/google/fonts/pull/5286
+ofl/notosanskr # https://github.com/google/fonts/pull/5532
+ofl/notosansmayannumerals # https://github.com/google/fonts/pull/5288
+ofl/notosanssc # https://github.com/google/fonts/pull/5533
+ofl/notosanstakri # https://github.com/google/fonts/pull/6409
+ofl/notosanstc # https://github.com/google/fonts/pull/5534
+ofl/oswald # https://github.com/google/fonts/pull/6514
 ofl/robotoflex # https://github.com/google/fonts/pull/6484
+ofl/teko # https://github.com/google/fonts/pull/6560
+ofl/wavefont # https://github.com/google/fonts/pull/6572
+
+# Metadata / Description / License
+ofl/gulzar # https://github.com/google/fonts/pull/6562
+ofl/notoserifkhitansmallscript # https://github.com/google/fonts/pull/6586
 
 # Sample texts
 lang/languages/af_Latn.textproto # https://github.com/google/fonts/pull/6468

--- a/to_sandbox.txt
+++ b/to_sandbox.txt
@@ -1,26 +1,17 @@
-# New
-ofl/adlamdisplay # https://github.com/google/fonts/pull/6522
-
 # Upgrade
-ofl/notosansindicsiyaqnumbers # https://github.com/google/fonts/pull/5285
-ofl/notosansinscriptionalpahlavi # https://github.com/google/fonts/pull/5286
 ofl/notosanskhojki # https://github.com/google/fonts/pull/6427
 ofl/notosanslycian # https://github.com/google/fonts/pull/5287
-ofl/notosansmayannumerals # https://github.com/google/fonts/pull/5288
-ofl/notosanstakri # https://github.com/google/fonts/pull/6409
 ofl/notoserifkhojki # https://github.com/google/fonts/pull/6426
-ofl/oswald # https://github.com/google/fonts/pull/6514
-ofl/teko # https://github.com/google/fonts/pull/6560
-ofl/wavefont # https://github.com/google/fonts/pull/6572
+ofl/wixmadefordisplay # https://github.com/google/fonts/pull/6607
 
 # Other
 ofl/robotocondensed # https://github.com/google/fonts/pull/6570
+ofl/wixmadefortext # https://github.com/google/fonts/pull/6608
 
 # Axis Registry
 axisregistry/z_rotation.textproto # https://github.com/google/fonts/pull/6554
 
 # Metadata / Description / License
-ofl/gulzar # https://github.com/google/fonts/pull/6562
 ofl/mingzat # https://github.com/google/fonts/pull/6574
 ofl/notosansavestan # https://github.com/google/fonts/pull/6574
 ofl/notosansbatak # https://github.com/google/fonts/pull/6574
@@ -33,7 +24,6 @@ ofl/notosansmahajani # https://github.com/google/fonts/pull/6574
 ofl/notosansolchiki # https://github.com/google/fonts/pull/6574
 ofl/notosanssaurashtra # https://github.com/google/fonts/pull/6574
 ofl/notoserifdogra # https://github.com/google/fonts/pull/6576
-ofl/notoserifkhitansmallscript # https://github.com/google/fonts/pull/6586
 
 # Sample texts
 lang/languages/ae_Avst.textproto # https://github.com/google/fonts/pull/6573


### PR DESCRIPTION
This is an updated version of PR https://github.com/google/fonts/pull/6613

It adds the foolowing to `to_production`:
```
# Metadata / Description / License
ofl/gulzar # https://github.com/google/fonts/pull/6562
ofl/notoserifkhitansmallscript # https://github.com/google/fonts/pull/6586
```