### PR TITLE
Update for zain project (to_lists)

### DIFF
--- a/to_production.txt
+++ b/to_production.txt
@@ -8,7 +8,6 @@ ofl/bonanovasc # https://github.com/google/fonts/pull/7774
 ofl/fustat # https://github.com/google/fonts/pull/7820
 ofl/gamaamli # https://github.com/google/fonts/pull/7826
 ofl/wittgenstein # https://github.com/google/fonts/pull/7818
-ofl/zain # https://github.com/google/fonts/pull/7825
 
 # Upgrade
 ofl/concertone # https://github.com/google/fonts/pull/7779

--- a/to_sandbox.txt
+++ b/to_sandbox.txt
@@ -16,7 +16,6 @@ ofl/playwritehr # https://github.com/google/fonts/pull/7718
 ofl/playwritehrlijeva # https://github.com/google/fonts/pull/7717
 ofl/playwritehu # https://github.com/google/fonts/pull/7719
 ofl/playwritepe # https://github.com/google/fonts/pull/7731
-ofl/zain # https://github.com/google/fonts/pull/7890
 
 # Upgrade
 ofl/cutive # https://github.com/google/fonts/pull/7836

--- a/to_sandbox.txt
+++ b/to_sandbox.txt
@@ -16,6 +16,7 @@ ofl/playwritehr # https://github.com/google/fonts/pull/7718
 ofl/playwritehrlijeva # https://github.com/google/fonts/pull/7717
 ofl/playwritehu # https://github.com/google/fonts/pull/7719
 ofl/playwritepe # https://github.com/google/fonts/pull/7731
+ofl/zain # https://github.com/google/fonts/pull/7890
 
 # Upgrade
 ofl/cutive # https://github.com/google/fonts/pull/7836


### PR DESCRIPTION
Zain has been updated. We now block the version `1.1` and remove it from the `to_prod` list.
The new version, `1.2`, has been merged, I added it to the `to_sandbox` list.

Here is the PR concerned: https://github.com/google/fonts/pull/7890

