### PR TITLE
CJK subset fix for the recently merged families

### DIFF
--- a/ofl/batang/METADATA.pb
+++ b/ofl/batang/METADATA.pb
@@ -14,7 +14,6 @@ fonts {
 }
 subsets: "cyrillic"
 subsets: "greek"
-subsets: "japanese"
 subsets: "korean"
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/batangche/METADATA.pb
+++ b/ofl/batangche/METADATA.pb
@@ -14,7 +14,6 @@ fonts {
 }
 subsets: "cyrillic"
 subsets: "greek"
-subsets: "japanese"
 subsets: "korean"
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/dotum/METADATA.pb
+++ b/ofl/dotum/METADATA.pb
@@ -14,7 +14,6 @@ fonts {
 }
 subsets: "cyrillic"
 subsets: "greek"
-subsets: "japanese"
 subsets: "korean"
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/dotumche/METADATA.pb
+++ b/ofl/dotumche/METADATA.pb
@@ -14,7 +14,6 @@ fonts {
 }
 subsets: "cyrillic"
 subsets: "greek"
-subsets: "japanese"
 subsets: "korean"
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/gulim/METADATA.pb
+++ b/ofl/gulim/METADATA.pb
@@ -14,7 +14,6 @@ fonts {
 }
 subsets: "cyrillic"
 subsets: "greek"
-subsets: "japanese"
 subsets: "korean"
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/gulimche/METADATA.pb
+++ b/ofl/gulimche/METADATA.pb
@@ -14,7 +14,6 @@ fonts {
 }
 subsets: "cyrillic"
 subsets: "greek"
-subsets: "japanese"
 subsets: "korean"
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/gungsuh/METADATA.pb
+++ b/ofl/gungsuh/METADATA.pb
@@ -14,7 +14,6 @@ fonts {
 }
 subsets: "cyrillic"
 subsets: "greek"
-subsets: "japanese"
 subsets: "korean"
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/gungsuhche/METADATA.pb
+++ b/ofl/gungsuhche/METADATA.pb
@@ -14,7 +14,6 @@ fonts {
 }
 subsets: "cyrillic"
 subsets: "greek"
-subsets: "japanese"
 subsets: "korean"
 subsets: "latin"
 subsets: "latin-ext"


### PR DESCRIPTION
The dev server is broken because multiple CJK subsets are declared in the fonts. In a private chat Rod said:

> Only one default slicing strategy can be taken, got [japanese, Korean]

This PR deletes "Japanese" from the recently merged families with "Korean" as primary_script.
