### PR TITLE
Don't use Sanskrit language for Sundanese

### DIFF
--- a/ofl/notosanssundanese/METADATA.pb
+++ b/ofl/notosanssundanese/METADATA.pb
@@ -43,6 +43,5 @@ source {
   branch: "main"
 }
 is_noto: true
-languages: "sa_Sund"  # Sanskrit, Sundanese
 languages: "su_Sund"  # Sundanese, Sundanese
 primary_script: "Sund"


### PR DESCRIPTION
Fixes #7507. I'll also separately delete the `sa_Sund` "language" from the lang repo. Will need a repush to update the font's display on the servers.