### PR TITLE
Fix duplicate tags for Sedan, Sedan SC.

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -6589,11 +6589,13 @@ Sedan,/Expressive/Calm,96
 Sedan,/Expressive/Sincere,92
 Sedan,/Expressive/Vintage,77
 Sedan,/Serif/Humanist Venetian,100
+Sedan,/Serif/Old Style Garalde,90
 Sedan SC,/Expressive/Business,50
 Sedan SC,/Expressive/Calm,96
 Sedan SC,/Expressive/Sincere,94
 Sedan SC,/Expressive/Vintage,75
 Sedan SC,/Serif/Humanist Venetian,100
+Sedan SC,/Serif/Old Style Garalde,90
 Sedgwick Ave,/Expressive/Active,66
 Sedgwick Ave,/Expressive/Artistic,12
 Sedgwick Ave,/Expressive/Awkward,32
@@ -8631,10 +8633,6 @@ Micro 5 Charted,/Expressive/Stiff,70
 Micro 5 Charted,/Sans/Geometric,70
 Micro 5 Charted,/Theme/Pixel,100
 Micro 5 Charted,/Theme/Techno,50
-Sedan,/Expressive/Sincere,80
-Sedan,/Serif/Old Style Garalde,90
-Sedan SC,/Expressive/Sincere,80
-Sedan SC,/Serif/Old Style Garalde,90
 Teachers,/Expressive/Artistic,5
 Teachers,/Expressive/Business,30
 Teachers,/Expressive/Calm,95


### PR DESCRIPTION
Note: there was two different values for /Expressive/Sincere I choose to retain the first occuring one.