### PR TITLE
Playwrite: `primary_language` added

### DIFF
--- a/ofl/playwritear/METADATA.pb
+++ b/ofl/playwritear/METADATA.pb
@@ -53,3 +53,4 @@ source {
 }
 display_name: "Playwrite Argentina"
 minisite_url: "https://primarium.info/countries/argentina"
+primary_language: "es_Latn"

--- a/ofl/playwriteat/METADATA.pb
+++ b/ofl/playwriteat/METADATA.pb
@@ -70,3 +70,4 @@ source {
 }
 display_name: "Playwrite Österreich"
 minisite_url: "https://primarium.info/countries/austria"
+primary_language: "de_Latn"

--- a/ofl/playwriteaunsw/METADATA.pb
+++ b/ofl/playwriteaunsw/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Australia NSW"
 minisite_url: "https://primarium.info/countries/australia"
+primary_language: "en_Latn"

--- a/ofl/playwriteauqld/METADATA.pb
+++ b/ofl/playwriteauqld/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Australia QLD"
 minisite_url: "https://primarium.info/countries/australia"
+primary_language: "en_Latn"

--- a/ofl/playwriteausa/METADATA.pb
+++ b/ofl/playwriteausa/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Australia SA"
 minisite_url: "https://primarium.info/countries/australia"
+primary_language: "en_Latn"

--- a/ofl/playwriteautas/METADATA.pb
+++ b/ofl/playwriteautas/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Australia Tasmania"
 minisite_url: "https://primarium.info/countries/australia"
+primary_language: "en_Latn"

--- a/ofl/playwriteauvic/METADATA.pb
+++ b/ofl/playwriteauvic/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Australia Victoria"
 minisite_url: "https://primarium.info/countries/australia"
+primary_language: "en_Latn"

--- a/ofl/playwritebevlg/METADATA.pb
+++ b/ofl/playwritebevlg/METADATA.pb
@@ -53,3 +53,4 @@ source {
 }
 display_name: "Playwrite België Vlaams Gewest"
 minisite_url: "https://primarium.info/countries/belgium"
+primary_language: "nl_Latn"

--- a/ofl/playwritebewal/METADATA.pb
+++ b/ofl/playwritebewal/METADATA.pb
@@ -53,3 +53,4 @@ source {
 }
 display_name: "Playwrite België Walloon"
 minisite_url: "https://primarium.info/countries/belgium"
+primary_language: "fr_Latn"

--- a/ofl/playwritebr/METADATA.pb
+++ b/ofl/playwritebr/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Brasil"
 minisite_url: "https://primarium.info/countries/brazil"
+primary_language: "pt_Latn"

--- a/ofl/playwriteca/METADATA.pb
+++ b/ofl/playwriteca/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Canada"
 minisite_url: "https://primarium.info/countries/canada"
+primary_language: "en_Latn"

--- a/ofl/playwritecl/METADATA.pb
+++ b/ofl/playwritecl/METADATA.pb
@@ -53,3 +53,4 @@ source {
 }
 display_name: "Playwrite Chile"
 minisite_url: "https://primarium.info/countries/chile"
+primary_language: "es_Latn"

--- a/ofl/playwriteco/METADATA.pb
+++ b/ofl/playwriteco/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Colombia"
 minisite_url: "https://primarium.info/countries/colombia"
+primary_language: "es_Latn"

--- a/ofl/playwritecu/METADATA.pb
+++ b/ofl/playwritecu/METADATA.pb
@@ -53,3 +53,4 @@ source {
 }
 display_name: "Playwrite Cuba"
 minisite_url: "https://primarium.info/countries/cuba"
+primary_language: "es_Latn"

--- a/ofl/playwritecz/METADATA.pb
+++ b/ofl/playwritecz/METADATA.pb
@@ -53,3 +53,4 @@ source {
 }
 display_name: "Playwrite Česko"
 minisite_url: "https://primarium.info/countries/czech-republic"
+primary_language: "cs_Latn"

--- a/ofl/playwritedegrund/METADATA.pb
+++ b/ofl/playwritedegrund/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Deutschland Grundschrift"
 minisite_url: "https://primarium.info/countries/germany"
+primary_language: "de_Latn"

--- a/ofl/playwritedela/METADATA.pb
+++ b/ofl/playwritedela/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Deutschland Lateinische Ausgangsschrift"
 minisite_url: "https://primarium.info/countries/germany"
+primary_language: "de_Latn"

--- a/ofl/playwritedesas/METADATA.pb
+++ b/ofl/playwritedesas/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Deutschland Schulausgangschrift"
 minisite_url: "https://primarium.info/countries/germany"
+primary_language: "de_Latn"

--- a/ofl/playwritedeva/METADATA.pb
+++ b/ofl/playwritedeva/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Deutschland Vereinfachte Ausgangsschrift"
 minisite_url: "https://primarium.info/countries/germany"
+primary_language: "de_Latn"

--- a/ofl/playwritedkloopet/METADATA.pb
+++ b/ofl/playwritedkloopet/METADATA.pb
@@ -53,3 +53,4 @@ source {
 }
 display_name: "Playwrite Danmark Loopet"
 minisite_url: "https://primarium.info/countries/denmark"
+primary_language: "da_Latn"

--- a/ofl/playwritedkuloopet/METADATA.pb
+++ b/ofl/playwritedkuloopet/METADATA.pb
@@ -53,3 +53,4 @@ source {
 }
 display_name: "Playwrite Danmark Uloopet"
 minisite_url: "https://primarium.info/countries/denmark"
+primary_language: "da_Latn"

--- a/ofl/playwritees/METADATA.pb
+++ b/ofl/playwritees/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite España"
 minisite_url: "https://primarium.info/countries/spain"
+primary_language: "es_Latn"

--- a/ofl/playwriteesdeco/METADATA.pb
+++ b/ofl/playwriteesdeco/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite España Decorativa"
 minisite_url: "https://primarium.info/countries/spain"
+primary_language: "es_Latn"

--- a/ofl/playwritefrmoderne/METADATA.pb
+++ b/ofl/playwritefrmoderne/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite France Moderne"
 minisite_url: "https://primarium.info/countries/france"
+primary_language: "fr_Latn"

--- a/ofl/playwritefrtrad/METADATA.pb
+++ b/ofl/playwritefrtrad/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite France Traditionnelle"
 minisite_url: "https://primarium.info/countries/france"
+primary_language: "fr_Latn"

--- a/ofl/playwritegbj/METADATA.pb
+++ b/ofl/playwritegbj/METADATA.pb
@@ -66,3 +66,4 @@ source {
 }
 display_name: "Playwrite England Joined"
 minisite_url: "https://primarium.info/countries/england"
+primary_language: "en_Latn"

--- a/ofl/playwritegbs/METADATA.pb
+++ b/ofl/playwritegbs/METADATA.pb
@@ -66,3 +66,4 @@ source {
 }
 display_name: "Playwrite England SemiJoined"
 minisite_url: "https://primarium.info/countries/england"
+primary_language: "en_Latn"

--- a/ofl/playwritehr/METADATA.pb
+++ b/ofl/playwritehr/METADATA.pb
@@ -53,3 +53,4 @@ source {
 }
 display_name: "Playwrite Hrvatska"
 minisite_url: "https://primarium.info/countries/croatia"
+primary_language: "hr_Latn"

--- a/ofl/playwritehrlijeva/METADATA.pb
+++ b/ofl/playwritehrlijeva/METADATA.pb
@@ -53,3 +53,4 @@ source {
 }
 display_name: "Playwrite Hrvatska Lijeva"
 minisite_url: "https://primarium.info/countries/croatia"
+primary_language: "hr_Latn"

--- a/ofl/playwritehu/METADATA.pb
+++ b/ofl/playwritehu/METADATA.pb
@@ -53,3 +53,4 @@ source {
 }
 display_name: "Playwrite Magyarország"
 minisite_url: "https://primarium.info/countries/hungary"
+primary_language: "hu_Latn"

--- a/ofl/playwriteid/METADATA.pb
+++ b/ofl/playwriteid/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Indonesia"
 minisite_url: "https://primarium.info/countries/indonesia"
+primary_language: "id_Latn"

--- a/ofl/playwriteie/METADATA.pb
+++ b/ofl/playwriteie/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Ireland"
 minisite_url: "https://primarium.info/countries/ireland"
+primary_language: "en_Latn"

--- a/ofl/playwritein/METADATA.pb
+++ b/ofl/playwritein/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite India"
 minisite_url: "https://primarium.info/countries/india"
+primary_language: "en_Latn"

--- a/ofl/playwriteis/METADATA.pb
+++ b/ofl/playwriteis/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Ísland"
 minisite_url: "https://primarium.info/countries/iceland"
+primary_language: "is_Latn"

--- a/ofl/playwriteitmoderna/METADATA.pb
+++ b/ofl/playwriteitmoderna/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Italia Moderna"
 minisite_url: "https://primarium.info/countries/italy"
+primary_language: "it_Latn"

--- a/ofl/playwriteittrad/METADATA.pb
+++ b/ofl/playwriteittrad/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Italia Tradizionale"
 minisite_url: "https://primarium.info/countries/italy"
+primary_language: "it_Latn"

--- a/ofl/playwritemx/METADATA.pb
+++ b/ofl/playwritemx/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite México"
 minisite_url: "https://primarium.info/countries/mexico"
+primary_language: "es_Latn"

--- a/ofl/playwritengmodern/METADATA.pb
+++ b/ofl/playwritengmodern/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Nigeria Modern"
 minisite_url: "https://primarium.info/countries/nigeria"
+primary_language: "en_Latn"

--- a/ofl/playwritenl/METADATA.pb
+++ b/ofl/playwritenl/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Netherland"
 minisite_url: "https://primarium.info/countries/the-netherlands"
+primary_language: "nl_Latn"

--- a/ofl/playwriteno/METADATA.pb
+++ b/ofl/playwriteno/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Norge"
 minisite_url: "https://primarium.info/countries/norway"
+primary_language: "nb_Latn"

--- a/ofl/playwritenz/METADATA.pb
+++ b/ofl/playwritenz/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite New Zealand"
 minisite_url: "https://primarium.info/countries/new-zealand"
+primary_language: "en_Latn"

--- a/ofl/playwritepe/METADATA.pb
+++ b/ofl/playwritepe/METADATA.pb
@@ -53,3 +53,4 @@ source {
 }
 display_name: "Playwrite Perú"
 minisite_url: "https://primarium.info/countries/peru"
+primary_language: "es_Latn"

--- a/ofl/playwritepl/METADATA.pb
+++ b/ofl/playwritepl/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Polska"
 minisite_url: "https://primarium.info/countries/poland"
+primary_language: "pl_Latn"

--- a/ofl/playwritept/METADATA.pb
+++ b/ofl/playwritept/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Portugal"
 minisite_url: "https://primarium.info/countries/portugal"
+primary_language: "pt_Latn"

--- a/ofl/playwritero/METADATA.pb
+++ b/ofl/playwritero/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite România"
 minisite_url: "https://primarium.info/countries/romania"
+primary_language: "ro_Latn"

--- a/ofl/playwritesk/METADATA.pb
+++ b/ofl/playwritesk/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Slovensko"
 minisite_url: "https://primarium.info/countries/slovakia"
+primary_language: "sk_Latn"

--- a/ofl/playwritetz/METADATA.pb
+++ b/ofl/playwritetz/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Tanzania"
 minisite_url: "https://primarium.info/countries/tanzania"
+primary_language: "en_Latn"

--- a/ofl/playwriteusmodern/METADATA.pb
+++ b/ofl/playwriteusmodern/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite USA Modern"
 minisite_url: "https://primarium.info/countries/united-states-of-america"
+primary_language: "en_Latn"

--- a/ofl/playwriteustrad/METADATA.pb
+++ b/ofl/playwriteustrad/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite USA Traditional"
 minisite_url: "https://primarium.info/countries/united-states-of-america"
+primary_language: "en_Latn"

--- a/ofl/playwritevn/METADATA.pb
+++ b/ofl/playwritevn/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite Việt Nam"
 minisite_url: "https://primarium.info/countries/vietnam"
+primary_language: "vi_Latn"

--- a/ofl/playwriteza/METADATA.pb
+++ b/ofl/playwriteza/METADATA.pb
@@ -49,3 +49,4 @@ source {
 }
 display_name: "Playwrite South Africa"
 minisite_url: "https://primarium.info/countries/south-africa"
+primary_language: "en_Latn"


### PR DESCRIPTION
This PR adds the `primary_language` metadata field to the Playwrite fonts.