### PR TITLE
Revert temporarily pin of glyphsets version in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
         # and benefit from its newest checks:
         run: |
           pip install --upgrade pip
-          pip install --pre fontbakery[googlefonts] glyphsets==0.6.11
+          pip install --pre fontbakery[googlefonts]
           pip install gftools[qa] pytest
         shell: bash
 


### PR DESCRIPTION
Note: https://pypi.org/project/fontbakery/0.12.0a1/

(issue #7276)