### PR TITLE
Update ofl/climatecrisis/METADATA.pb minisite URL bugs

### DIFF
--- a/ofl/climatecrisis/METADATA.pb
+++ b/ofl/climatecrisis/METADATA.pb
@@ -28,7 +28,6 @@ source {
   repository_url: "https://github.com/dancoull/ClimateCrisis"
   commit: "e0398e2d7e84a9f08cf7ec67bb463e4e2bb35431"
 }
-minisite_url: "https://kampanjat.hs.fi/climatefont/index.html"
+minisite_url: "https://kampanjat.hs.fi/climatefont"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"
-minisite_url: "https://kampanjat.hs.fi/climatefont/"


### PR DESCRIPTION
* Don't include a trailing slash
* Don't include a trailing index.htm[l]
* Don't include more than one `minisite_url`