### PR TITLE
Update Boutros fonts credits

### DIFF
--- a/ofl/almarai/METADATA.pb
+++ b/ofl/almarai/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Almarai"
-designer: "Boutros Fonts"
+designer: "Boutros Fonts, Mourad Boutros, Arlette Boutros"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2019-06-04"

--- a/ofl/almarai/METADATA.pb
+++ b/ofl/almarai/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Almarai"
-designer: "Boutros Fonts, Mourad Boutros, Arlette Boutros"
+designer: "Boutros Fonts, Mourad Boutros"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2019-06-04"

--- a/ofl/beiruti/METADATA.pb
+++ b/ofl/beiruti/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Beiruti"
-designer: "Boutros Fonts"
+designer: "Boutros Fonts, Arlette Boutros, Volker Schnebel"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2024-06-07"

--- a/ofl/tajawal/METADATA.pb
+++ b/ofl/tajawal/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Tajawal"
-designer: "Boutros Fonts"
+designer: "Boutros Fonts, Mourad Boutros, Soulaf Khalifeh"
 license: "OFL"
 category: "SANS_SERIF"
 date_added: "2018-04-04"


### PR DESCRIPTION
Mourad emailed me a request to make these updates. 

I've asked him to fill in [the form](https://forms.gle/NABTwXGjfgZ1fDGC8) 5 times so that the designers named in this PR can have profiles populated, but that can happen as a second step.

1. Mourad Boutros
1. Arlette Boutros
1. Soulaf Khalifeh
1. Volker Schnebel
1. Boutros Fonts


Also, I noticed that the tajawal/METADATA.pb update isn't needed, as this credit is already live on fonts.google.com; I'm not sure how the update landed in the internal METADATA file but not here, but this prompts me to file a new issue here for @chrissimpkins to sync them up somehow :)