### PR TITLE
Remove mistaken field

### DIFF
--- a/ofl/notocoloremoji/METADATA.pb
+++ b/ofl/notocoloremoji/METADATA.pb
@@ -14,7 +14,6 @@ fonts {
 }
 subsets: "menu"
 subsets: "emoji"
-foundry: "GOOGLE"
 is_noto: true
 sample_text {
   masthead_full: "🎶🎷🐛"


### PR DESCRIPTION
Fixes inability to parse Noto Color Emoji's METADATA.pb noted  http://github.com/google/fonts/issues/6666