### PR TITLE
Subtree pull Axis Registry at v0.4.10

### DIFF
--- a/axisregistry/.github/workflows/publish-release.yml
+++ b/axisregistry/.github/workflows/publish-release.yml
@@ -7,9 +7,8 @@ name: Create and Publish Release
 
 jobs:
   build:
-    name: Create and Publish Release
+    name: Build distribution
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
         with:
@@ -23,7 +22,8 @@ jobs:
       - name: Install release dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade setuptools wheel twine
+          pip install --upgrade setuptools wheel build
+
       - name: Get release notes
         id: release_notes
         run: |
@@ -34,6 +34,7 @@ jobs:
           git fetch --tags --force
           TAG_NAME=${GITHUB_REF/refs\/tags\//}
           echo "$(git tag -l --format='%(contents)' $TAG_NAME)" > "${{ runner.temp }}/CHANGELOG.md"
+
       - name: Create GitHub release
         id: create_release
         uses: actions/create-release@v1
@@ -46,10 +47,34 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Build and publish to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload dist/axisregistry*
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/axisregistry
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.11
+        with:
+          # repository-url: https://test.pypi.org/legacy/ # for testing purposes
+          verify-metadata: false # twine previously didn't verify metadata when uploading

--- a/axisregistry/CHANGELOG.md
+++ b/axisregistry/CHANGELOG.md
@@ -1,58 +1,126 @@
 Below are the most important changes from each release.
 
-## Upcoming release: 0.3.11 (2022-Dic-??)
-  - ...
+### 0.4.10 (2024-Jul-03)
+
+- Add Element Expansion [ELXP] axis by @vv-monsalve in https://github.com/googlefonts/axisregistry/pull/166
+- Add Size of Paint 1 [SZP1] axis by @vv-monsalve in https://github.com/googlefonts/axisregistry/pull/167
+- Add Size of Paint 2 [SZP2] axis by @vv-monsalve in https://github.com/googlefonts/axisregistry/pull/168
+- Add Horizontal Element Alignment [XELA] axis by @simoncozens in https://github.com/googlefonts/axisregistry/pull/158
+- Add Horizontal Position Paint 1 [XPN1] axis by @vv-monsalve in https://github.com/googlefonts/axisregistry/pull/169
+- Add Horizontal Position Paint 2 [XPN2] axis by @vv-monsalve in https://github.com/googlefonts/axisregistry/pull/170
+- Add Vertical Position of Paint 1 [YPN1] axis by @vv-monsalve in https://github.com/googlefonts/axisregistry/pull/171
+- Add Vertical Position of Paint 2 [YPN2] axis by @vv-monsalve in https://github.com/googlefonts/axisregistry/pull/172
+- YELA desc updated to match reviewed XELA by @vv-monsalve in https://github.com/googlefonts/axisregistry/pull/174
 
 
-## 0.3.10 (2022-Nov-24)
+### 0.4.9 (2024-Feb-26)
+
+- Allow less aggressive renames [#165](https://github.com/googlefonts/axisregistry/pull/165)
+
+### 0.4.8 (2024-Feb-05)
+
+- repull and push
+
+### 0.4.7 (2024-Feb-05)
+
+- publish-release: update to trusted publishers workflow [#164](https://github.com/googlefonts/axisregistry/pull/164)
+
+### 0.4.6 (2024-Feb-05)
+
+- _fvar_dflts: move priority of opsz axis [#162](https://github.com/googlefonts/axisregistry/pull/162)
+
+### 0.4.5 (2023-Nov-17)
+
+- Create shadow.textproto by @yanone in https://github.com/googlefonts/axisregistry/pull/150
+- Adding [SCAN] Scanlines custom Axis by @vv-monsalve in https://github.com/googlefonts/axisregistry/pull/145
+- Adding [BLED] Bleed custom Axis by @vv-monsalve in https://github.com/googlefonts/axisregistry/pull/144
+- Don't fail if there are no axis values by @simoncozens in https://github.com/googlefonts/axisregistry/pull/155
+- @yanone made their first contribution in https://github.com/googlefonts/axisregistry/pull/150
+
+### 0.4.4 (2023-Oct-25)
+
+- Adding [ZROT] Rotation in Z custom axis by @vv-monsalve in #137
+- Update z_rotation.textproto with fallback_only field by @chrissimpkins in #140
+- Add test for proto wellformedness (no missing required fields) by @simoncozens in #143
+- Update requirements.txt by @felipesanches in #146
+- Adding [ARRR] AR Retinal Resolution custom Axis by @vv-monsalve in #141
+- If we delete a name STAT was using, put it back by @simoncozens in #154
+
+### 0.4.3 (2023-Jun-22)
+  - Adding [SHRP] Sharpness custom Axis by @vv-monsalve in #121
+  - Delete MUTA axis by @vv-monsalve in #124
+  - Adding [YALN] Y Alignment custom Axis by @vv-monsalve in #125
+
+### 0.4.2 (2023-Apr-14)
+  - update name builders #133
+
+### 0.4.1 (2023-Apr-13)
+  - build_name_table: set bits as well #131
+
+### 0.4.0 (2023-Mar-24)
+  - #120 MORPH axis added
+  - #119 VOLM axis updated
+  - #118 XROT YROT updated
+  - #115 FLAR axis updated
+  - #97 OPSZ range increase
+
+### 0.3.11 (2023-Jan-11)
+  - Update x_rotation.textproto 05a0728
+  - Update y_rotation.textproto 944a3e7
+  - Add Spacing [SPAC] axis #62
+  - Add Informality [INFM] axis #90
+  - Add Bounce [BNCE] axis #63
+  - tests/data/RobotoFlex-ttf Correct Optical Size title case 2d86d4c
+  - Add Mutation [MUTA] axis #100
+  - Update width.textproto #105
+  - Update wonky.textproto #107
+  - Also protect STAT table name IDs from the axis list #108
+  - Fix ci #110
+
+### 0.3.10 (2022-Nov-24)
   - Better issue templates (PR #94)
   - build_stat: improve elided axisvalues (PR #95)
 
-## 0.3.9 (2022-Oct-27)
+### 0.3.9 (2022-Oct-27)
   - loosen protobuf dependency on setup.py so that it is easier to install axisregistry as a dependency of other projects (such as fontbakery) (https://github.com/googlefonts/axisregistry/commit/bb213824f9b8a6215b9b78c28f59773e0bd93515)
   - #91 Added ROND axis
   - #55 Added YROT axis
   - #55 Added XROT axis
 
-
-## 0.3.8 (2022-Oct-10)
+### 0.3.8 (2022-Oct-10)
   - fix_stat do not drop nameids <= 25 (PR #88)
 
-
-## 0.3.7 (2022-Oct-10)
+### 0.3.7 (2022-Oct-10)
   - build_stat: do not rm fvar axis name records (PR #87)
 
-
-## 0.3.6 (2022-Oct-07)
+### 0.3.6 (2022-Oct-07)
   - Added YEAR axis (PR #53)
   - Added ELSH axis (PR #56)
   - Changed EGRD to ELGR (PR #57)
   - Added EHLT and EDPT (PR #61)
   - Added HEXP axis (PR #79)
 
-
-## 0.3.5 (2022-Jul-01)
+### 0.3.5 (2022-Jul-01)
   - Move nameid25 to its own func (PR #52)
 
-
-## 0.3.4 (2022-Jul-01)
+### 0.3.4 (2022-Jul-01)
   - Fix typo and ensure tox runs tests correctly (PR #50)
 
 
-## 0.3.3 (2022-Jul-01)
+### 0.3.3 (2022-Jul-01)
   - Don't delete name IDs which are shared with the STAT table (PR #49)
 
 
-## 0.3.2 (2022-Jun-27)
+### 0.3.2 (2022-Jun-27)
   - added _fvar_instance_collision function, which determines whether a family of fonts will have fvar instances which collide.	
   - build_vf_name_table: only use v1 name tables if fvar instances match (PR #48)
 
 
-## 0.3.1 (2022-Jun-24)
+### 0.3.1 (2022-Jun-24)
   - AxisRegistry: add items method. Fixed googlefonts/gftools#576 (PR #47)
 
 
-## 0.3.0 (2022-Jun-23)
+### 0.3.0 (2022-Jun-23)
   - Add name builder (PR #31)
   - Add illustrations (PRs #29, #30, #32 and #35)
   - Reduce length of parametric axis descriptions (PR #34)
@@ -60,19 +128,19 @@ Below are the most important changes from each release.
   - tox: use black (PR #39)
 
 
-## 0.2.0 (2022-Mar-14)
+### 0.2.0 (2022-Mar-14)
   - Remove pre-processing of fallback names and simplify API
 
 
-## 0.1.1 (2022-Mar-14)
+### 0.1.1 (2022-Mar-14)
   - Fix typos on cursive and monospace axes descriptions.
   - Remove space characteres from fallback name entries of all axes. (issue #7)
-  - Update `min_value` and `default_value` on **y_transparent_uppercase**.
+  - Update `min_value` and `default_value` on --y_transparent_uppercase--.
 
 
-## 0.1.0 (2022-Mar-04)
-### Release notes
+### 0.1.0 (2022-Mar-04)
+#### Release notes
   - Initial release of the `axisregistry` python module.
   - Most of the code & data was migrated from the [`fontbakery`](https://github.com/googlefonts/fontbakery/) and [`google/fonts`](https://github.com/google/fonts/) git repositories so that the GF Axis Registry data can be easily available to all our tools. The most immediate user of this module is `Font Bakery` itself, as well as `GFTools`.
-  - Axis Registry definitions are still being gradualy updated on the `google/fonts` repo, on its **axisregistry/** directory (https://github.com/google/fonts/tree/main/axisregistry) and this `axisregistry` python module will try to be kept in sync.
+  - Axis Registry definitions are still being gradualy updated on the `google/fonts` repo, on its --axisregistry/-- directory (https://github.com/google/fonts/tree/main/axisregistry) and this `axisregistry` python module will try to be kept in sync.
   - There's an ongoing plan to make this module the main place to update these definitions, avoiding data duplication and guaranteeing uniformity across tools.

--- a/axisregistry/Lib/axisregistry/data/element_expansion.textproto
+++ b/axisregistry/Lib/axisregistry/data/element_expansion.textproto
@@ -1,0 +1,14 @@
+#Element Expansion, based on https://github.com/petrvanblokland/TYPETR-Bitcount
+tag: "ELXP"
+display_name: "Element Expansion"
+min_value: 0
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description: 
+  "As the Element Expansion axis progresses, the elements move apart."

--- a/axisregistry/Lib/axisregistry/data/size_paint_1.textproto
+++ b/axisregistry/Lib/axisregistry/data/size_paint_1.textproto
@@ -1,0 +1,17 @@
+#Size of Paint 1, based on https://github.com/petrvanblokland/TYPETR-Bitcount
+tag: "SZP1"
+display_name: "Size of Paint 1"
+min_value: -100
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description: 
+  "Modifies the size of a paint element going from an initial size (0)"
+  " to positive values that increase the size (100%)"
+  " or negative values that shrink it down (-100%)."
+  " Reducing the size can create transparency."

--- a/axisregistry/Lib/axisregistry/data/size_paint_2.textproto
+++ b/axisregistry/Lib/axisregistry/data/size_paint_2.textproto
@@ -1,0 +1,18 @@
+#Size of Paint 2, based on https://github.com/petrvanblokland/TYPETR-Bitcount
+tag: "SZP2"
+display_name: "Size of Paint 2"
+min_value: -100
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description: 
+  "Modifies the size of a paint element going from an initial size (0)"
+  " to positive values that increase the size (100%)"
+  " or negative values that shrink it down (-100%)."
+  " Reducing the size can create transparency."
+  " Paint 2 is in front of Paint 1."

--- a/axisregistry/Lib/axisregistry/data/x_element_alignment.textproto
+++ b/axisregistry/Lib/axisregistry/data/x_element_alignment.textproto
@@ -1,0 +1,16 @@
+#XELA based on [SixtyFour](https://github.com/jenskutilek/homecomputer-fonts/Sixtyfour)
+tag: "XELA"
+display_name: "Horizontal Element Alignment"
+min_value: -100.0
+default_value: -1
+max_value: 100.0
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description:
+  "Align glyph elements from their default position (0%),"
+  " usually the baseline, to a rightmost (100%)"
+  " or leftmost (-100%) position."

--- a/axisregistry/Lib/axisregistry/data/x_position_paint_1.textproto
+++ b/axisregistry/Lib/axisregistry/data/x_position_paint_1.textproto
@@ -1,0 +1,16 @@
+#Horizontal Position of Paint 1, based on https://github.com/petrvanblokland/TYPETR-Bitcount
+tag: "XPN1"
+display_name: "Horizontal Position of Paint 1"
+min_value: -100
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0.0
+}
+fallback_only: false
+description: 
+  "The position of the paint moves left and right. Negative values"
+  " move to the left and positive values move to the right, in the X dimension."
+  " Paint 1 is behind Paint 2."

--- a/axisregistry/Lib/axisregistry/data/x_position_paint_2.textproto
+++ b/axisregistry/Lib/axisregistry/data/x_position_paint_2.textproto
@@ -1,0 +1,16 @@
+#Horizontal Position of Paint 2, based on https://github.com/petrvanblokland/TYPETR-Bitcount
+tag: "XPN2"
+display_name: "Horizontal Position of Paint 2"
+min_value: -100
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0.0
+}
+fallback_only: false
+description: 
+  "The position of the paint moves left and right. Negative values"
+  " move to the left and positive values move to the right, in the X dimension."
+  " Paint 2 is in front of Paint 1."

--- a/axisregistry/Lib/axisregistry/data/y_element_alignment.textproto
+++ b/axisregistry/Lib/axisregistry/data/y_element_alignment.textproto
@@ -11,6 +11,6 @@ fallback {
 }
 fallback_only: false
 description:
-  "Align glyphs from their default position (0%),"
+  "Align glyphs elements from their default position (0%),"
   " usually the baseline, to an upper (100%)"
   " or lower (-100%) position."

--- a/axisregistry/Lib/axisregistry/data/y_position_paint_1.textproto
+++ b/axisregistry/Lib/axisregistry/data/y_position_paint_1.textproto
@@ -1,0 +1,15 @@
+#Vertical Position Paint 1, based on https://github.com/petrvanblokland/TYPETR-Bitcount
+tag: "YPN1"
+display_name: "Vertical Position of Paint 1"
+min_value: -100
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description: 
+  "The position of the paint moves up and down. Negative values"
+  " move down and positive values move up. Paint 1 is behind Paint 2."

--- a/axisregistry/Lib/axisregistry/data/y_position_paint_2.textproto
+++ b/axisregistry/Lib/axisregistry/data/y_position_paint_2.textproto
@@ -1,0 +1,15 @@
+#Vertical Position Paint 2, based on https://github.com/petrvanblokland/TYPETR-Bitcount
+tag: "YPN2"
+display_name: "Vertical Position of Paint 2"
+min_value: -100
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description: 
+  "The position of the paint moves up and down. Negative values"
+  " move down and positive values move up. Paint 2 is in front of Paint 1."

--- a/axisregistry/tests/gen_test_data.py
+++ b/axisregistry/tests/gen_test_data.py
@@ -2,6 +2,7 @@
 Regenerate ttx dumps. Run this is the axis registry files in
 Lib/axisregistry/data/*.textproto have been updated.
 """
+
 from fontTools.ttLib import TTFont
 from fontTools.misc.testTools import getXML, parseXML
 from glob import glob

--- a/axisregistry/tests/test_names.py
+++ b/axisregistry/tests/test_names.py
@@ -303,13 +303,13 @@ def _test_names(ttFont, expected):
             None,
             [],
             {
-                (1, 3, 1, 0x409): "Playfair 5pt SemiExpanded Light",
+                (1, 3, 1, 0x409): "Playfair SemiExpanded Light",
                 (2, 3, 1, 0x409): "Regular",
-                (3, 3, 1, 0x409): "2.000;FTH;Playfair-5ptSemiExpandedLight",
-                (4, 3, 1, 0x409): "Playfair 5pt SemiExpanded Light",
-                (6, 3, 1, 0x409): "Playfair-5ptSemiExpandedLight",
+                (3, 3, 1, 0x409): "2.000;FTH;Playfair-SemiExpandedLight",
+                (4, 3, 1, 0x409): "Playfair SemiExpanded Light",
+                (6, 3, 1, 0x409): "Playfair-SemiExpandedLight",
                 (16, 3, 1, 0x409): "Playfair",
-                (17, 3, 1, 0x409): "5pt SemiExpanded Light",
+                (17, 3, 1, 0x409): "SemiExpanded Light",
             },
         ),
     ],
@@ -319,6 +319,37 @@ def test_name_table(fp, family_name, style_name, siblings, expected):
     siblings = [TTFont(fp) for fp in siblings]
     build_name_table(font, family_name, style_name, siblings)
     _test_names(font, expected)
+
+
+def test_name_table_aggression():
+    font = TTFont(mavenpro_fp)
+    build_name_table(font, "Raven Am", "Regular", aggressive=True)
+    _test_names(
+        font,
+        {
+            (
+                0,
+                3,
+                1,
+                0x409,
+            ): 'Copyright 2011 The Raven Am Project Authors (http://www.vissol.co.uk/mavenpro/), with Reserved Font Name "Raven Am".',
+            (4, 3, 1, 0x409): "Raven Am Regular",
+        },
+    )
+    font = TTFont(mavenpro_fp)
+    build_name_table(font, "Raven Am", "Regular", aggressive=False)
+    _test_names(
+        font,
+        {
+            (
+                0,
+                3,
+                1,
+                0x409,
+            ): 'Copyright 2011 The Maven Pro Project Authors (http://www.vissol.co.uk/mavenpro/), with Reserved Font Name "Maven Pro".',
+            (4, 3, 1, 0x409): "Raven Am Regular",
+        },
+    )
 
 
 @pytest.mark.parametrize(

--- a/axisregistry/tox.ini
+++ b/axisregistry/tox.ini
@@ -16,7 +16,7 @@ skip_install = true
 deps =
     -r test_requirements.txt
 commands =
-    black --check --diff --extend-exclude "_version.py" .
+    black --check --diff --extend-exclude "_version.py|axes*" .
 
 [testenv:coverage-report]
 skip_install = true


### PR DESCRIPTION
This PR introduces:
- [x] `XELA` required by Sixtyfour Convergence.
    #7919 PR is ready to be reviewed. 
    
- [x] `ELXP`, `SZP1`, `SZP2`, `XPN1`, `XPN2`, `YPN1`, `YPN2` required by Bitcount.
    Bitcount font will be added later in Q3, but this PR can include the axes.