### PR TITLE
ofl/robotoflex/article updated with youtube embed

### DIFF
--- a/ofl/robotoflex/article/ARTICLE.en_us.html
+++ b/ofl/robotoflex/article/ARTICLE.en_us.html
@@ -1,5 +1,6 @@
-<a href="https://youtu.be/f3IQSmKFokU"><img src="hero.png" /></a>
-<p><em><a href="https://youtu.be/f3IQSmKFokU">Watch the introduction video on YouTube</a></em</p>
+
+https://www.youtube.com/embed/f3IQSmKFokU
+
 <p>
   There’s no perfect typeface that works for every size, every device, every application, every style, and every mood.
   But as the default for Android, with over 2.5 billion active users spanning over 190 countries, and as Google Fonts’ most popular download, <a href="https://fonts.google.com/specimen/Roboto">Roboto</a> needs to be as flexible as possible.


### PR DESCRIPTION
Per internal discussion, perhaps we can embed youtube videos on specimen pages properly rather than the current workaround :)