### PR TITLE
Wavefont: removing latin subsets

### DIFF
--- a/ofl/wavefont/METADATA.pb
+++ b/ofl/wavefont/METADATA.pb
@@ -12,8 +12,6 @@ fonts {
   full_name: "Wavefont Thin"
   copyright: "Copyright 2022 The Wavefont Project Authors (https://github.com/dy/wavefont)"
 }
-subsets: "latin"
-subsets: "latin-ext"
 subsets: "menu"
 axes {
   tag: "ROND"


### PR DESCRIPTION
Because subsetting would be disabled for that font.