### PR TITLE
Subtree pull Axis Registry introducing XELA default fix

### DIFF
--- a/axisregistry/Lib/axisregistry/data/x_element_alignment.textproto
+++ b/axisregistry/Lib/axisregistry/data/x_element_alignment.textproto
@@ -2,7 +2,7 @@
 tag: "XELA"
 display_name: "Horizontal Element Alignment"
 min_value: -100.0
-default_value: -1
+default_value: 0.0
 max_value: 100.0
 precision: 0
 fallback {


### PR DESCRIPTION
This PR follows up #7923 with a small fix for the Axis default value to unblock #7919.