### PR TITLE
Tac One Article: update <img> to <video> for mp4 formats

### DIFF
--- a/ofl/tacone/article/ARTICLE.en_us.html
+++ b/ofl/tacone/article/ARTICLE.en_us.html
@@ -3,11 +3,11 @@
 <p>To contribute, see <a href="https://github.com/Afrotype/tac">github.com/Afrotype/tac</a>.</p>
 
 <hr>
-<img src="1.mp4">
+<video src="1.mp4">
 <img src="2.1.jpg">
-<img src="2.2.mp4">
-<img src="2.3.mp4">
-<img src="3.1.mp4">
+<video src="2.2.mp4">
+<video src="2.3.mp4">
+<video src="3.1.mp4">
 <img src="2.4.jpg">
 <img src="3.2.jpg">
 <img src="3.3.jpg">

--- a/ofl/tacone/article/ARTICLE.en_us.html
+++ b/ofl/tacone/article/ARTICLE.en_us.html
@@ -3,11 +3,19 @@
 <p>To contribute, see <a href="https://github.com/Afrotype/tac">github.com/Afrotype/tac</a>.</p>
 
 <hr>
-<video src="1.mp4">
+<video autoplay muted>
+    <source src="1.mp4" type="video/mp4">
+  </video>
 <img src="2.1.jpg">
-<video src="2.2.mp4">
-<video src="2.3.mp4">
-<video src="3.1.mp4">
+<video autoplay muted>
+    <source src="2.2.mp4" type="video/mp4">
+  </video>
+  <video autoplay muted>
+    <source src="2.3.mp4" type="video/mp4">
+  </video>
+  <video autoplay muted>
+    <source src="3.1.mp4" type="video/mp4">
+  </video>
 <img src="2.4.jpg">
 <img src="3.2.jpg">
 <img src="3.3.jpg">


### PR DESCRIPTION
Fix that bug:

<img width="1142" alt="Screenshot 2024-04-17 at 12 10 57" src="https://github.com/google/fonts/assets/64773544/cea69e61-b33d-4af7-8be8-538c4e78dbc9">


@simoncozens 
not sure if I have to add all of this?

```
<video width="320" height="240" controls>
  <source src="movie.mp4" type="video/mp4">
  <source src="movie.ogg" type="video/ogg">
Your browser does not support the video tag.
</video>
```