### PR TITLE
Subtree pull Axis Registry introducing `BLED`, `SCAN`, and `SHLN`

### DIFF
--- a/axisregistry/Lib/axisregistry/data/bleed.textproto
+++ b/axisregistry/Lib/axisregistry/data/bleed.textproto
@@ -1,0 +1,16 @@
+# BLED based on https://github.com/jenskutilek/homecomputer-fonts
+tag: "BLED"
+display_name: "Bleed"
+min_value: 0
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0.0
+}
+fallback_only: false
+description: 
+  "Bleed adjusts the overall darkness in the typographic color of strokes or other forms, without"
+  " any changes in overall width, line breaks, or page layout. Negative values make the font appearance"
+  " lighter, while positive values make it darker, similarly to ink bleed or dot gain on paper."

--- a/axisregistry/Lib/axisregistry/data/scanlines.textproto
+++ b/axisregistry/Lib/axisregistry/data/scanlines.textproto
@@ -1,0 +1,16 @@
+# SCAN based on https://github.com/jenskutilek/homecomputer-fonts
+tag: "SCAN"
+display_name: "Scanlines"
+min_value: -100
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description:
+  "Break up shapes into horizontal segments without any changes in overall width,"
+  " letter spacing, or kerning, so there are no line breaks or page layout changes."
+  " Negative values make the scanlines thinner, and positive values make them thicker."

--- a/axisregistry/Lib/axisregistry/data/shadow_length.textproto
+++ b/axisregistry/Lib/axisregistry/data/shadow_length.textproto
@@ -1,0 +1,15 @@
+# SHLN based on https://github.com/EkType/Honk
+tag: "SHLN"
+display_name: "Shadow Length"
+min_value: 0.0 
+default_value: 50.0 
+max_value: 100.0
+precision: -1
+fallback {
+  name: "Default"
+  value: 50.0
+}
+fallback_only: false
+description: 
+  "Adjusts the font's shadow length from no shadow visible (0 %)"
+  " to a maximum shadow applied (100%) relative to each family design."

--- a/axisregistry/Lib/axisregistry/data/sharpness.textproto
+++ b/axisregistry/Lib/axisregistry/data/sharpness.textproto
@@ -1,4 +1,4 @@
-#SHRP based on https://github.com/monokromskriftforlag/geologisk/
+#SHRP based on https://github.com/googlefonts/geologica
 tag: "SHRP"
 display_name: "Sharpness"
 min_value: 0


### PR DESCRIPTION
This PR includes

- [x] `BLED - Bleed` axis required by Syxtyfour and Worbench, Homecomputer fonts
- [x]  `SCAN - Scanlines`  axis required by Syxtyfour and Worbench, Homecomputer fonts
- [x] `SHLN - Shadow Lenght` required for Honk

Sixtyfour #6919 and Workbench #6917 fonts PRs are ready to be reviewed. So this PR can navigate through the pipeline simultaneously with those PR. 

Honk font will be added next week. The SHLN axis can be included by this PR