### PR TITLE
Convert Cactus, Chocolate, and LXGW Henkai families CJK subset policy to chinese-hongkong

### DIFF
--- a/ofl/cactusclassicalserif/METADATA.pb
+++ b/ofl/cactusclassicalserif/METADATA.pb
@@ -12,7 +12,7 @@ fonts {
   full_name: "Cactus Classical Serif Regular"
   copyright: "Copyright 2024 The Cactus Classical Serif Project Authors (https://github.com/MoonlitOwen/CactusSerif)"
 }
-subsets: "chinese-traditional"
+subsets: "chinese-hongkong"
 subsets: "cyrillic"
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/chocolateclassicalsans/METADATA.pb
+++ b/ofl/chocolateclassicalsans/METADATA.pb
@@ -12,7 +12,7 @@ fonts {
   full_name: "Chocolate Classical Sans Regular"
   copyright: "Copyright 2024 The Chocolate Classical Sans Project Authors (https://github.com/MoonlitOwen/ChocolateSans)"
 }
-subsets: "chinese-traditional"
+subsets: "chinese-hongkong"
 subsets: "cyrillic"
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/lxgwwenkaimonotc/METADATA.pb
+++ b/ofl/lxgwwenkaimonotc/METADATA.pb
@@ -30,7 +30,7 @@ fonts {
   full_name: "LXGW WenKai Mono TC Bold"
   copyright: "Copyright 2024 The LXGW WenKai Project Authors (https://github.com/lxgw/LxgwWenkaiTC)"
 }
-subsets: "chinese-traditional"
+subsets: "chinese-hongkong"
 subsets: "cyrillic"
 subsets: "cyrillic-ext"
 subsets: "greek"

--- a/ofl/lxgwwenkaitc/METADATA.pb
+++ b/ofl/lxgwwenkaitc/METADATA.pb
@@ -30,7 +30,7 @@ fonts {
   full_name: "LXGW WenKai TC Bold"
   copyright: "Copyright 2024 The LXGW WenKai Project Authors (https://github.com/lxgw/LxgwWenkaiTC)"
 }
-subsets: "chinese-traditional"
+subsets: "chinese-hongkong"
 subsets: "cyrillic"
 subsets: "cyrillic-ext"
 subsets: "greek"


### PR DESCRIPTION
Adjusts the approach that we pushed in https://github.com/google/fonts/pull/7746 to use the `chinese-hongkong` subset following a review of the contents of these files.