### PR TITLE
Update minisite URL in METADATA.pb for Wavefont

### DIFF
--- a/ofl/wavefont/METADATA.pb
+++ b/ofl/wavefont/METADATA.pb
@@ -51,6 +51,6 @@ sample_text {
   poster_md: "0123456789"
   poster_lg: "0123456789"
 }
-minisite_url: "https://dy.github.io/wavefont/out"
+minisite_url: "https://dy.github.io/wavefont/scripts/"
 classifications: "DISPLAY"
 classifications: "SYMBOLS"


### PR DESCRIPTION
The minisite URL that we have in production 404s.  This PR updates the URL to https://dy.github.io/wavefont/scripts/