### PR TITLE
Emoji subset added to PPS metadata

### DIFF
--- a/ofl/playpensans/METADATA.pb
+++ b/ofl/playpensans/METADATA.pb
@@ -12,11 +12,11 @@ fonts {
   full_name: "Playpen Sans Regular"
   copyright: "Copyright 2023 The Playpen Sans Project Authors (https://github.com/TypeTogether/Playpen-Sans)"
 }
+subsets: "emoji"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "math"
 subsets: "menu"
-subsets: "symbols"
 subsets: "vietnamese"
 axes {
   tag: "wght"


### PR DESCRIPTION
Changing subset `symbols` to `emoji` to #7006.

@RosaWagner The PR updating the font was merged this morning. In cases like these small quick fixes, should we add the `METADATA` label to this PR in any case?

Edit: Not adding labels to only track the changes through the font's PR linked above.