### PR TITLE
CI: unpin browser-actions

### DIFF
--- a/.github/workflows/font_tags.yaml
+++ b/.github/workflows/font_tags.yaml
@@ -4,10 +4,10 @@ name: Font tagging structure
 on:
   push:
     paths:
-    - 'tags/*/*'
+    - 'tags/all/families.csv'
   pull_request:
     paths:
-    - 'tags/*/*'
+    - 'tags/all/families.csv'
 
 jobs:
   test_server_files:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,10 +32,6 @@ jobs:
         uses: browser-actions/setup-chrome@latest
       - name: Setup Chrome Driver
         uses: nanasess/setup-chromedriver@master
-        with:
-          # TODO: Unpin when nanasess/setup-chromedriver#190 is fixed:
-          #       https://github.com/nanasess/setup-chromedriver/issues/190
-          chromedriver-version: 114.0.5735.90
 
       - name: Setup Firefox
         uses: m4rc1e/setup-firefox@master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,11 +34,9 @@ jobs:
         uses: nanasess/setup-chromedriver@master
 
       - name: Setup Firefox
-        uses: m4rc1e/setup-firefox@master
-        with:
-          firefox-version: '84.0'
+        uses: browser-actions/setup-firefox@latest
       - name: Setup Firefox Driver
-        uses: m4rc1e/setup-geckodriver@master
+        uses: browser-actions/setup-geckodriver@latest
 
       - name: Run Diffbrowsers
         run: |


### PR DESCRIPTION
@RosaWagner reported that many of the diff images are not generating anymore, https://github.com/googlefonts/diffenator2/issues/120. This PR unpins the drivers and drops my forks in favour of the offical releases since they're now fixed.