### PR TITLE
Repush Noto Sans/Serif Ethiopic

### DIFF
--- a/to_production.txt
+++ b/to_production.txt
@@ -17,6 +17,10 @@ ofl/robotoflex # https://github.com/google/fonts/pull/6484
 ofl/teko # https://github.com/google/fonts/pull/6560
 ofl/wavefont # https://github.com/google/fonts/pull/6572
 
+# Other
+ofl/notosansethiopic
+ofl/notoserifethiopic
+
 # Metadata / Description / License
 ofl/gulzar # https://github.com/google/fonts/pull/6562
 ofl/notoserifkhitansmallscript # https://github.com/google/fonts/pull/6586

--- a/to_sandbox.txt
+++ b/to_sandbox.txt
@@ -7,6 +7,8 @@ ofl/wixmadefordisplay # https://github.com/google/fonts/pull/6607
 # Other
 ofl/robotocondensed # https://github.com/google/fonts/pull/6570
 ofl/wixmadefortext # https://github.com/google/fonts/pull/6608
+ofl/notosansethiopic
+ofl/notoserifethiopic
 
 # Axis Registry
 axisregistry/z_rotation.textproto # https://github.com/google/fonts/pull/6554


### PR DESCRIPTION
Noto Ethiopic supports Gurage codepoints (Unicode 14.0), and I added these to the glyphsets, but we haven't repushed these since the glyphset update so the Garage isn't available yet. This should, I think, make it available.