### PR TITLE
GB S metadata display name added

### DIFF
--- a/ofl/playwritegbs/METADATA.pb
+++ b/ofl/playwritegbs/METADATA.pb
@@ -36,3 +36,4 @@ source {
   repository_url: "https://github.com/TypeTogether/Playwrite/"
   commit: "7f0e083357d763db855e665a5d4e58c002b61943"
 }
+display_name: "Playwrite England Semijoin"


### PR DESCRIPTION
This PR adds the `display_name` field to the metadata of Playwrite GB S font added on #7194.
That PR, which includes the full ofl directory, will track this change through the pipeline.