### PR TITLE
Update content.md with additional preconnect to `https://fonts.googleapis.com`

### DIFF
--- a/cc-by-sa/knowledge/modules/using_type/lessons/using_web_fonts_from_a_font_delivery_service/content.md
+++ b/cc-by-sa/knowledge/modules/using_type/lessons/using_web_fonts_from_a_font_delivery_service/content.md
@@ -14,7 +14,8 @@ In this article we’ll first look at the process of adding fonts from a font de
 Once we’ve browsed the font library and made our selection(s), we’ll need to copy the code provided by the delivery service into the `<head>` of our HTML. Google Fonts provides something like this:
 
 ```
-<link rel="preconnect" href="https://fonts.gstatic.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=FAMILY_NAME:wght@WEIGHT_OR_RANGE&display=swap" rel="stylesheet">
 ```
 


### PR DESCRIPTION
When adding new fonts, Google Fonts now suggests adding both of the tags:

```
<link rel="preconnect" href="https://fonts.googleapis.com">
<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
```

for example when adding: Lexend and Alegreya 

```
<link rel="preconnect" href="https://fonts.googleapis.com">
<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
<link href="https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400..900;1,400..900&family=Lexend:wght@100..900&display=swap" rel="stylesheet">
```