### PR TITLE
Lists July 9th

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -6798,8 +6798,8 @@ Six Caps,/Expressive/Stiff,94
 Six Caps,/Expressive/Vintage,59
 Six Caps,/Sans/Grotesque,100
 Six Caps,/Theme/Woodtype,50
-Sixtyfour,/Expressive/Stiff,50
 Sixtyfour,/Expressive/Vintage,80
+Sixtyfour,/Monospace/Monospace,100
 Sixtyfour,/Theme/Techno,100
 Skranji,/Expressive/Awkward,69
 Skranji,/Expressive/Calm,85
@@ -8290,9 +8290,9 @@ Baskervville SC,/Serif/Transitional,100
 Batang,/Expressive/Business,75
 Batang,/Expressive/Sincere,75
 Batang,/Serif/Transitional,100
-Batangche,/Expressive/Business,75
-Batangche,/Expressive/Sincere,100
-Batangche,/Serif/Transitional,100
+BatangChe,/Expressive/Business,75
+BatangChe,/Expressive/Sincere,100
+BatangChe,/Serif/Transitional,100
 Beiruti,/Arabic/Kufi,80
 Beiruti,/Arabic/Naskh,40
 Beiruti,/Expressive/Calm,60
@@ -8395,8 +8395,8 @@ Danfo,/Theme/Wacky,75
 Danfo,/Theme/Woodtype,90
 Dotum,/Expressive/Calm,75
 Dotum,/Sans/Geometric,100
-Dotumche,/Expressive/Calm,100
-Dotumche,/Sans/Geometric,100
+DotumChe,/Expressive/Calm,100
+DotumChe,/Sans/Geometric,100
 Edu AU NSW ACT Arrows Guide,/Expressive/Active,60
 Edu AU NSW ACT Arrows Guide,/Expressive/Childlike,90
 Edu AU NSW ACT Arrows Guide,/Script/Handwritten,100
@@ -8660,14 +8660,14 @@ Ga Maamli,/Theme/Wacky,10
 Gulim,/Expressive/Calm,75
 Gulim,/Sans/Geometric,50
 Gulim,/Sans/Rounded,100
-Gulimche,/Expressive/Calm,75
-Gulimche,/Sans/Geometric,75
-Gulimche,/Sans/Rounded,100
+GulimChe,/Expressive/Calm,75
+GulimChe,/Sans/Geometric,75
+GulimChe,/Sans/Rounded,100
 Gungsuh,/Script/Formal,100
 Gungsuh,/Slab/Geometric,100
 Gungsuh,/Theme/Brush,100
-Gungsuhche,/Script/Formal,100
-Gungsuhche,/Slab/Geometric,100
+GungsuhChe,/Script/Formal,100
+GungsuhChe,/Slab/Geometric,100
 Jaini,/Expressive/Excited,20
 Jaini,/Expressive/Innovative,20
 Jaini,/Expressive/Loud,20
@@ -8859,6 +8859,30 @@ Micro 5 Charted,/Expressive/Stiff,70
 Micro 5 Charted,/Sans/Geometric,70
 Micro 5 Charted,/Theme/Pixel,100
 Micro 5 Charted,/Theme/Techno,50
+Moderustic,/Expressive/Active,80
+Moderustic,/Expressive/Awkward,88
+Moderustic,/Expressive/Business,5
+Moderustic,/Expressive/Calm,35
+Moderustic,/Expressive/Competent,85
+Moderustic,/Expressive/Cute,23
+Moderustic,/Expressive/Excited,37
+Moderustic,/Expressive/Futuristic,56
+Moderustic,/Expressive/Happy,5
+Moderustic,/Expressive/Innovative,56
+Moderustic,/Expressive/Loud,90
+Moderustic,/Expressive/Playful,55
+Moderustic,/Expressive/Rugged,80
+Moderustic,/Expressive/Sincere,5
+Moderustic,/Expressive/Stiff,50
+Moderustic,/Expressive/Vintage,20
+Moderustic,/Sans/Geometric,60
+Moderustic,/Sans/Grotesque,70
+Moderustic,/Sans/Humanist,50
+Moderustic,/Sans/Neo Grotesque,100
+Mona Sans,/Expressive/Business,80
+Mona Sans,/Expressive/Calm,80
+Mona Sans,/Expressive/Competent,80
+Mona Sans,/Sans/Geometric,100
 Noto Serif Hentaigana,/Expressive/Sincere,20
 Noto Serif Hentaigana,/Expressive/Sophisticated,10
 Noto Serif Hentaigana,/Script/Formal,20
@@ -9275,6 +9299,12 @@ Sedan,/Expressive/Sincere,80
 Sedan,/Serif/Old Style Garalde,90
 Sedan SC,/Expressive/Sincere,80
 Sedan SC,/Serif/Old Style Garalde,90
+Sixtyfour Convergence,/Expressive/Innovative,60
+Sixtyfour Convergence,/Expressive/Vintage,60
+Sixtyfour Convergence,/Monospace/Monospace,100
+Sixtyfour Convergence,/Sans/Geometric,60
+Sixtyfour Convergence,/Sans/Rounded,100
+Sixtyfour Convergence,/Theme/Techno,90
 Teachers,/Expressive/Artistic,5
 Teachers,/Expressive/Business,30
 Teachers,/Expressive/Calm,95

--- a/to_delist.txt
+++ b/to_delist.txt
@@ -25,3 +25,6 @@ https://fonts.google.com/noto/specimen/Noto+Sans+Phags+Pa
 
 # Apache license will be replaced by ofl
 apache/roboto # https://github.com/google/fonts/pull/6943
+
+# Sample text needed to unblock Noto Sans Syloti Nagri 
+lang/languages/sa_Sylo.textproto # https://github.com/google/fonts/pull/7248

--- a/to_production.txt
+++ b/to_production.txt
@@ -1,23 +1,17 @@
 # New
-ofl/playwritear # https://github.com/google/fonts/pull/7695
-ofl/playwriteat # https://github.com/google/fonts/pull/7696
-ofl/playwritebevlg # https://github.com/google/fonts/pull/7702
-ofl/playwritebewal # https://github.com/google/fonts/pull/7703
-ofl/playwritecl # https://github.com/google/fonts/pull/7705
-ofl/playwritecu # https://github.com/google/fonts/pull/7706
-ofl/playwritecz # https://github.com/google/fonts/pull/7707
-ofl/playwritedkloopet # https://github.com/google/fonts/pull/7711
-ofl/playwritedkuloopet # https://github.com/google/fonts/pull/7712
-ofl/playwritehr # https://github.com/google/fonts/pull/7718
-ofl/playwritehrlijeva # https://github.com/google/fonts/pull/7717
-ofl/playwritehu # https://github.com/google/fonts/pull/7719
-ofl/playwritepe # https://github.com/google/fonts/pull/7731
+ofl/eduauvicwanthand # https://github.com/google/fonts/pull/7628
+ofl/kalniaglaze # https://github.com/google/fonts/pull/7864
 
 # Upgrade
-ofl/cutive # https://github.com/google/fonts/pull/7836
-ofl/inter # https://github.com/google/fonts/pull/7776
+ofl/lifesavers # https://github.com/google/fonts/pull/7866
+ofl/notoseriftoto # https://github.com/google/fonts/pull/7858
+ofl/rammettoone # https://github.com/google/fonts/pull/7854
 
 # Designer profile
 catalog/designers/afoteyclementniiodai # https://github.com/google/fonts/pull/7861
 catalog/designers/amaasantewadiaka # https://github.com/google/fonts/pull/7862
 catalog/designers/davidannerteyabbeythompson # https://github.com/google/fonts/pull/7863
+catalog/designers/lauragarciamut # https://github.com/google/fonts/pull/7850
+
+# Other
+ofl/elsieswashcaps # https://github.com/google/fonts/pull/7522

--- a/to_sandbox.txt
+++ b/to_sandbox.txt
@@ -1,15 +1,73 @@
 # New
+ofl/sankofadisplay # https://github.com/google/fonts/pull/7614
 
 # Upgrade
-
-# Designer profile
+ofl/notosanslimbu # https://github.com/google/fonts/pull/7827
+ofl/notosansmandaic # https://github.com/google/fonts/pull/7828
+ofl/notosansmarchen # https://github.com/google/fonts/pull/7829
+ofl/notoserifbalinese # https://github.com/google/fonts/pull/7929
+ofl/philosopher # https://github.com/google/fonts/pull/7887
 
 # Knowledge
+cc-by-sa/knowledge/modules/using_variable_fonts_on_the_web/lessons/optimizing_typographic_space_with_variable_fonts/content.md # https://github.com/google/fonts/pull/7803
 
 # Sample texts
-# Deleted: lang/languages/mlt_Latn.textproto # https://github.com/google/fonts/pull/7680
-# Deleted: lang/languages/sa_Sylo.textproto # https://github.com/google/fonts/pull/7248
+lang/languages/bdh_Latn.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/beh_Latn.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/bgn_Arab.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/bkc_Latn.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/bsc_Latn_GN.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/bsq_Bass.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/bsq_Latn.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/cjy_Hans.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/cjy_Hant.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/crh_Cyrl.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/dnj_Latn_LR.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/evn_Latn.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/gan_Hans.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/gan_Hant.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/hak_Hans.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/hak_Hant.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/hak_Latn.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/hsn_Hans.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/hsn_Hant.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/kr_Arab.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/lzh_Hans.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/lzh_Hant.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/nan_Hans.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/nan_Hant.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/nan_Latn.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/sa_Nand.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/uma_Latn.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/wal_Ethi.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/wal_Latn.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/wuu_Hans.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/wuu_Hant.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/xsm_Latn_BF.textproto # https://github.com/google/fonts/pull/7680
+lang/languages/yue_Hani.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/yue_Hans.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/yue_Hant.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/za_Hans.textproto # https://github.com/google/fonts/pull/7877
+lang/languages/za_Hant.textproto # https://github.com/google/fonts/pull/7877
 
 # Other
+ofl/bethellen # https://github.com/google/fonts/pull/7627
+ofl/cactusclassicalserif # https://github.com/google/fonts/pull/7792
+ofl/chocolateclassicalsans # https://github.com/google/fonts/pull/7792
+ofl/danfo # https://github.com/google/fonts/pull/7566
+ofl/jaro # https://github.com/google/fonts/pull/7603
+ofl/lxgwwenkaimonotc # https://github.com/google/fonts/pull/7792
+ofl/lxgwwenkaitc # https://github.com/google/fonts/pull/7792
+ofl/notosanshk # https://github.com/google/fonts/pull/7792
+ofl/notosanssc # https://github.com/google/fonts/pull/7792
+ofl/notosanstc # https://github.com/google/fonts/pull/7792
+ofl/notoserifhk # https://github.com/google/fonts/pull/7792
+ofl/notoserifsc # https://github.com/google/fonts/pull/7792
+ofl/notoseriftc # https://github.com/google/fonts/pull/7792
+ofl/wittgenstein # https://github.com/google/fonts/pull/7920
+
+# Deleted
+# Deleted: lang/languages/mlt_Latn.textproto # https://github.com/google/fonts/pull/7680
 
 # Tags
+tags/all/families.csv


### PR DESCRIPTION
@chrissimpkins, these are the early lists for this week (given dev server was broken last Friday)

@nyshadhr9 
- Kalnia Glaze, a new COLRv1 VF that doesn't include the `SVG` table which is okay according to our current [Color font requirements](https://googlefonts.github.io/gf-guide/color.html#technical). However, on the previous list [PR](https://github.com/google/fonts/pull/7922#issuecomment-2209356750), Garret mentioned an initiated discussion around it. Please let us know if we can move ahead with it now.
#7248 is needed to unblock #6432. It was included in the previous lists with a `#` informing about the deletion, but with no effect. I've added it now to the `delist` list. Could you please confirm if something else is needed here?



