### PR TITLE
to_production list July 4th fix

### DIFF
--- a/to_production.txt
+++ b/to_production.txt
@@ -1,5 +1,4 @@
 # New
-ofl/eduauvicwanthand # https://github.com/google/fonts/pull/7628
 ofl/kalniaglaze # https://github.com/google/fonts/pull/7864
 ofl/maname # https://github.com/google/fonts/pull/7869
 ofl/playwritear # https://github.com/google/fonts/pull/7695

--- a/to_production.txt
+++ b/to_production.txt
@@ -1,5 +1,4 @@
 # New
-ofl/kalniaglaze # https://github.com/google/fonts/pull/7864
 ofl/maname # https://github.com/google/fonts/pull/7869
 ofl/playwritear # https://github.com/google/fonts/pull/7695
 ofl/playwriteat # https://github.com/google/fonts/pull/7696

--- a/to_production.txt
+++ b/to_production.txt
@@ -1,5 +1,4 @@
 # New
-ofl/maname # https://github.com/google/fonts/pull/7869
 ofl/playwritear # https://github.com/google/fonts/pull/7695
 ofl/playwriteat # https://github.com/google/fonts/pull/7696
 ofl/playwritebevlg # https://github.com/google/fonts/pull/7702


### PR DESCRIPTION
@chrissimpkins This PR removes `Edu AU VIC WA NT Hand` from the prod list.

@garretrieger, please confirm if Kalnia Glaze should also be deleted from the list? See this [comment](https://github.com/google/fonts/pull/7917#issuecomment-2209087737) on the previous PR.