### PR TITLE
Add Slab Serif as a stroke category for Montagu Slab

### DIFF
--- a/ofl/montaguslab/METADATA.pb
+++ b/ofl/montaguslab/METADATA.pb
@@ -30,5 +30,5 @@ registry_default_overrides {
   key: "opsz"
   value: 144.0
 }
-stroke: "SERIF"
+stroke: "SLAB_SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
This came up in a Google Fonts related chat today, Montagu Slab is missing from the Slab Serif stroke category.

I updated the Category Confirmation Google sheet, so this PR both fixes the bug and keeps the sheet in sync.

@vv-monsalve and I will try to make an issue where we compile more issues like this, so updates can be made in batches.

Also, @evanwadams if we have lots of PRs like this it might be helpful to add a tool for doing this to gftools that can read from the Google Sheet or a CSV, and batch update all the changes. That way the sheet will not get out of sync with what is in GitHub.