### PR TITLE
RocknRoll One metadata

### DIFF
--- a/ofl/rocknrollone/METADATA.pb
+++ b/ofl/rocknrollone/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "RocknRoll One Regular"
   copyright: "Copyright 2020 The RocknRoll Project Authors (https://github.com/fontworks-fonts/RocknRoll)"
 }
-subsets: "cyrillic"
 subsets: "japanese"
 subsets: "latin"
 subsets: "latin-ext"


### PR DESCRIPTION
removed cyrillic: see https://github.com/google/fonts/issues/7156
@vv-monsalve 
Closes #7156