### PR TITLE
knowledge_graph.py: check outbound links

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,4 +38,4 @@ jobs:
     - name: Install dependencies
       run: pip install absl-py mistune gftools
     - name: Check Knowledge graph
-      run: python3 .github/workflows/knowledge_graph.py
+      run: python3 .github/workflows/knowledge_graph.py --check_outbound_links

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,16 @@ on:
   push:
     branches: [main]
     tags: ["v*.*.*"]
+    paths:
+    - "cc-by-sa/*"
+    - "to_*.txt"
+    - ".github/workflows/ci.yaml"
   pull_request:
     branches: ['**']
+    paths:
+    - "cc-by-sa/*"
+    - "to_*.txt"
+    - ".github/workflows/ci.yaml"
 
 jobs:
   test_server_files:

--- a/.github/workflows/knowledge_graph.py
+++ b/.github/workflows/knowledge_graph.py
@@ -68,6 +68,7 @@ FLAGS = flags.FLAGS
 
 
 flags.DEFINE_bool("print_valid", False, "Whether to print valid links")
+flags.DEFINE_bool("check_outbound_links", False, "Check outbound urls")
 
 
 MdValue = Union[Mapping[str, "MdValue"]]
@@ -222,7 +223,8 @@ def _check_md_files(knowledge: KnowledgeContent) -> bool:
             if not target:
                 continue  # TODO: are empty links bad
             if re.search("^http(s)?://", target.lower()):
-                result = _check_outbound_link(target) and result
+                if FLAGS.check_outbound_links:
+                    result = _check_outbound_link(target) and result
             else:
                 target_path = knowledge.link_target_to_path(target)
                 result = _check_file_present(knowledge.repo_root, md_file, target, target_path) and result

--- a/.github/workflows/knowledge_graph.py
+++ b/.github/workflows/knowledge_graph.py
@@ -190,21 +190,51 @@ def _check_md_file_contents(repo_root: Path, md_file: Path, ast: List[MdValue]) 
 
 @lru_cache()
 def _check_outbound_link(url: str):
-    # Following urls work correctly on a web browser but 404 when using python requests
-    whitelist = frozenset(["https://www.jessicahische.is/talkingtype"])
+    # Following urls work correctly on a web browser but raise a 400 code when using python requests
+    whitelist = frozenset([
+        "https://www.jessicahische.is/talkingtype",
+        "http://www.layoutgridcalculator.com/typographic-scale/",
+        "https://www.figma.com/community/plugin/1088610476491668236/Material-Symbols",
+        "https://www.researchgate.net/publication/274013793_Legibility_in_Industrial_AR_Text_Style_Color_Coding_and_Illuminance",
+        "https://www.researchgate.net/figure/Biblia-latina-The-42-Line-Bible-Mainz-Johannes-Gutenberg-for-Johann-Fust-ca_fig3_317915502",
+        "https://www.nytimes.com/2003/10/21/business/the-media-business-a-face-lift-for-the-times-typographically-that-is.html",
+        "https://www.circuitousroot.com/artifice/letters/pantocut/benton/vertical/index.html",
+        "https://www.circuitousroot.com/artifice/letters/press/typemaking/after-casting/mortising/rouse/inst-and-print/index.html",
+        "https://www.paulshawletterdesign.com/2011/11/tutorial-no-6%E2%80%94tight-but-not-touching-kerning/",
+        "https://codepen.io/mandymichael/pen/pxXNbr",
+        "https://typetura.com",
+        "https://gigapress.net/reduce-http-requests/",
+        "https://help.figma.com/hc/en-us/articles/5579502031511-Use-variable-fonts#Replace_static_fonts",
+        "https://twitter.com/romanshamin_en/status/1562801657691672576",
+        "https://www.sciencedirect.com/science/article/pii/S0042698907005561",
+        "https://doi.org/10.1002/rrq.411",
+        "https://www.webmd.com/healthy-aging/news/20140318/color-vision-tends-to-fade-with-age-study#1",
+        "https://support.google.com/accessibility/android/answer/12159181?hl=en",
+        "http://www.languagegeek.com/typography/syllabics/syllabic_variation.pdf",
+        "https://www.freepik.com/free-photos-vectors/travel",
+        "https://psycnet.apa.org/record/2018-13691-001",
+        "https://www.cortezlawfirmpllc.com/wp-content/uploads/sites/1600711/2020/05/glare_congressional_report.pdf",
+        "http://kupferschrift.de/cms/2012/03/on-classifications/",
+        "https://medium.engineering/typography-is-impossible-5872b0c7f891",
+        "https://medium.com/microsoft-design/leading-trim-the-future-of-digital-typesetting-d082d84b202",
+        "https://medium.com/eightshapes-llc/space-in-design-systems-188bcbae0d62#:~:text=Solve%20Collisions%20like%20Line%20Height%20Systematically",
+        "https://nedwin.medium.com/the-1-5m-napkin-abd2702927d0",
+        "https://www.colourblindawareness.org/colour-blindness/types-of-colour-blindness/",
+        "https://medium.com/the-readability-group/whats-in-a-word-53bcf217d5c1",
+        "https://medium.com/the-readability-group/a-guide-to-understanding-what-makes-a-typeface-accessible-and-how-to-make-informed-decisions-9e5c0b9040a0",
+        "https://medium.com/@mcpflug/whats-in-a-name-the-perception-of-pro-7fffa6cddcb8",
+        "https://medium.com/@tilougarou/the-typographic-scale-reworked-a1b441b2beb2",
+    ])
     # Following urls will be fixed at a later date. If the CI is failing and a suitable
     # replacement url cannot be found, please add them to this set.
     to_fix = frozenset()
     if url in whitelist | to_fix:
         return True
 
-    response = requests.get(url, allow_redirects=True)
-    if response.status_code == 404:
-        print(f"INVALID url '{url}' returned response status code '{response.status_code}'")
-        return False
-    elif response.status_code == 495:
-        print(f"INVALID SSL '{url}'")
-    return True
+    response = requests.head(url, allow_redirects=True)
+    if not response.ok:
+        print(f"INVALID url {url}' returned response status code '{response.status_code}'")
+    return response.ok
 
 
 def _check_md_files(knowledge: KnowledgeContent) -> bool:

--- a/.github/workflows/knowledge_graph.py
+++ b/.github/workflows/knowledge_graph.py
@@ -192,18 +192,18 @@ def _check_md_file_contents(repo_root: Path, md_file: Path, ast: List[MdValue]) 
 def _check_outbound_link(url: str):
     # Following urls work correctly on a web browser but 404 when using python requests
     whitelist = frozenset(["https://www.jessicahische.is/talkingtype"])
-    if url in whitelist:
+    # Following urls will be fixed at a later date. If the CI is failing and a suitable
+    # replacement url cannot be found, please add them to this set.
+    to_fix = frozenset()
+    if url in whitelist | to_fix:
         return True
 
-    try:
-        url_status_code = requests.get(url).status_code
-    except requests.exceptions.SSLError:
-        print(f"INVALID SSL '{url}'")
-        # The url does exist but the cert is expired. I'm going to claim this is ok.
-        return True
-    if url_status_code == 404:
-        print(f"INVALID url '{url}' returned response status code '{url_status_code}'")
+    response = requests.get(url, allow_redirects=True)
+    if response.status_code == 404:
+        print(f"INVALID url '{url}' returned response status code '{response.status_code}'")
         return False
+    elif response.status_code == 495:
+        print(f"INVALID SSL '{url}'")
     return True
 
 


### PR DESCRIPTION
Some caveats I need to mention:

- I'm only checking for 404 response codes. Many servers will send 403s, 406s etc when using Python requests but are ok when using a webbrowser. If we want to check all 400 codes, I'll need to add more urls to the whitelist.
- We're checking ~500 urls so running the knowledge graph now takes 2 minutes. It used to take < 1 sec. If we want a speed up, we can async the code. Personally, 2 minutes seems fine since we rarely update knowledge items.
- Since it's slow, it's off by default. Include cli arg `--check_outbound_links` in order for it to run.
- SSL warnings do not fail the CI since these pages do exist.

Fixes https://github.com/google/fonts/issues/7277