### PR TITLE
Subtree pull Axis Registry introducing `ARRR`

### DIFF
--- a/axisregistry/Lib/axisregistry/data/ar_retinal_resolution.textproto
+++ b/axisregistry/Lib/axisregistry/data/ar_retinal_resolution.textproto
@@ -1,0 +1,15 @@
+tag: "ARRR"
+display_name: "AR Retinal Resolution"
+min_value: 10
+default_value: 10
+max_value: 60
+precision: 0
+fallback {
+  name: "Default"
+  value: 10
+}
+fallback_only: false
+description: 
+  " Resolution-specific enhancements in AR/VR typefaces to optimize"
+  " rendering across the different resolutions of the headsets"
+  " making designs accessible and easy to read."

--- a/axisregistry/requirements.txt
+++ b/axisregistry/requirements.txt
@@ -1,3 +1,3 @@
 --index-url https://pypi.python.org/simple/
-protobuf==3.19.4
+protobuf==3.20.3
 -e .

--- a/axisregistry/tests/test_wellformed.py
+++ b/axisregistry/tests/test_wellformed.py
@@ -1,0 +1,19 @@
+import pytest
+from axisregistry import AxisRegistry
+from axisregistry.axes_pb2 import AxisProto
+
+registry = AxisRegistry()
+
+OPTIONAL_FIELDS = ["illustration_url", "is_parametric"]
+
+
+@pytest.mark.parametrize("axis_tag", registry.keys())
+def test_proto_wellformed(axis_tag):
+    axis = registry[axis_tag]
+    raw_fields = dict([(k.name, v) for k, v in axis.ListFields()])
+    for field in AxisProto.DESCRIPTOR.fields:
+        field_name = field.name
+        if field_name in OPTIONAL_FIELDS:
+            continue
+        assert field_name in raw_fields, field_name
+        assert raw_fields[field_name] is not None, field_name


### PR DESCRIPTION
Includes 
- [x] `ARRR - AR Retinal Resolution` axis required by AR One Sans
- [x] Requirements.txt update

This PR should navigate through the pipeline simultaneously with #6662 