### PR TITLE
Allow per-directory overrides

### DIFF
--- a/.ci/run.py
+++ b/.ci/run.py
@@ -100,6 +100,12 @@ def main():
 
     for directory, check_type in directory_check_types(args.branch):
         out = os.path.join("out", os.path.basename(directory))
+        fontbakery = ["--fontbakery"]
+        fbconfig = os.path.join(directory, "fontbakery.yml")
+        if os.path.exists(fbconfig):
+            fontbakery += ["--extra-fontbakery-args=--configuration",
+                           f"--extra-fontbakery-args={fbconfig}"]
+
         fonts = glob(os.path.join(directory, "*.ttf"))
 
         qa_cmd_prefix = ["gftools", "qa", "-f"] + fonts + ["-o", out]
@@ -123,15 +129,15 @@ def main():
 
         elif check_type == CheckType.NEW_FAMILY:
             print(f"Checking new family: {directory}")
-            subprocess.run(qa_cmd_prefix + ["--fontbakery", "--interpolations"])
+            subprocess.run(qa_cmd_prefix + fontbakery + ["--interpolations"])
 
         elif check_type == CheckType.MODIFIED_FAMILY:
             print(f"Checking modified family: {directory}")
-            subprocess.run(qa_cmd_prefix + ["-gfb", "--fontbakery", "--diffenator", "--interpolations"])
+            subprocess.run(qa_cmd_prefix + ["-gfb"] + fontbakery + ["--diffenator", "--interpolations"])
 
         elif check_type == CheckType.MODIFIED_FAMILY_METADATA:
             print(f"Checking modified family metadata: {directory}")
-            subprocess.run(qa_cmd_prefix + ["--fontbakery", "-o", out])
+            subprocess.run(qa_cmd_prefix + fontbakery + ["-o", out])
 
         elif check_type == CheckType.DESIGNER:
             print(f"Checking designer profile: {directory}")

--- a/ofl/pushster/METADATA.pb
+++ b/ofl/pushster/METADATA.pb
@@ -10,7 +10,7 @@ fonts {
   filename: "Pushster-Regular.ttf"
   post_script_name: "Pushster-Regular"
   full_name: "Pushster Regular"
-  copyright: "Copyright 2010 xyz The Lobster Project Authors (https://github.com/impallari/The-Lobster-Font), with Reserved Font Name \"Lobster\".4"
+  copyright: "Copyright 2010 xyz The Lobster Project Authors (https://github.com/impallari/The-Lobster-Font), with Reserved Font Name \"Lobster\".5"
 }
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/pushster/fontbakery.yml
+++ b/ofl/pushster/fontbakery.yml
@@ -1,0 +1,7 @@
+exclude_checks:
+    - com.google.fonts/check/soft_dotted
+    - com.google.fonts/check/glyphsets/shape_languages
+
+overrides:
+    com.google.fonts/check/outline_jaggy_segments:
+        found-jaggy-segments: INFO


### PR DESCRIPTION
This allows (and demonstrates) how to set per-directory overrides on fontbakery checks. It must be merged after https://github.com/googlefonts/gftools/pull/812 (and a new gftools release).

A file called `fontbakery.yml` in a font directory will be passed to fontbakery, and this can be used either to exclude specific checks or to modify the check status codes.