### PR TITLE
Refix font tags

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -9,8 +9,6 @@ ADLaM Display,/Sans/Rounded,20
 ADLaM Display,/Theme/Wacky,20
 AR One Sans,/Expressive/Calm,97
 AR One Sans,/Expressive/Competent,68
-AR One Sans,/Expressive/Futuristic,47
-AR One Sans,/Expressive/Stiff,50
 AR One Sans,/Sans/Geometric,30
 AR One Sans,/Sans/Humanist,50
 Abel,/Expressive/Calm,100
@@ -167,8 +165,6 @@ Alex Brush,/Script/Formal,70
 Alexandria,/Arabic/Kufi,100
 Alexandria,/Expressive/Artistic,31
 Alexandria,/Expressive/Calm,99
-Alexandria,/Expressive/Fancy,76
-Alexandria,/Expressive/Sophisticated,68
 Alexandria,/Sans/Geometric,40
 Alexandria,/Sans/Humanist,20
 Alfa Slab One,/Expressive/Business,80
@@ -412,7 +408,6 @@ Aoboshi One,/Expressive/Artistic,11
 Aoboshi One,/Expressive/Calm,88
 Aoboshi One,/Expressive/Sincere,92
 Aoboshi One,/Expressive/Vintage,100
-Arapey,/Expressive/Competent,68
 Arapey,/Expressive/Loud,42
 Arapey,/Expressive/Sincere,97
 Arapey,/Expressive/Vintage,20
@@ -420,30 +415,22 @@ Arapey,/Serif/Modern,30
 Arapey,/Serif/Transitional,60
 Arbutus,/Expressive/Innovative,38
 Arbutus,/Expressive/Playful,30
-Arbutus,/Expressive/Sincere,97
 Arbutus,/Expressive/Vintage,100
 Arbutus,/Slab/Humanist,50
 Arbutus,/Theme/Woodtype,100
 Arbutus Slab,/Expressive/Business,36
-Arbutus Slab,/Expressive/Innovative,38
-Arbutus Slab,/Expressive/Playful,30
 Arbutus Slab,/Expressive/Sincere,99
 Arbutus Slab,/Expressive/Vintage,100
 Arbutus Slab,/Slab/Clarendon,50
 Arbutus Slab,/Slab/Humanist,10
 Architects Daughter,/Expressive/Artistic,62
 Architects Daughter,/Expressive/Awkward,71
-Architects Daughter,/Expressive/Business,36
 Architects Daughter,/Expressive/Childlike,49
 Architects Daughter,/Expressive/Cute,20
 Architects Daughter,/Expressive/Playful,28
-Architects Daughter,/Expressive/Sincere,99
-Architects Daughter,/Expressive/Vintage,100
-Archivo,/Expressive/Awkward,71
 Archivo,/Expressive/Business,18
 Archivo,/Expressive/Calm,99
 Archivo,/Expressive/Competent,55
-Archivo,/Expressive/Playful,28
 Archivo,/Sans/Grotesque,70
 Archivo Black,/Expressive/Business,19
 Archivo Black,/Expressive/Calm,99
@@ -453,30 +440,23 @@ Archivo Black,/Sans/Grotesque,70
 Archivo Narrow,/Expressive/Business,19
 Archivo Narrow,/Expressive/Calm,99
 Archivo Narrow,/Expressive/Competent,58
-Archivo Narrow,/Expressive/Stiff,30
 Archivo Narrow,/Sans/Grotesque,70
 Are You Serious,/Expressive/Artistic,38
 Are You Serious,/Expressive/Awkward,35
 Are You Serious,/Expressive/Innovative,54
 Are You Serious,/Expressive/Playful,40
 Are You Serious,/Expressive/Rugged,16
-Are You Serious,/Expressive/Sincere,50
-Are You Serious,/Expressive/Vintage,100
 Are You Serious,/Theme/Wacky,40
 Aref Ruqaa,/Arabic/Ruqah,100
 Aref Ruqaa,/Expressive/Artistic,40
-Aref Ruqaa,/Expressive/Business,19
 Aref Ruqaa,/Expressive/Childlike,13
-Aref Ruqaa,/Expressive/Competent,58
 Aref Ruqaa,/Expressive/Playful,11
 Aref Ruqaa,/Expressive/Sincere,50
 Aref Ruqaa,/Expressive/Vintage,100
 Aref Ruqaa,/Serif/Humanist Venetian,60
 Aref Ruqaa Ink,/Arabic/Ruqah,100
 Aref Ruqaa Ink,/Expressive/Artistic,32
-Aref Ruqaa Ink,/Expressive/Awkward,35
 Aref Ruqaa Ink,/Expressive/Childlike,13
-Aref Ruqaa Ink,/Expressive/Innovative,54
 Aref Ruqaa Ink,/Expressive/Playful,11
 Aref Ruqaa Ink,/Expressive/Sincere,50
 Aref Ruqaa Ink,/Expressive/Vintage,99
@@ -484,21 +464,15 @@ Aref Ruqaa Ink,/Serif/Humanist Venetian,60
 Arima,/Expressive/Artistic,11
 Arima,/Expressive/Calm,74
 Arima,/Expressive/Cute,14
-Arima,/Expressive/Playful,11
-Arima,/Expressive/Sincere,50
-Arima,/Expressive/Vintage,99
 Arima,/Script/Upright Script,30
 Arimo,/Expressive/Business,47
 Arimo,/Expressive/Calm,98
 Arizonia,/Expressive/Artistic,99
-Arizonia,/Expressive/Business,47
 Arizonia,/Expressive/Fancy,47
 Arizonia,/Expressive/Sophisticated,77
 Arizonia,/Script/Informal,50
 Armata,/Expressive/Calm,93
-Armata,/Expressive/Fancy,47
 Armata,/Expressive/Futuristic,47
-Armata,/Expressive/Sophisticated,77
 Armata,/Expressive/Stiff,58
 Armata,/Sans/Geometric,10
 Armata,/Sans/Humanist,50
@@ -809,28 +783,20 @@ Baumans,/Theme/Techno,30
 Bayon,/Expressive/Calm,78
 Bayon,/Sans/Grotesque,40
 Bayon,"/South East Asian (Thai, Khmer, Lao)/Loopless",100
-Be Vietnam Pro,/Expressive/Business,59
 Be Vietnam Pro,/Expressive/Calm,99
 Be Vietnam Pro,/Expressive/Competent,11
-Be Vietnam Pro,/Expressive/Sincere,91
 Be Vietnam Pro,/Expressive/Stiff,30
 Be Vietnam Pro,/Expressive/Vintage,57
 Be Vietnam Pro,/Sans/Neo Grotesque,100
 Beau Rivage,/Expressive/Artistic,80
-Beau Rivage,/Expressive/Competent,11
 Beau Rivage,/Expressive/Fancy,57
 Beau Rivage,/Expressive/Loud,42
 Beau Rivage,/Expressive/Sophisticated,77
-Beau Rivage,/Expressive/Stiff,30
-Beau Rivage,/Expressive/Vintage,57
 Beau Rivage,/Script/Formal,100
 Bebas Neue,/Expressive/Business,59
 Bebas Neue,/Expressive/Calm,100
-Bebas Neue,/Expressive/Fancy,57
 Bebas Neue,/Expressive/Rugged,68
-Bebas Neue,/Expressive/Sophisticated,77
 Bebas Neue,/Sans/Neo Grotesque,100
-Belanosima,/Expressive/Business,59
 Belanosima,/Expressive/Calm,93
 Belanosima,/Expressive/Happy,51
 Belanosima,/Expressive/Rugged,33
@@ -839,10 +805,7 @@ Belanosima,/Sans/Grotesque,30
 Belanosima,/Sans/Rounded,50
 Belgrano,/Expressive/Business,22
 Belgrano,/Expressive/Calm,79
-Belgrano,/Expressive/Happy,51
 Belgrano,/Expressive/Sincere,97
-Belgrano,/Expressive/Vintage,74
-Bellefair,/Expressive/Business,22
 Bellefair,/Expressive/Calm,94
 Bellefair,/Expressive/Loud,41
 Bellefair,/Expressive/Sincere,94
@@ -853,16 +816,12 @@ Bellefair,/Serif/Old Style Garalde,75
 Belleza,/Expressive/Awkward,11
 Belleza,/Expressive/Calm,91
 Belleza,/Expressive/Futuristic,33
-Belleza,/Expressive/Sincere,94
-Belleza,/Expressive/Vintage,99
 Belleza,/Sans/Grotesque,10
 Belleza,/Sans/Humanist,90
 Bellota,/Expressive/Artistic,11
-Bellota,/Expressive/Awkward,11
 Bellota,/Expressive/Calm,62
 Bellota,/Expressive/Childlike,50
 Bellota,/Expressive/Cute,39
-Bellota,/Expressive/Futuristic,33
 Bellota,/Sans/Geometric,20
 Bellota,/Sans/Humanist,80
 Bellota Text,/Expressive/Calm,92
@@ -877,10 +836,8 @@ BenchNine,/Sans/Humanist,70
 BenchNine,/Sans/Rounded,20
 Benne,/Expressive/Business,19
 Benne,/Expressive/Calm,94
-Benne,/Expressive/Competent,79
 Benne,/Expressive/Loud,45
 Benne,/Expressive/Sincere,100
-Benne,/Expressive/Stiff,40
 Benne,/Expressive/Vintage,98
 Benne,/Indic/Traditional,100
 Benne,/Serif/Old Style Garalde,100
@@ -889,7 +846,6 @@ Bentham,/Expressive/Calm,95
 Bentham,/Expressive/Sincere,100
 Bentham,/Expressive/Vintage,98
 Bentham,/Serif/Modern,100
-Berkshire Swash,/Expressive/Business,37
 Berkshire Swash,/Expressive/Calm,63
 Berkshire Swash,/Expressive/Cute,32
 Berkshire Swash,/Expressive/Loud,70
@@ -900,15 +856,11 @@ Berkshire Swash,/Sans/Humanist,50
 Berkshire Swash,/Script/Upright Script,50
 Besley,/Expressive/Business,39
 Besley,/Expressive/Calm,94
-Besley,/Expressive/Playful,33
 Besley,/Expressive/Sincere,97
 Besley,/Expressive/Vintage,98
 Besley,/Slab/Clarendon,100
 Beth Ellen,/Expressive/Artistic,30
-Beth Ellen,/Expressive/Business,39
 Beth Ellen,/Expressive/Childlike,10
-Beth Ellen,/Expressive/Sincere,97
-Beth Ellen,/Expressive/Vintage,98
 Beth Ellen,/Script/Handwritten,100
 Bevan,/Expressive/Business,59
 Bevan,/Expressive/Calm,76
@@ -934,7 +886,6 @@ BhuTuka Expanded One,/Slab/Humanist,100
 Big Shoulders Display,/Expressive/Calm,79
 Big Shoulders Display,/Expressive/Competent,98
 Big Shoulders Display,/Expressive/Futuristic,56
-Big Shoulders Display,/Expressive/Innovative,71
 Big Shoulders Display,/Expressive/Playful,11
 Big Shoulders Display,/Expressive/Stiff,30
 Big Shoulders Display,/Sans/Geometric,20
@@ -974,8 +925,6 @@ Big Shoulders Stencil Text,/Expressive/Calm,59
 Big Shoulders Stencil Text,/Expressive/Competent,100
 Big Shoulders Stencil Text,/Expressive/Futuristic,56
 Big Shoulders Stencil Text,/Expressive/Innovative,56
-Big Shoulders Stencil Text,/Expressive/Playful,47
-Big Shoulders Stencil Text,/Expressive/Sincere,30
 Big Shoulders Stencil Text,/Sans/Geometric,10
 Big Shoulders Stencil Text,/Sans/Grotesque,30
 Big Shoulders Stencil Text,/Sans/Humanist,10
@@ -983,27 +932,19 @@ Big Shoulders Stencil Text,/Sans/Superellipse,20
 Big Shoulders Stencil Text,/Theme/Stencil,30
 Big Shoulders Text,/Expressive/Calm,79
 Big Shoulders Text,/Expressive/Competent,92
-Big Shoulders Text,/Expressive/Excited,11
 Big Shoulders Text,/Expressive/Futuristic,56
-Big Shoulders Text,/Expressive/Sincere,52
-Big Shoulders Text,/Expressive/Vintage,27
 Big Shoulders Text,/Sans/Geometric,20
 Big Shoulders Text,/Sans/Grotesque,40
 Big Shoulders Text,/Sans/Humanist,20
 Big Shoulders Text,/Sans/Superellipse,20
-Bigelow Rules,/Expressive/Competent,98
-Bigelow Rules,/Expressive/Futuristic,56
 Bigelow Rules,/Expressive/Innovative,33
 Bigelow Rules,/Expressive/Playful,47
 Bigelow Rules,/Expressive/Sincere,30
-Bigelow Rules,/Expressive/Stiff,30
 Bigelow Rules,/Serif/Modern,40
 Bigelow Rules,/Theme/Wacky,60
 Bigshot One,/Expressive/Calm,76
-Bigshot One,/Expressive/Competent,99
 Bigshot One,/Expressive/Excited,11
 Bigshot One,/Expressive/Futuristic,48
-Bigshot One,/Expressive/Innovative,71
 Bigshot One,/Expressive/Loud,59
 Bigshot One,/Expressive/Rugged,75
 Bigshot One,/Expressive/Sincere,52
@@ -2322,17 +2263,13 @@ Ek Mukta,/Expressive/Stiff,53
 Ek Mukta,/Indic/Contemporary,100
 Ek Mukta,/Sans/Humanist,100
 El Messiri,/Expressive/Calm,73
-El Messiri,/Expressive/Futuristic,100
 El Messiri,/Expressive/Innovative,11
 El Messiri,/Expressive/Loud,20
-El Messiri,/Expressive/Stiff,99
 El Messiri,/Expressive/Vintage,13
 El Messiri,/Sans/Glyphic,80
 Electrolize,/Expressive/Calm,59
 Electrolize,/Expressive/Futuristic,100
-Electrolize,/Expressive/Innovative,11
 Electrolize,/Expressive/Stiff,99
-Electrolize,/Expressive/Vintage,13
 Electrolize,/Sans/Geometric,80
 Electrolize,/Theme/Techno,100
 Elsie,/Expressive/Business,12
@@ -3347,7 +3284,6 @@ Iceland,/Expressive/Innovative,53
 Iceland,/Expressive/Stiff,100
 Iceland,/Expressive/Vintage,53
 Iceland,/Theme/Techno,100
-Imbue,/Expressive/Business,71
 Imbue,/Expressive/Loud,91
 Imbue,/Expressive/Sincere,91
 Imbue,/Serif/Didone,100
@@ -3463,30 +3399,40 @@ Itim,/Expressive/Playful,76
 Itim,/Sans/Humanist,40
 Itim,/Script/Handwritten,50
 Itim,/Theme/Brush,100
+Jacquard 12,/Expressive/Artistic,40
 Jacquard 12,/Expressive/Sophisticated,50
 Jacquard 12,/Theme/Blackletter,100
 Jacquard 12,/Theme/Brush,40
 Jacquard 12,/Theme/Pixel,100
+Jacquard 12 Charted,/Expressive/Artistic,40
 Jacquard 12 Charted,/Expressive/Sophisticated,50
 Jacquard 12 Charted,/Theme/Blackletter,100
 Jacquard 12 Charted,/Theme/Brush,40
 Jacquard 12 Charted,/Theme/Pixel,100
+Jacquard 24,/Expressive/Artistic,40
 Jacquard 24,/Expressive/Sophisticated,50
 Jacquard 24,/Theme/Blackletter,100
 Jacquard 24,/Theme/Brush,40
 Jacquard 24,/Theme/Pixel,100
+Jacquard 24 Charted,/Expressive/Artistic,40
 Jacquard 24 Charted,/Expressive/Sophisticated,50
 Jacquard 24 Charted,/Theme/Blackletter,100
 Jacquard 24 Charted,/Theme/Brush,40
 Jacquard 24 Charted,/Theme/Pixel,100
+Jacquarda Bastarda 9,/Expressive/Artistic,70
+Jacquarda Bastarda 9,/Expressive/Cute,20
 Jacquarda Bastarda 9,/Expressive/Happy,40
 Jacquarda Bastarda 9,/Expressive/Innovative,50
+Jacquarda Bastarda 9,/Expressive/Rugged,10
 Jacquarda Bastarda 9,/Expressive/Sophisticated,40
 Jacquarda Bastarda 9,/Expressive/Vintage,70
 Jacquarda Bastarda 9,/Script/Upright Script,50
 Jacquarda Bastarda 9,/Theme/Pixel,100
+Jacquarda Bastarda 9 Charted,/Expressive/Artistic,70
+Jacquarda Bastarda 9 Charted,/Expressive/Cute,20
 Jacquarda Bastarda 9 Charted,/Expressive/Happy,40
 Jacquarda Bastarda 9 Charted,/Expressive/Innovative,50
+Jacquarda Bastarda 9 Charted,/Expressive/Rugged,10
 Jacquarda Bastarda 9 Charted,/Expressive/Sophisticated,40
 Jacquarda Bastarda 9 Charted,/Expressive/Vintage,70
 Jacquarda Bastarda 9 Charted,/Script/Upright Script,50
@@ -3830,11 +3776,9 @@ Knewave,/Script/Handwritten,100
 Knewave,/Script/Informal,100
 Knewave,/Theme/Blobby,80
 Knewave,/Theme/Brush,100
-KoHo,/Expressive/Business,80
 KoHo,/Expressive/Calm,78
 KoHo,/Expressive/Competent,52
 KoHo,/Expressive/Happy,11
-KoHo,/Expressive/Sincere,95
 KoHo,/Sans/Geometric,60
 KoHo,/Sans/Humanist,60
 KoHo,/Sans/Neo Grotesque,40
@@ -3846,8 +3790,6 @@ Kodchasan,/Sans/Rounded,100
 Kodchasan,"/South East Asian (Thai, Khmer, Lao)/Looped",100
 Kode Mono,/Monospace/Monospace,100
 Koh Santepheap,/Expressive/Business,80
-Koh Santepheap,/Expressive/Competent,52
-Koh Santepheap,/Expressive/Happy,11
 Koh Santepheap,/Expressive/Sincere,95
 Koh Santepheap,/Serif/Modern,100
 Koh Santepheap,/Serif/Scotch,100
@@ -4189,7 +4131,6 @@ Lobster Two,/Expressive/Artistic,75
 Lobster Two,/Expressive/Childlike,20
 Lobster Two,/Expressive/Vintage,47
 Lobster Two,/Script/Informal,40
-Lohit Bengali,/Expressive/Vintage,47
 Londrina Outline,/Expressive/Awkward,61
 Londrina Outline,/Expressive/Calm,25
 Londrina Outline,/Expressive/Excited,24
@@ -4237,21 +4178,14 @@ Londrina Solid,/Theme/Distressed,100
 Londrina Solid,/Theme/Wacky,10
 Long Cang,/Expressive/Active,12
 Long Cang,/Expressive/Artistic,43
-Long Cang,/Expressive/Awkward,64
 Long Cang,/Expressive/Childlike,49
 Long Cang,/Expressive/Excited,45
-Long Cang,/Expressive/Happy,89
-Long Cang,/Expressive/Innovative,72
 Long Cang,/Expressive/Playful,17
 Long Cang,/Expressive/Rugged,22
-Long Cang,/Expressive/Stiff,60
 Long Cang,/Script/Handwritten,100
 Long Cang,/Script/Informal,100
-Lora,/Expressive/Active,12
 Lora,/Expressive/Business,59
 Lora,/Expressive/Calm,98
-Lora,/Expressive/Excited,45
-Lora,/Expressive/Playful,17
 Lora,/Expressive/Sincere,99
 Lora,/Expressive/Stiff,50
 Lora,/Expressive/Vintage,74
@@ -4274,24 +4208,16 @@ Love Ya Like A Sister,/Theme/Distressed,90
 Love Ya Like A Sister,/Theme/Wacky,60
 Love Ya Like A Sister,/Theme/Woodtype,20
 Loved by the King,/Expressive/Artistic,51
-Loved by the King,/Expressive/Business,59
 Loved by the King,/Expressive/Childlike,77
 Loved by the King,/Expressive/Excited,66
 Loved by the King,/Expressive/Happy,55
 Loved by the King,/Expressive/Playful,34
 Loved by the King,/Expressive/Rugged,15
-Loved by the King,/Expressive/Sincere,99
-Loved by the King,/Expressive/Stiff,50
-Loved by the King,/Expressive/Vintage,74
 Loved by the King,/Script/Handwritten,100
 Loved by the King,/Script/Informal,100
 Loved by the King,/Script/Upright Script,100
 Lovers Quarrel,/Expressive/Artistic,100
-Lovers Quarrel,/Expressive/Awkward,87
-Lovers Quarrel,/Expressive/Excited,34
 Lovers Quarrel,/Expressive/Fancy,65
-Lovers Quarrel,/Expressive/Happy,57
-Lovers Quarrel,/Expressive/Innovative,72
 Lovers Quarrel,/Expressive/Playful,11
 Lovers Quarrel,/Expressive/Sophisticated,73
 Lovers Quarrel,/Expressive/Vintage,19
@@ -4300,19 +4226,12 @@ Luckiest Guy,/Expressive/Awkward,12
 Luckiest Guy,/Expressive/Calm,71
 Luckiest Guy,/Expressive/Childlike,81
 Luckiest Guy,/Expressive/Excited,25
-Luckiest Guy,/Expressive/Fancy,65
 Luckiest Guy,/Expressive/Happy,64
 Luckiest Guy,/Expressive/Playful,58
-Luckiest Guy,/Expressive/Sophisticated,73
-Luckiest Guy,/Expressive/Vintage,19
 Luckiest Guy,/Theme/Wacky,40
 Luckiest Guy,/Theme/Woodtype,30
 Lugrasimo,/Expressive/Active,64
 Lugrasimo,/Expressive/Artistic,79
-Lugrasimo,/Expressive/Awkward,12
-Lugrasimo,/Expressive/Excited,25
-Lugrasimo,/Expressive/Happy,64
-Lugrasimo,/Expressive/Playful,58
 Lugrasimo,/Expressive/Vintage,69
 Lugrasimo,/Script/Formal,100
 Lugrasimo,/Script/Handwritten,100
@@ -4322,92 +4241,62 @@ Lumanosimo,/Expressive/Cute,16
 Lumanosimo,/Expressive/Happy,25
 Lumanosimo,/Expressive/Vintage,22
 Lumanosimo,/Script/Informal,50
-Lunasima,/Expressive/Active,62
 Lunasima,/Expressive/Calm,100
-Lunasima,/Expressive/Happy,25
 Lunasima,/Expressive/Stiff,64
-Lunasima,/Expressive/Vintage,22
 Lunasima,/Sans/Humanist,100
 Lusitana,/Expressive/Business,58
 Lusitana,/Expressive/Calm,97
 Lusitana,/Expressive/Sincere,100
-Lusitana,/Expressive/Stiff,60
 Lusitana,/Expressive/Vintage,49
 Lusitana,/Serif/Transitional,100
 Lustria,/Expressive/Business,28
 Lustria,/Expressive/Calm,97
 Lustria,/Expressive/Sincere,85
 Lustria,/Expressive/Stiff,10
-Lustria,/Expressive/Vintage,49
 Lustria,/Serif/Transitional,60
 Luxurious Roman,/Expressive/Active,3
 Luxurious Roman,/Expressive/Artistic,34
-Luxurious Roman,/Expressive/Business,28
 Luxurious Roman,/Expressive/Happy,11
 Luxurious Roman,/Expressive/Playful,11
 Luxurious Roman,/Expressive/Sincere,21
-Luxurious Roman,/Expressive/Stiff,10
 Luxurious Roman,/Expressive/Vintage,67
 Luxurious Roman,/Serif/Humanist Venetian,50
 Luxurious Roman,/Serif/Transitional,50
-Luxurious Script,/Expressive/Active,3
 Luxurious Script,/Expressive/Artistic,99
 Luxurious Script,/Expressive/Fancy,77
-Luxurious Script,/Expressive/Happy,11
-Luxurious Script,/Expressive/Playful,11
-Luxurious Script,/Expressive/Sincere,21
 Luxurious Script,/Expressive/Sophisticated,99
-Luxurious Script,/Expressive/Vintage,67
 Luxurious Script,/Script/Formal,100
 M PLUS 1,/Expressive/Calm,99
-M PLUS 1,/Expressive/Competent,16
 M PLUS 1,/Sans/Geometric,50
 M PLUS 1,/Sans/Humanist,50
 M PLUS 1 Code,/Expressive/Calm,68
 M PLUS 1 Code,/Expressive/Competent,78
 M PLUS 1 Code,/Expressive/Futuristic,54
-M PLUS 1 Code,/Expressive/Innovative,11
-M PLUS 1 Code,/Expressive/Sophisticated,52
 M PLUS 1 Code,/Expressive/Stiff,10
 M PLUS 1 Code,/Monospace/Monospace,100
 M PLUS 1 Code,/Sans/Humanist,60
 M PLUS 1 Code,/Sans/Superellipse,30
 M PLUS 1 Code,/Slab/Geometric,10
-M PLUS 1p,/Expressive/Business,53
 M PLUS 1p,/Expressive/Calm,99
-M PLUS 1p,/Expressive/Sincere,90
 M PLUS 1p,/Sans/Geometric,50
 M PLUS 1p,/Sans/Humanist,50
 M PLUS 2,/Expressive/Calm,99
-M PLUS 2,/Expressive/Competent,76
-M PLUS 2,/Expressive/Stiff,30
 M PLUS 2,/Sans/Geometric,50
 M PLUS 2,/Sans/Humanist,50
-M PLUS Code Latin,/Expressive/Awkward,96
 M PLUS Code Latin,/Expressive/Calm,68
 M PLUS Code Latin,/Expressive/Competent,78
-M PLUS Code Latin,/Expressive/Excited,97
 M PLUS Code Latin,/Expressive/Futuristic,58
-M PLUS Code Latin,/Expressive/Happy,100
-M PLUS Code Latin,/Expressive/Innovative,78
-M PLUS Code Latin,/Expressive/Playful,78
 Ma Shan Zheng,/Expressive/Active,19
-Ma Shan Zheng,/Expressive/Business,99
 Ma Shan Zheng,/Expressive/Childlike,47
 Ma Shan Zheng,/Expressive/Excited,39
-Ma Shan Zheng,/Expressive/Sincere,98
-Ma Shan Zheng,/Expressive/Stiff,50
-Ma Shan Zheng,/Expressive/Vintage,57
 Ma Shan Zheng,/Script/Handwritten,100
 Ma Shan Zheng,/Script/Informal,50
 Ma Shan Zheng,/Theme/Brush,100
 Macondo,/Expressive/Awkward,11
 Macondo,/Expressive/Childlike,41
 Macondo,/Expressive/Cute,36
-Macondo,/Expressive/Fancy,77
 Macondo,/Expressive/Loud,46
 Macondo,/Expressive/Playful,25
-Macondo,/Expressive/Sophisticated,99
 Macondo,/Expressive/Vintage,80
 Macondo,/Theme/Blobby,10
 Macondo,/Theme/Medieval,80
@@ -4423,12 +4312,12 @@ Macondo Swash Caps,/Theme/Medieval,80
 Mada,/Arabic/Kufi,100
 Mada,/Expressive/Business,57
 Mada,/Expressive/Calm,99
-Mada,/Expressive/Competent,78
-Mada,/Expressive/Futuristic,54
 Mada,/Expressive/Stiff,40
 Mada,/Sans/Humanist,80
 Mada,/Sans/Neo Grotesque,20
+Madimi One,/Expressive/Cute,40
 Madimi One,/Expressive/Happy,60
+Madimi One,/Expressive/Loud,30
 Madimi One,/Expressive/Playful,50
 Madimi One,/Sans/Geometric,10
 Madimi One,/Sans/Humanist,50
@@ -4450,14 +4339,10 @@ Maiden Orange,/Theme/Wacky,40
 Maiden Orange,/Theme/Woodtype,70
 Maitree,/Expressive/Business,36
 Maitree,/Expressive/Calm,98
-Maitree,/Expressive/Competent,78
-Maitree,/Expressive/Futuristic,58
 Maitree,/Expressive/Sincere,86
 Maitree,/Expressive/Stiff,60
 Maitree,/Serif/Transitional,50
-Major Mono Display,/Expressive/Active,19
 Major Mono Display,/Expressive/Calm,92
-Major Mono Display,/Expressive/Excited,39
 Major Mono Display,/Expressive/Futuristic,78
 Major Mono Display,/Expressive/Innovative,61
 Major Mono Display,/Expressive/Playful,16
@@ -4466,18 +4351,14 @@ Major Mono Display,/Monospace/Monospace,100
 Major Mono Display,/Sans/Glyphic,100
 Major Mono Display,/Theme/Art Deco,80
 Major Mono Display,/Theme/Techno,80
-Mako,/Expressive/Awkward,11
 Mako,/Expressive/Business,69
 Mako,/Expressive/Calm,98
-Mako,/Expressive/Playful,25
 Mako,/Expressive/Stiff,76
-Mako,/Expressive/Vintage,80
 Mali,/Expressive/Awkward,41
 Mali,/Expressive/Childlike,90
 Mali,/Expressive/Cute,14
 Mali,/Expressive/Happy,43
 Mali,/Expressive/Playful,22
-Mali,/Expressive/Vintage,80
 Mali,/Script/Handwritten,100
 Mali,/Script/Informal,100
 Mallanna,/Expressive/Business,6
@@ -4490,7 +4371,6 @@ Mallanna,/Sans/Neo Grotesque,20
 Mallanna,/Sans/Rounded,100
 Mandali,/Expressive/Business,6
 Mandali,/Expressive/Calm,96
-Mandali,/Expressive/Competent,64
 Mandali,/Expressive/Cute,2
 Mandali,/Expressive/Playful,11
 Mandali,/Expressive/Stiff,40
@@ -4500,28 +4380,22 @@ Mandali,/Sans/Rounded,100
 Manjari,/Expressive/Awkward,41
 Manjari,/Expressive/Business,37
 Manjari,/Expressive/Calm,98
-Manjari,/Expressive/Excited,33
 Manjari,/Expressive/Happy,42
-Manjari,/Expressive/Innovative,41
 Manjari,/Expressive/Playful,11
 Manjari,/Expressive/Rugged,3
-Manjari,/Expressive/Sincere,2
 Manjari,/Sans/Geometric,100
 Manjari,/Sans/Rounded,100
 Manrope,/Expressive/Business,46
 Manrope,/Expressive/Calm,99
-Manrope,/Expressive/Sincere,86
 Manrope,/Expressive/Stiff,71
 Manrope,/Sans/Neo Grotesque,100
 Mansalva,/Expressive/Awkward,88
 Mansalva,/Expressive/Childlike,99
 Mansalva,/Expressive/Cute,25
 Mansalva,/Expressive/Excited,66
-Mansalva,/Expressive/Futuristic,78
 Mansalva,/Expressive/Innovative,62
 Mansalva,/Expressive/Playful,17
 Mansalva,/Expressive/Rugged,24
-Mansalva,/Expressive/Stiff,72
 Mansalva,/Script/Handwritten,100
 Mansalva,/Script/Informal,100
 Mansalva,/Script/Upright Script,30
@@ -4530,114 +4404,80 @@ Manuale,/Expressive/Calm,96
 Manuale,/Expressive/Sincere,97
 Manuale,/Expressive/Stiff,71
 Manuale,/Serif/Transitional,20
-Marcellus,/Expressive/Awkward,41
 Marcellus,/Expressive/Business,33
 Marcellus,/Expressive/Calm,79
-Marcellus,/Expressive/Happy,43
 Marcellus,/Expressive/Loud,52
-Marcellus,/Expressive/Playful,22
 Marcellus,/Expressive/Sincere,10
 Marcellus,/Expressive/Stiff,20
 Marcellus SC,/Expressive/Business,32
 Marcellus SC,/Expressive/Calm,79
 Marcellus SC,/Expressive/Loud,52
-Marcellus SC,/Expressive/Playful,11
 Marcellus SC,/Expressive/Sincere,10
 Marcellus SC,/Expressive/Stiff,20
 Marck Script,/Expressive/Active,88
 Marck Script,/Expressive/Artistic,74
-Marck Script,/Expressive/Business,6
 Marck Script,/Expressive/Cute,47
 Marck Script,/Expressive/Fancy,26
 Marck Script,/Expressive/Happy,16
-Marck Script,/Expressive/Playful,11
 Marck Script,/Expressive/Sophisticated,33
-Marck Script,/Expressive/Stiff,40
 Marck Script,/Script/Handwritten,50
 Marck Script,/Script/Informal,100
 Marck Script,/Theme/Brush,80
-Margarine,/Expressive/Awkward,41
-Margarine,/Expressive/Business,37
 Margarine,/Expressive/Childlike,100
 Margarine,/Expressive/Excited,15
-Margarine,/Expressive/Happy,42
 Margarine,/Expressive/Innovative,91
-Margarine,/Expressive/Playful,11
 Margarine,/Expressive/Rugged,96
 Margarine,/Theme/Brush,100
 Margarine,/Theme/Distressed,100
-Marhey,/Expressive/Business,46
 Marhey,/Expressive/Childlike,38
 Marhey,/Expressive/Loud,10
 Marhey,/Expressive/Playful,45
-Marhey,/Expressive/Stiff,71
 Marhey,/Sans/Humanist,40
 Marhey,/Script/Upright Script,30
 Marhey,/Theme/Brush,50
-Markazi Text,/Expressive/Awkward,88
 Markazi Text,/Expressive/Business,99
 Markazi Text,/Expressive/Calm,96
-Markazi Text,/Expressive/Excited,66
-Markazi Text,/Expressive/Innovative,62
 Markazi Text,/Expressive/Loud,40
-Markazi Text,/Expressive/Playful,17
 Markazi Text,/Expressive/Sincere,98
 Markazi Text,/Expressive/Stiff,50
 Markazi Text,/Expressive/Vintage,57
 Markazi Text,/Serif/Old Style Garalde,30
 Markazi Text,/Serif/Transitional,30
-Marko One,/Expressive/Business,74
 Marko One,/Expressive/Loud,71
 Marko One,/Expressive/Playful,22
-Marko One,/Expressive/Sincere,97
-Marko One,/Expressive/Stiff,71
 Marko One,/Script/Upright Script,20
 Marko One,/Theme/Brush,30
-Marmelad,/Expressive/Business,33
 Marmelad,/Expressive/Calm,77
 Marmelad,/Expressive/Loud,47
-Marmelad,/Expressive/Sincere,10
-Marmelad,/Expressive/Stiff,20
 Marmelad,/Sans/Humanist,60
 Marmelad,/Sans/Neo Grotesque,20
 Marmelad,/Sans/Rounded,80
 Martel,/Expressive/Business,96
 Martel,/Expressive/Sincere,99
-Martel,/Expressive/Stiff,20
 Martel,/Serif/Humanist Venetian,20
 Martel,/Serif/Old Style Garalde,20
-Martel Sans,/Expressive/Active,88
 Martel Sans,/Expressive/Calm,95
-Martel Sans,/Expressive/Fancy,26
-Martel Sans,/Expressive/Happy,16
-Martel Sans,/Expressive/Sophisticated,33
 Martel Sans,/Sans/Humanist,100
 Martian Mono,/Expressive/Business,11
 Martian Mono,/Expressive/Calm,64
 Martian Mono,/Expressive/Competent,44
-Martian Mono,/Expressive/Excited,15
 Martian Mono,/Expressive/Futuristic,96
 Martian Mono,/Expressive/Happy,42
-Martian Mono,/Expressive/Innovative,91
 Martian Mono,/Expressive/Stiff,71
 Martian Mono,/Sans/Grotesque,100
 Martian Mono,/Slab/Geometric,30
 Marvel,/Expressive/Calm,93
 Marvel,/Expressive/Competent,79
-Marvel,/Expressive/Playful,45
 Marvel,/Sans/Humanist,70
 Marvel,/Sans/Superellipse,100
 Mate,/Expressive/Business,31
-Mate,/Expressive/Playful,22
 Mate,/Expressive/Sincere,95
 Mate,/Serif/Humanist Venetian,50
 Mate SC,/Expressive/Business,31
 Mate SC,/Expressive/Sincere,95
 Mate SC,/Serif/Humanist Venetian,50
-Maven Pro,/Expressive/Business,96
 Maven Pro,/Expressive/Calm,75
 Maven Pro,/Expressive/Futuristic,72
-Maven Pro,/Expressive/Sincere,99
 Maven Pro,/Expressive/Stiff,91
 Maven Pro,/Expressive/Vintage,93
 Maven Pro,/Sans/Humanist,50
@@ -4647,48 +4487,32 @@ McLaren,/Expressive/Excited,32
 McLaren,/Expressive/Playful,35
 McLaren,/Sans/Geometric,20
 Mea Culpa,/Expressive/Artistic,100
-Mea Culpa,/Expressive/Business,11
-Mea Culpa,/Expressive/Competent,44
 Mea Culpa,/Expressive/Fancy,100
-Mea Culpa,/Expressive/Futuristic,96
-Mea Culpa,/Expressive/Happy,42
 Mea Culpa,/Expressive/Sophisticated,89
-Mea Culpa,/Expressive/Stiff,71
 Mea Culpa,/Expressive/Vintage,93
 Mea Culpa,/Script/Formal,100
 Meddon,/Expressive/Active,78
 Meddon,/Expressive/Artistic,97
-Meddon,/Expressive/Competent,79
 Meddon,/Expressive/Fancy,98
 Meddon,/Expressive/Vintage,93
 Meddon,/Script/Formal,50
 Meddon,/Script/Handwritten,100
 MedievalSharp,/Expressive/Artistic,49
-MedievalSharp,/Expressive/Business,31
-MedievalSharp,/Expressive/Sincere,95
 MedievalSharp,/Expressive/Vintage,40
 MedievalSharp,/Sans/Glyphic,100
 MedievalSharp,/Theme/Blackletter,20
 MedievalSharp,/Theme/Medieval,60
-Medula One,/Expressive/Business,31
 Medula One,/Expressive/Calm,75
 Medula One,/Expressive/Competent,99
-Medula One,/Expressive/Sincere,95
 Medula One,/Expressive/Stiff,54
 Medula One,/Sans/Rounded,40
 Medula One,/Theme/Blackletter,50
 Meera Inimai,/Expressive/Calm,97
-Meera Inimai,/Expressive/Futuristic,72
-Meera Inimai,/Expressive/Stiff,91
-Meera Inimai,/Expressive/Vintage,93
 Meera Inimai,/Sans/Geometric,40
 Meera Inimai,/Sans/Neo Grotesque,40
-Megrim,/Expressive/Awkward,41
 Megrim,/Expressive/Calm,52
-Megrim,/Expressive/Excited,32
 Megrim,/Expressive/Futuristic,97
 Megrim,/Expressive/Innovative,93
-Megrim,/Expressive/Playful,35
 Megrim,/Expressive/Stiff,91
 Megrim,/Theme/Art Deco,10
 Meie Script,/Expressive/Artistic,40
@@ -4696,12 +4520,10 @@ Meie Script,/Expressive/Fancy,75
 Meie Script,/Expressive/Sophisticated,99
 Meie Script,/Expressive/Vintage,93
 Meie Script,/Script/Formal,100
-Meow Script,/Expressive/Active,78
 Meow Script,/Expressive/Artistic,36
 Meow Script,/Expressive/Cute,100
 Meow Script,/Expressive/Fancy,38
 Meow Script,/Expressive/Happy,33
-Meow Script,/Expressive/Vintage,93
 Meow Script,/Script/Handwritten,20
 Meow Script,/Script/Informal,100
 Meow Script,/Theme/Brush,100
@@ -4714,10 +4536,8 @@ Merge One,/Sans/Humanist,100
 Merge One,/Sans/Rounded,50
 Merienda,/Expressive/Active,22
 Merienda,/Expressive/Childlike,30
-Merienda,/Expressive/Competent,99
 Merienda,/Expressive/Excited,10
 Merienda,/Expressive/Rugged,16
-Merienda,/Expressive/Stiff,50
 Merienda,/Script/Handwritten,100
 Merienda,/Script/Informal,40
 Merienda,/Theme/Brush,100
@@ -4729,24 +4549,16 @@ Merriweather,/Serif/Old Style Garalde,40
 Merriweather,/Serif/Transitional,20
 Merriweather Sans,/Expressive/Business,20
 Merriweather Sans,/Expressive/Calm,98
-Merriweather Sans,/Expressive/Futuristic,97
-Merriweather Sans,/Expressive/Innovative,93
-Merriweather Sans,/Expressive/Stiff,91
 Merriweather Sans,/Sans/Humanist,100
 Mervale Script,/Expressive/Active,25
 Mervale Script,/Expressive/Artistic,57
 Mervale Script,/Expressive/Cute,32
-Mervale Script,/Expressive/Fancy,75
 Mervale Script,/Expressive/Sophisticated,73
-Mervale Script,/Expressive/Vintage,93
 Mervale Script,/Script/Formal,30
 Metal,/Expressive/Business,39
-Metal,/Expressive/Fancy,38
-Metal,/Expressive/Happy,33
 Metal,/Expressive/Sincere,97
 Metal,/Serif/Old Style Garalde,100
 Metal Mania,/Expressive/Awkward,13
-Metal Mania,/Expressive/Competent,52
 Metal Mania,/Expressive/Excited,72
 Metal Mania,/Expressive/Innovative,94
 Metal Mania,/Expressive/Loud,50
@@ -4756,54 +4568,41 @@ Metal Mania,/Expressive/Stiff,91
 Metal Mania,/Expressive/Vintage,77
 Metal Mania,/Theme/Distressed,100
 Metal Mania,/Theme/Wacky,10
-Metamorphous,/Expressive/Active,22
 Metamorphous,/Expressive/Artistic,93
-Metamorphous,/Expressive/Excited,10
 Metamorphous,/Expressive/Sincere,23
 Metamorphous,/Theme/Medieval,100
-Metrophobic,/Expressive/Business,97
 Metrophobic,/Expressive/Calm,77
 Metrophobic,/Expressive/Competent,71
 Metrophobic,/Expressive/Futuristic,74
-Metrophobic,/Expressive/Sincere,97
 Metrophobic,/Expressive/Stiff,79
 Metrophobic,/Sans/Superellipse,100
 Miama,/Expressive/Artistic,60
-Miama,/Expressive/Business,20
 Miama,/Expressive/Loud,70
 Miama,/Expressive/Sophisticated,24
 Miama,/Script/Formal,50
-Michroma,/Expressive/Active,25
 Michroma,/Expressive/Calm,85
 Michroma,/Expressive/Competent,94
 Michroma,/Expressive/Futuristic,100
-Michroma,/Expressive/Sophisticated,73
 Michroma,/Expressive/Stiff,98
 Michroma,/Expressive/Vintage,59
 Michroma,/Sans/Superellipse,100
 Michroma,/Theme/Techno,60
 Milonga,/Expressive/Artistic,12
 Milonga,/Expressive/Awkward,71
-Milonga,/Expressive/Business,39
 Milonga,/Expressive/Innovative,11
 Milonga,/Expressive/Playful,11
 Milonga,/Expressive/Sincere,40
 Milonga,/Serif/Transitional,100
 Miltonian,/Expressive/Artistic,8
-Miltonian,/Expressive/Awkward,13
 Miltonian,/Expressive/Childlike,15
-Miltonian,/Expressive/Excited,72
 Miltonian,/Expressive/Happy,77
 Miltonian,/Expressive/Innovative,53
 Miltonian,/Expressive/Loud,70
 Miltonian,/Expressive/Sincere,10
-Miltonian,/Expressive/Stiff,91
-Miltonian,/Expressive/Vintage,77
 Miltonian,/Serif/Modern,40
 Miltonian,/Theme/Brush,10
 Miltonian,/Theme/Inline,100
 Miltonian Tattoo,/Expressive/Artistic,8
-Miltonian Tattoo,/Expressive/Sincere,23
 Miltonian Tattoo,/Serif/Modern,40
 Miltonian Tattoo,/Theme/Brush,10
 Mina,/Expressive/Calm,82
@@ -4815,36 +4614,25 @@ Mina,/Sans/Humanist,20
 Mina,/Sans/Superellipse,100
 Mingzat,/Expressive/Business,54
 Mingzat,/Expressive/Calm,99
-Mingzat,/Expressive/Sophisticated,24
 Mingzat,/Expressive/Stiff,51
 Mingzat,/Expressive/Vintage,93
 Mingzat,/Sans/Grotesque,20
 Mingzat,/Sans/Neo Grotesque,80
 Miniver,/Expressive/Active,54
-Miniver,/Expressive/Competent,94
 Miniver,/Expressive/Cute,78
 Miniver,/Expressive/Excited,15
-Miniver,/Expressive/Futuristic,100
 Miniver,/Expressive/Playful,35
 Miniver,/Expressive/Rugged,12
-Miniver,/Expressive/Stiff,98
-Miniver,/Expressive/Vintage,59
 Miniver,/Script/Informal,100
 Miniver,/Theme/Wacky,40
-Miriam Libre,/Expressive/Awkward,71
 Miriam Libre,/Expressive/Calm,69
 Miriam Libre,/Expressive/Competent,34
-Miriam Libre,/Expressive/Innovative,11
-Miriam Libre,/Expressive/Playful,11
-Miriam Libre,/Expressive/Sincere,40
 Miriam Libre,/Sans/Geometric,10
 Miriam Libre,/Sans/Superellipse,70
 Miriam Libre,/Slab/Geometric,30
 Mirza,/Expressive/Artistic,11
 Mirza,/Expressive/Awkward,21
 Mirza,/Expressive/Calm,15
-Mirza,/Expressive/Happy,77
-Mirza,/Expressive/Innovative,53
 Mirza,/Expressive/Sincere,5
 Mirza,/Sans/Glyphic,100
 Miss Fajardose,/Expressive/Artistic,80
@@ -4855,23 +4643,15 @@ Miss Fajardose,/Script/Formal,40
 Mitr,/Expressive/Calm,85
 Mitr,/Expressive/Competent,14
 Mitr,/Expressive/Cute,11
-Mitr,/Expressive/Futuristic,96
 Mitr,/Expressive/Playful,32
-Mitr,/Expressive/Stiff,96
-Mitr,/Expressive/Vintage,72
 Mitr,/Sans/Humanist,100
 Mochiy Pop One,/Expressive/Awkward,12
-Mochiy Pop One,/Expressive/Business,54
 Mochiy Pop One,/Expressive/Calm,56
 Mochiy Pop One,/Expressive/Happy,11
 Mochiy Pop One,/Expressive/Playful,13
-Mochiy Pop One,/Expressive/Stiff,50
-Mochiy Pop One,/Expressive/Vintage,93
 Mochiy Pop One,/Sans/Humanist,50
-Mochiy Pop P One,/Expressive/Active,54
 Mochiy Pop P One,/Expressive/Awkward,12
 Mochiy Pop P One,/Expressive/Calm,56
-Mochiy Pop P One,/Expressive/Excited,15
 Mochiy Pop P One,/Expressive/Happy,11
 Mochiy Pop P One,/Expressive/Playful,13
 Mochiy Pop P One,/Sans/Humanist,50
@@ -4884,42 +4664,30 @@ Modak,/Expressive/Playful,100
 Modak,/Sans/Humanist,100
 Modak,/Serif/Humanist Venetian,50
 Modak,/Theme/Blobby,95
-Modern Antiqua,/Expressive/Awkward,21
 Modern Antiqua,/Expressive/Sincere,30
 Modern Antiqua,/Expressive/Vintage,93
 Modern Antiqua,/Theme/Medieval,70
 Mogra,/Expressive/Active,13
 Mogra,/Expressive/Cute,27
 Mogra,/Expressive/Excited,72
-Mogra,/Expressive/Fancy,80
 Mogra,/Expressive/Innovative,80
 Mogra,/Expressive/Playful,91
-Mogra,/Expressive/Sophisticated,47
 Mogra,/Script/Informal,50
 Mogra,/Theme/Brush,100
 Mohave,/Expressive/Calm,98
 Mohave,/Expressive/Competent,98
 Mohave,/Expressive/Futuristic,76
-Mohave,/Expressive/Playful,32
 Mohave,/Expressive/Stiff,79
 Mohave,/Sans/Superellipse,100
-Moirai One,/Expressive/Awkward,12
 Moirai One,/Expressive/Cute,17
-Moirai One,/Expressive/Happy,11
 Moirai One,/Expressive/Playful,100
-Molengo,/Expressive/Awkward,12
 Molengo,/Expressive/Calm,99
-Molengo,/Expressive/Happy,11
-Molengo,/Expressive/Playful,13
 Molengo,/Sans/Humanist,100
 Molle,/Expressive/Artistic,73
-Molle,/Expressive/Competent,32
 Molle,/Expressive/Cute,57
-Molle,/Expressive/Excited,78
 Molle,/Expressive/Fancy,12
 Molle,/Expressive/Innovative,20
 Molle,/Expressive/Loud,96
-Molle,/Expressive/Playful,100
 Molle,/Expressive/Vintage,50
 Molle,/Script/Informal,50
 Molle,/Theme/Art Nouveau,30
@@ -4929,17 +4697,13 @@ Monda,/Expressive/Business,34
 Monda,/Expressive/Calm,97
 Monda,/Expressive/Competent,85
 Monda,/Expressive/Futuristic,83
-Monda,/Expressive/Sincere,30
 Monda,/Expressive/Stiff,87
 Monda,/Expressive/Vintage,13
 Monda,/Sans/Humanist,40
 Monda,/Sans/Superellipse,100
-Monofett,/Expressive/Active,13
 Monofett,/Expressive/Competent,69
-Monofett,/Expressive/Excited,72
 Monofett,/Expressive/Futuristic,48
 Monofett,/Expressive/Innovative,98
-Monofett,/Expressive/Playful,91
 Monofett,/Expressive/Stiff,91
 Monofett,/Monospace/Monospace,100
 Monofett,/Sans/Geometric,10
@@ -4966,72 +4730,44 @@ Monsieur La Doulaise,/Expressive/Fancy,100
 Monsieur La Doulaise,/Expressive/Sophisticated,100
 Monsieur La Doulaise,/Expressive/Vintage,93
 Monsieur La Doulaise,/Script/Formal,100
-Montaga,/Expressive/Fancy,12
-Montaga,/Expressive/Innovative,20
 Montaga,/Expressive/Sincere,92
-Montaga,/Expressive/Vintage,50
 Montaga,/Serif/Humanist Venetian,80
 Montaga,/Serif/Old Style Garalde,20
 Montagu Slab,/Expressive/Business,17
-Montagu Slab,/Expressive/Competent,85
-Montagu Slab,/Expressive/Futuristic,83
 Montagu Slab,/Expressive/Rugged,53
 Montagu Slab,/Expressive/Sincere,92
-Montagu Slab,/Expressive/Stiff,87
 Montagu Slab,/Expressive/Vintage,93
 Montagu Slab,/Slab/Clarendon,100
 MonteCarlo,/Expressive/Artistic,40
-MonteCarlo,/Expressive/Competent,69
 MonteCarlo,/Expressive/Fancy,56
-MonteCarlo,/Expressive/Futuristic,48
-MonteCarlo,/Expressive/Innovative,98
 MonteCarlo,/Expressive/Sophisticated,97
-MonteCarlo,/Expressive/Stiff,91
 MonteCarlo,/Script/Formal,100
-Montez,/Expressive/Competent,65
 Montez,/Expressive/Cute,32
 Montez,/Expressive/Excited,34
-Montez,/Expressive/Futuristic,76
 Montez,/Expressive/Playful,12
-Montez,/Expressive/Stiff,60
 Montez,/Script/Handwritten,100
 Montez,/Script/Upright Script,100
 Montserrat,/Expressive/Business,56
 Montserrat,/Expressive/Calm,100
-Montserrat,/Expressive/Excited,91
-Montserrat,/Expressive/Futuristic,15
-Montserrat,/Expressive/Innovative,97
-Montserrat,/Expressive/Playful,15
 Montserrat,/Sans/Geometric,100
 Montserrat Alternates,/Expressive/Calm,100
-Montserrat Alternates,/Expressive/Fancy,100
 Montserrat Alternates,/Expressive/Playful,11
-Montserrat Alternates,/Expressive/Sophisticated,100
-Montserrat Alternates,/Expressive/Vintage,93
 Montserrat Alternates,/Sans/Geometric,100
 Montserrat Subrayada,/Expressive/Calm,71
-Montserrat Subrayada,/Expressive/Sincere,92
 Montserrat Subrayada,/Sans/Geometric,100
 Moo Lah Lah,/Expressive/Awkward,78
-Moo Lah Lah,/Expressive/Business,17
 Moo Lah Lah,/Expressive/Childlike,70
 Moo Lah Lah,/Expressive/Excited,80
 Moo Lah Lah,/Expressive/Innovative,95
 Moo Lah Lah,/Expressive/Playful,100
 Moo Lah Lah,/Expressive/Rugged,74
-Moo Lah Lah,/Expressive/Sincere,92
-Moo Lah Lah,/Expressive/Vintage,93
 Moo Lah Lah,/Theme/Wacky,100
 Mooli,/Expressive/Calm,80
 Mooli,/Expressive/Childlike,11
 Mooli,/Expressive/Competent,16
-Mooli,/Expressive/Fancy,56
-Mooli,/Expressive/Sophisticated,97
 Mooli,/Sans/Humanist,100
 Moon Dance,/Expressive/Artistic,40
-Moon Dance,/Expressive/Excited,34
 Moon Dance,/Expressive/Innovative,11
-Moon Dance,/Expressive/Playful,12
 Moon Dance,/Expressive/Sophisticated,52
 Moon Dance,/Script/Formal,100
 Moon Dance,/Script/Handwritten,100
@@ -5041,7 +4777,6 @@ Moul,/Expressive/Sincere,90
 Moul,/Slab/Clarendon,100
 Moulpali,/Expressive/Calm,85
 Moulpali,/Expressive/Competent,76
-Moulpali,/Expressive/Playful,11
 Moulpali,/Expressive/Stiff,30
 Moulpali,/Sans/Humanist,50
 Moulpali,/Sans/Superellipse,50
@@ -5059,17 +4794,13 @@ Mouse Memoirs,/Expressive/Awkward,91
 Mouse Memoirs,/Expressive/Calm,17
 Mouse Memoirs,/Expressive/Cute,11
 Mouse Memoirs,/Expressive/Excited,72
-Mouse Memoirs,/Expressive/Innovative,95
 Mouse Memoirs,/Expressive/Playful,77
 Mouse Memoirs,/Sans/Glyphic,100
 Mouse Memoirs,/Sans/Grotesque,20
 Mouse Memoirs,/Theme/Wacky,100
-Mr Bedfort,/Expressive/Awkward,91
 Mr Bedfort,/Expressive/Cute,13
-Mr Bedfort,/Expressive/Excited,72
 Mr Bedfort,/Expressive/Fancy,34
 Mr Bedfort,/Expressive/Loud,46
-Mr Bedfort,/Expressive/Playful,77
 Mr Bedfort,/Expressive/Sophisticated,54
 Mr Bedfort,/Expressive/Vintage,66
 Mr Bedfort,/Script/Formal,50
@@ -5080,12 +4811,10 @@ Mr Dafoe,/Expressive/Cute,43
 Mr Dafoe,/Expressive/Excited,46
 Mr Dafoe,/Expressive/Fancy,26
 Mr Dafoe,/Expressive/Sophisticated,18
-Mr Dafoe,/Expressive/Vintage,66
 Mr Dafoe,/Script/Handwritten,100
 Mr Dafoe,/Script/Informal,100
 Mr Dafoe,/Theme/Brush,100
 Mr De Haviland,/Expressive/Artistic,40
-Mr De Haviland,/Expressive/Excited,46
 Mr De Haviland,/Expressive/Fancy,75
 Mr De Haviland,/Expressive/Happy,32
 Mr De Haviland,/Expressive/Sophisticated,59
@@ -5096,7 +4825,6 @@ Mr De Haviland,/Script/Informal,40
 Mr De Haviland,/Theme/Brush,10
 Mrs Saint Delafield,/Expressive/Artistic,20
 Mrs Saint Delafield,/Expressive/Fancy,97
-Mrs Saint Delafield,/Expressive/Happy,32
 Mrs Saint Delafield,/Expressive/Sophisticated,98
 Mrs Saint Delafield,/Expressive/Vintage,93
 Mrs Saint Delafield,/Script/Formal,80
@@ -5110,16 +4838,11 @@ Mrs Sheppards,/Expressive/Fancy,26
 Mrs Sheppards,/Expressive/Happy,14
 Mrs Sheppards,/Expressive/Loud,58
 Mrs Sheppards,/Expressive/Playful,54
-Mrs Sheppards,/Expressive/Sophisticated,98
-Mrs Sheppards,/Expressive/Vintage,93
 Mrs Sheppards,/Script/Handwritten,100
 Mrs Sheppards,/Script/Informal,100
 Mrs Sheppards,/Theme/Brush,100
-Ms Madi,/Expressive/Active,79
 Ms Madi,/Expressive/Artistic,36
-Ms Madi,/Expressive/Awkward,14
 Ms Madi,/Expressive/Cute,79
-Ms Madi,/Expressive/Excited,20
 Ms Madi,/Expressive/Fancy,73
 Ms Madi,/Expressive/Happy,31
 Ms Madi,/Expressive/Playful,12
@@ -5127,9 +4850,6 @@ Ms Madi,/Script/Handwritten,100
 Ms Madi,/Script/Informal,100
 Ms Madi,/Theme/Brush,60
 Mukta,/Expressive/Calm,100
-Mukta,/Expressive/Fancy,73
-Mukta,/Expressive/Happy,31
-Mukta,/Expressive/Playful,12
 Mukta,/Sans/Humanist,100
 Mukta Mahee,/Expressive/Calm,100
 Mukta Mahee,/Sans/Humanist,100
@@ -5156,18 +4876,15 @@ My Soul,/Script/Formal,80
 My Soul,/Script/Handwritten,100
 Mynerve,/Expressive/Awkward,51
 Mynerve,/Expressive/Childlike,99
-Mynerve,/Expressive/Competent,34
 Mynerve,/Expressive/Cute,68
 Mynerve,/Expressive/Happy,58
 Mynerve,/Expressive/Innovative,22
 Mynerve,/Expressive/Rugged,42
-Mynerve,/Expressive/Vintage,59
 Mynerve,/Script/Handwritten,100
 Mynerve,/Script/Informal,100
 Mystery Quest,/Expressive/Artistic,40
 Mystery Quest,/Expressive/Awkward,95
 Mystery Quest,/Expressive/Happy,99
-Mystery Quest,/Expressive/Innovative,22
 Mystery Quest,/Expressive/Sincere,50
 Mystery Quest,/Theme/Wacky,100
 NATS,/Expressive/Business,83
@@ -5178,63 +4895,42 @@ NATS,/Sans/Geometric,100
 NTR,/Expressive/Calm,68
 NTR,/Expressive/Childlike,30
 NTR,/Expressive/Cute,32
-NTR,/Expressive/Futuristic,99
 NTR,/Expressive/Playful,31
-NTR,/Expressive/Stiff,96
-NTR,/Expressive/Vintage,72
 NTR,/Sans/Geometric,60
 NTR,/Sans/Rounded,100
-Nabla,/Expressive/Awkward,95
 Nabla,/Expressive/Futuristic,98
-Nabla,/Expressive/Happy,99
 Nabla,/Expressive/Innovative,100
 Nabla,/Expressive/Rugged,91
-Nabla,/Expressive/Sincere,50
 Nabla,/Expressive/Stiff,91
 Nabla,/Theme/Shaded,100
 Nabla,/Theme/Techno,40
 Namdhinggo,/Expressive/Business,95
 Namdhinggo,/Expressive/Calm,94
-Namdhinggo,/Expressive/Futuristic,98
-Namdhinggo,/Expressive/Innovative,100
 Namdhinggo,/Expressive/Sincere,98
 Namdhinggo,/Expressive/Stiff,60
 Namdhinggo,/Expressive/Vintage,93
 Namdhinggo,/Serif/Humanist Venetian,100
 Nanum Brush Script,/Expressive/Awkward,36
-Nanum Brush Script,/Expressive/Business,95
 Nanum Brush Script,/Expressive/Childlike,38
 Nanum Brush Script,/Expressive/Excited,59
 Nanum Brush Script,/Expressive/Innovative,12
 Nanum Brush Script,/Expressive/Playful,35
 Nanum Brush Script,/Expressive/Rugged,14
-Nanum Brush Script,/Expressive/Sincere,98
-Nanum Brush Script,/Expressive/Stiff,60
-Nanum Brush Script,/Expressive/Vintage,93
 Nanum Brush Script,/Script/Handwritten,100
 Nanum Pen,/Expressive/Artistic,12
 Nanum Pen,/Expressive/Awkward,21
 Nanum Pen,/Expressive/Childlike,79
-Nanum Pen,/Expressive/Competent,72
 Nanum Pen,/Expressive/Cute,67
-Nanum Pen,/Expressive/Futuristic,32
 Nanum Pen,/Expressive/Happy,47
-Nanum Pen,/Expressive/Stiff,10
 Nanum Pen,/Script/Handwritten,100
 Nanum Pen,/Script/Informal,100
 Nanum Pen,/Theme/Brush,100
-NanumGothic,/Expressive/Awkward,36
 NanumGothic,/Expressive/Calm,99
-NanumGothic,/Expressive/Excited,59
-NanumGothic,/Expressive/Innovative,12
-NanumGothic,/Expressive/Playful,35
 NanumGothic,/Sans/Grotesque,70
 NanumGothic,/Sans/Humanist,30
-NanumGothicCoding,/Expressive/Awkward,21
 NanumGothicCoding,/Expressive/Calm,78
 NanumGothicCoding,/Expressive/Competent,72
 NanumGothicCoding,/Expressive/Futuristic,32
-NanumGothicCoding,/Expressive/Happy,47
 NanumGothicCoding,/Expressive/Stiff,10
 NanumGothicCoding,/Sans/Geometric,40
 NanumGothicCoding,/Sans/Grotesque,20
@@ -5246,53 +4942,36 @@ NanumMyeongjo,/Expressive/Sincere,99
 NanumMyeongjo,/Expressive/Stiff,40
 NanumMyeongjo,/Expressive/Vintage,93
 NanumMyeongjo,/Serif/Old Style Garalde,100
-Narnoor,/Expressive/Business,99
 Narnoor,/Expressive/Calm,99
-Narnoor,/Expressive/Sincere,99
-Narnoor,/Expressive/Stiff,40
-Narnoor,/Expressive/Vintage,93
 Narnoor,/Sans/Humanist,100
 Neonderthaw,/Expressive/Active,78
 Neonderthaw,/Expressive/Artistic,74
-Neonderthaw,/Expressive/Business,83
 Neonderthaw,/Expressive/Cute,36
 Neonderthaw,/Expressive/Fancy,72
 Neonderthaw,/Expressive/Innovative,74
 Neonderthaw,/Expressive/Playful,32
-Neonderthaw,/Expressive/Stiff,50
-Neonderthaw,/Expressive/Vintage,65
 Neonderthaw,/Script/Formal,40
 Neonderthaw,/Theme/Inline,20
-Nerko One,/Expressive/Active,78
 Nerko One,/Expressive/Awkward,32
 Nerko One,/Expressive/Childlike,99
-Nerko One,/Expressive/Fancy,72
 Nerko One,/Expressive/Happy,17
-Nerko One,/Expressive/Innovative,74
 Nerko One,/Expressive/Playful,77
 Nerko One,/Script/Handwritten,40
 Nerko One,/Theme/Brush,100
 Neucha,/Expressive/Awkward,76
 Neucha,/Expressive/Childlike,38
-Neucha,/Expressive/Happy,17
 Neucha,/Expressive/Playful,52
 Neucha,/Expressive/Rugged,15
 Neucha,/Sans/Humanist,20
-Neuton,/Expressive/Awkward,76
 Neuton,/Expressive/Business,72
-Neuton,/Expressive/Playful,52
 Neuton,/Expressive/Sincere,98
 Neuton,/Serif/Humanist Venetian,100
 New Rocker,/Expressive/Artistic,58
-New Rocker,/Expressive/Business,72
 New Rocker,/Expressive/Loud,56
 New Rocker,/Expressive/Rugged,98
-New Rocker,/Expressive/Sincere,98
 New Rocker,/Expressive/Stiff,91
 New Rocker,/Expressive/Vintage,60
 New Rocker,/Theme/Blackletter,100
-New Tegomin,/Expressive/Business,32
-New Tegomin,/Expressive/Competent,79
 New Tegomin,/Expressive/Excited,15
 New Tegomin,/Expressive/Innovative,12
 New Tegomin,/Expressive/Playful,20
@@ -5304,61 +4983,42 @@ New Tegomin,/Slab/Humanist,50
 News Cycle,/Expressive/Business,32
 News Cycle,/Expressive/Calm,86
 News Cycle,/Expressive/Competent,79
-News Cycle,/Expressive/Stiff,91
-News Cycle,/Expressive/Vintage,60
 News Cycle,/Sans/Grotesque,20
 News Cycle,/Sans/Humanist,80
 Newsreader,/Expressive/Business,78
-Newsreader,/Expressive/Excited,15
-Newsreader,/Expressive/Innovative,12
 Newsreader,/Expressive/Loud,20
-Newsreader,/Expressive/Playful,20
 Newsreader,/Expressive/Sincere,99
-Newsreader,/Expressive/Vintage,93
 Newsreader,/Serif/Transitional,100
 Niconne,/Expressive/Active,66
-Niconne,/Expressive/Business,78
 Niconne,/Expressive/Fancy,57
 Niconne,/Expressive/Loud,37
 Niconne,/Expressive/Sincere,40
 Niconne,/Serif/Modern,100
-Niramit,/Expressive/Active,66
 Niramit,/Expressive/Business,81
 Niramit,/Expressive/Calm,97
-Niramit,/Expressive/Fancy,57
 Niramit,/Expressive/Happy,11
-Niramit,/Expressive/Sincere,40
 Niramit,/Expressive/Stiff,53
 Niramit,/Expressive/Vintage,61
 Niramit,/Sans/Geometric,90
 Niramit,/Sans/Humanist,10
 Nixie One,/Expressive/Awkward,11
-Nixie One,/Expressive/Business,81
-Nixie One,/Expressive/Happy,11
 Nixie One,/Expressive/Sincere,93
-Nixie One,/Expressive/Stiff,50
-Nixie One,/Expressive/Vintage,61
 Nixie One,/Slab/Humanist,100
-Nobile,/Expressive/Awkward,11
 Nobile,/Expressive/Business,20
 Nobile,/Expressive/Calm,98
-Nobile,/Expressive/Sincere,93
 Nobile,/Sans/Humanist,100
 Nokora,/Expressive/Business,40
 Nokora,/Expressive/Calm,99
 Nokora,/Sans/Neo Grotesque,100
-Norican,/Expressive/Business,40
 Norican,/Expressive/Cute,14
 Norican,/Expressive/Fancy,18
 Norican,/Expressive/Loud,25
 Norican,/Expressive/Sophisticated,24
 Norican,/Script/Formal,50
 Nosifer,/Expressive/Excited,34
-Nosifer,/Expressive/Fancy,18
 Nosifer,/Expressive/Innovative,76
 Nosifer,/Expressive/Loud,50
 Nosifer,/Expressive/Rugged,92
-Nosifer,/Expressive/Sophisticated,24
 Nosifer,/Expressive/Stiff,55
 Nosifer,/Theme/Wacky,100
 Nosifer Caps,/Expressive/Excited,34
@@ -5368,8 +5028,6 @@ Nosifer Caps,/Expressive/Rugged,92
 Nosifer Caps,/Expressive/Stiff,55
 Nosifer Caps,/Theme/Wacky,100
 Notable,/Expressive/Artistic,97
-Notable,/Expressive/Excited,34
-Notable,/Expressive/Innovative,76
 Notable,/Expressive/Loud,98
 Notable,/Expressive/Rugged,76
 Notable,/Expressive/Stiff,71
@@ -5379,33 +5037,22 @@ Nothing You Could Do,/Expressive/Childlike,90
 Nothing You Could Do,/Expressive/Excited,23
 Nothing You Could Do,/Expressive/Playful,22
 Nothing You Could Do,/Expressive/Rugged,16
-Nothing You Could Do,/Expressive/Stiff,71
 Nothing You Could Do,/Script/Handwritten,100
 Nothing You Could Do,/Script/Informal,100
-Noticia Text,/Expressive/Active,76
 Noticia Text,/Expressive/Business,80
-Noticia Text,/Expressive/Excited,23
-Noticia Text,/Expressive/Playful,22
 Noticia Text,/Expressive/Sincere,100
 Noticia Text,/Slab/Humanist,100
-Noto Color Emoji,/Expressive/Business,80
 Noto Color Emoji,/Expressive/Childlike,90
 Noto Color Emoji,/Expressive/Cute,95
 Noto Color Emoji,/Expressive/Excited,100
 Noto Color Emoji,/Expressive/Innovative,100
 Noto Color Emoji,/Expressive/Loud,90
 Noto Color Emoji,/Expressive/Playful,100
-Noto Color Emoji,/Expressive/Sincere,100
-Noto Color Emoji Compat Test,/Expressive/Excited,100
-Noto Color Emoji Compat Test,/Expressive/Innovative,100
-Noto Color Emoji Compat Test,/Expressive/Playful,100
 Noto Color Emoji Compat Test,/Not text/Symbols,100
 Noto Emoji,/Expressive/Cute,80
 Noto Emoji,/Expressive/Innovative,99
 Noto Emoji,/Expressive/Playful,80
 Noto Kufi Arabic,/Arabic/Kufi,100
-Noto Kufi Arabic,/Expressive/Innovative,99
-Noto Kufi Arabic,/Expressive/Playful,80
 Noto Music,/Expressive/Business,58
 Noto Music,/Expressive/Calm,99
 Noto Music,/Not text/Symbols,100
@@ -5427,7 +5074,6 @@ Noto Rashi Hebrew,/Hebrew/Rashi,100
 Noto Rashi Hebrew,/Serif/Transitional,100
 Noto Sans,/Expressive/Business,58
 Noto Sans,/Expressive/Calm,99
-Noto Sans,/Expressive/Sincere,99
 Noto Sans,/Sans/Humanist,100
 Noto Sans Adlam,/Expressive/Business,58
 Noto Sans Adlam,/Expressive/Calm,99
@@ -5438,7 +5084,6 @@ Noto Sans Adlam Unjoined,/Sans/Humanist,100
 Noto Sans Anatolian Hieroglyphs,/Expressive/Business,58
 Noto Sans Anatolian Hieroglyphs,/Expressive/Calm,99
 Noto Sans Anatolian Hieroglyphs,/Sans/Humanist,100
-Noto Sans Arabic,/Expressive/Business,58
 Noto Sans Arabic,/Sans/Humanist,100
 Noto Sans Arabic UI,/Sans/Humanist,100
 Noto Sans Armenian,/Expressive/Business,58
@@ -5633,7 +5278,6 @@ Noto Sans Lao,/Sans/Humanist,100
 Noto Sans Lao Looped,/Expressive/Business,58
 Noto Sans Lao Looped,/Expressive/Calm,99
 Noto Sans Lao Looped,/Sans/Humanist,100
-Noto Sans Lao UI,/Expressive/Business,58
 Noto Sans Lao UI,/Sans/Humanist,100
 Noto Sans Lepcha,/Expressive/Business,58
 Noto Sans Lepcha,/Expressive/Calm,99
@@ -5650,7 +5294,6 @@ Noto Sans Linear B,/Sans/Humanist,100
 Noto Sans Lisu,/Expressive/Business,58
 Noto Sans Lisu,/Expressive/Calm,99
 Noto Sans Lisu,/Sans/Humanist,100
-Noto Sans Lycian,/Expressive/Business,58
 Noto Sans Lycian,/Sans/Humanist,100
 Noto Sans Lydian,/Expressive/Business,58
 Noto Sans Lydian,/Expressive/Calm,99
@@ -5661,7 +5304,6 @@ Noto Sans Mahajani,/Sans/Humanist,100
 Noto Sans Malayalam,/Expressive/Business,58
 Noto Sans Malayalam,/Expressive/Calm,99
 Noto Sans Malayalam,/Sans/Humanist,100
-Noto Sans Malayalam UI,/Expressive/Business,58
 Noto Sans Malayalam UI,/Sans/Humanist,100
 Noto Sans Mandaic,/Expressive/Business,58
 Noto Sans Mandaic,/Expressive/Calm,99
@@ -5711,7 +5353,6 @@ Noto Sans Mro,/Sans/Humanist,100
 Noto Sans Multani,/Expressive/Business,58
 Noto Sans Multani,/Expressive/Calm,99
 Noto Sans Multani,/Sans/Humanist,100
-Noto Sans Myanmar,/Expressive/Business,58
 Noto Sans Myanmar,/Sans/Humanist,100
 Noto Sans Myanmar UI,/Sans/Humanist,100
 Noto Sans NKo,/Expressive/Business,58
@@ -5771,7 +5412,6 @@ Noto Sans Old Turkic,/Sans/Humanist,100
 Noto Sans Oriya,/Expressive/Business,58
 Noto Sans Oriya,/Expressive/Calm,99
 Noto Sans Oriya,/Sans/Humanist,100
-Noto Sans Oriya UI,/Expressive/Business,58
 Noto Sans Oriya UI,/Sans/Humanist,100
 Noto Sans Osage,/Expressive/Business,58
 Noto Sans Osage,/Expressive/Calm,99
@@ -5827,7 +5467,6 @@ Noto Sans SignWriting,/Sans/Humanist,100
 Noto Sans Sinhala,/Expressive/Business,58
 Noto Sans Sinhala,/Expressive/Calm,99
 Noto Sans Sinhala,/Sans/Humanist,100
-Noto Sans Sinhala UI,/Expressive/Business,58
 Noto Sans Sinhala UI,/Sans/Humanist,100
 Noto Sans Sogdian,/Expressive/Business,58
 Noto Sans Sogdian,/Expressive/Calm,99
@@ -5884,7 +5523,6 @@ Noto Sans Tamil,/Sans/Humanist,100
 Noto Sans Tamil Supplement,/Expressive/Business,58
 Noto Sans Tamil Supplement,/Expressive/Calm,99
 Noto Sans Tamil Supplement,/Sans/Humanist,100
-Noto Sans Tamil UI,/Expressive/Business,58
 Noto Sans Tamil UI,/Sans/Humanist,100
 Noto Sans Tangsa,/Expressive/Business,58
 Noto Sans Tangsa,/Expressive/Calm,99
@@ -5892,7 +5530,6 @@ Noto Sans Tangsa,/Sans/Humanist,100
 Noto Sans Telugu,/Expressive/Business,58
 Noto Sans Telugu,/Expressive/Calm,99
 Noto Sans Telugu,/Sans/Humanist,100
-Noto Sans Telugu UI,/Expressive/Business,58
 Noto Sans Telugu UI,/Sans/Humanist,100
 Noto Sans Thaana,/Expressive/Business,58
 Noto Sans Thaana,/Expressive/Calm,99
@@ -5903,7 +5540,6 @@ Noto Sans Thai,/Sans/Humanist,100
 Noto Sans Thai Looped,/Expressive/Business,58
 Noto Sans Thai Looped,/Expressive/Calm,99
 Noto Sans Thai Looped,/Sans/Humanist,100
-Noto Sans Thai UI,/Expressive/Business,58
 Noto Sans Thai UI,/Sans/Humanist,100
 Noto Sans Tifinagh,/Expressive/Business,58
 Noto Sans Tifinagh,/Expressive/Calm,99
@@ -6060,9 +5696,7 @@ Noto Serif Yezidi,/Expressive/Sincere,99
 Noto Serif Yezidi,/Serif/Transitional,100
 Noto Traditional Nushu,/Expressive/Business,58
 Noto Traditional Nushu,/Expressive/Calm,99
-Noto Traditional Nushu,/Expressive/Sincere,99
 Noto Traditional Nushu,/Sans/Humanist,100
-Nova Cut,/Expressive/Business,58
 Nova Cut,/Expressive/Futuristic,78
 Nova Cut,/Expressive/Loud,28
 Nova Cut,/Expressive/Stiff,96
@@ -6071,10 +5705,8 @@ Nova Cut,/Theme/Blackletter,20
 Nova Flat,/Expressive/Competent,14
 Nova Flat,/Expressive/Futuristic,38
 Nova Flat,/Expressive/Stiff,96
-Nova Flat,/Expressive/Vintage,11
 Nova Flat,/Theme/Blackletter,20
 Nova Flat,/Theme/Techno,30
-Nova Mono,/Expressive/Competent,14
 Nova Mono,/Expressive/Futuristic,38
 Nova Mono,/Expressive/Playful,14
 Nova Mono,/Expressive/Stiff,30
@@ -6085,29 +5717,22 @@ Nova Mono,/Theme/Blackletter,10
 Nova Mono,/Theme/Techno,50
 Nova Oval,/Expressive/Calm,73
 Nova Oval,/Expressive/Competent,32
-Nova Oval,/Expressive/Futuristic,38
 Nova Oval,/Expressive/Playful,14
-Nova Oval,/Expressive/Stiff,30
 Nova Oval,/Expressive/Vintage,41
 Nova Oval,/Sans/Superellipse,40
 Nova Oval,/Theme/Blackletter,10
 Nova Oval,/Theme/Medieval,50
 Nova Round,/Expressive/Calm,38
 Nova Round,/Expressive/Competent,53
-Nova Round,/Expressive/Playful,14
 Nova Round,/Expressive/Stiff,30
 Nova Round,/Expressive/Vintage,11
 Nova Round,/Sans/Superellipse,60
 Nova Round,/Theme/Blackletter,10
 Nova Round,/Theme/Techno,20
 Nova Script,/Expressive/Active,37
-Nova Script,/Expressive/Competent,53
-Nova Script,/Expressive/Stiff,30
-Nova Script,/Expressive/Vintage,11
 Nova Script,/Sans/Superellipse,40
 Nova Script,/Theme/Medieval,50
 Nova Script,/Theme/Techno,10
-Nova Slim,/Expressive/Active,37
 Nova Slim,/Expressive/Artistic,17
 Nova Slim,/Expressive/Calm,78
 Nova Slim,/Expressive/Competent,32
@@ -6116,18 +5741,15 @@ Nova Slim,/Expressive/Stiff,10
 Nova Slim,/Expressive/Vintage,53
 Nova Slim,/Sans/Superellipse,60
 Nova Square,/Expressive/Calm,55
-Nova Square,/Expressive/Competent,32
 Nova Square,/Expressive/Futuristic,99
 Nova Square,/Expressive/Stiff,96
 Nova Square,/Expressive/Vintage,72
 Nova Square,/Theme/Techno,100
 Numans,/Expressive/Business,16
 Numans,/Expressive/Calm,96
-Numans,/Expressive/Playful,31
 Numans,/Sans/Geometric,30
 Numans,/Sans/Grotesque,40
 Numans,/Sans/Humanist,30
-Nunito,/Expressive/Business,16
 Nunito,/Expressive/Calm,99
 Nunito,/Expressive/Cute,21
 Nunito,/Expressive/Playful,1
@@ -6137,55 +5759,44 @@ Nunito,/Sans/Rounded,100
 Nunito Sans,/Expressive/Business,96
 Nunito Sans,/Expressive/Calm,100
 Nunito Sans,/Expressive/Competent,91
-Nunito Sans,/Expressive/Playful,1
 Nunito Sans,/Sans/Humanist,20
 Nunito Sans,/Sans/Neo Grotesque,80
 Nunito Sans,/Sans/Rounded,100
 Nuosu SIL,/Expressive/Business,100
-Nuosu SIL,/Expressive/Competent,91
 Nuosu SIL,/Expressive/Sincere,97
 Nuosu SIL,/Serif/Old Style Garalde,50
 Nuosu SIL,/Serif/Transitional,50
 OFL Sorts Mill Goudy TT,/Expressive/Business,67
 OFL Sorts Mill Goudy TT,/Expressive/Calm,97
-OFL Sorts Mill Goudy TT,/Expressive/Competent,64
-OFL Sorts Mill Goudy TT,/Expressive/Futuristic,98
-OFL Sorts Mill Goudy TT,/Expressive/Innovative,21
 OFL Sorts Mill Goudy TT,/Expressive/Sincere,99
-OFL Sorts Mill Goudy TT,/Expressive/Stiff,94
 OFL Sorts Mill Goudy TT,/Expressive/Vintage,93
 OFL Sorts Mill Goudy TT,/Serif/Old Style Garalde,100
-Odibee Sans,/Expressive/Business,100
 Odibee Sans,/Expressive/Competent,55
 Odibee Sans,/Expressive/Futuristic,80
 Odibee Sans,/Expressive/Rugged,73
-Odibee Sans,/Expressive/Sincere,97
 Odibee Sans,/Expressive/Stiff,97
 Odibee Sans,/Theme/Blackletter,20
 Odibee Sans,/Theme/Wacky,50
 Odor Mean Chey,/Expressive/Business,61
-Odor Mean Chey,/Expressive/Competent,55
-Odor Mean Chey,/Expressive/Futuristic,80
 Odor Mean Chey,/Expressive/Sincere,54
 Odor Mean Chey,/Expressive/Stiff,30
-Offside,/Expressive/Business,61
 Offside,/Expressive/Competent,64
 Offside,/Expressive/Futuristic,98
 Offside,/Expressive/Innovative,21
-Offside,/Expressive/Sincere,54
 Offside,/Expressive/Stiff,94
 Offside,/Sans/Superellipse,100
 Offside,/Theme/Medieval,10
 Offside,/Theme/Stencil,10
 Offside,/Theme/Techno,100
-Oi,/Expressive/Business,67
 Oi,/Expressive/Innovative,98
 Oi,/Expressive/Loud,78
 Oi,/Expressive/Rugged,98
 Oi,/Expressive/Sincere,10
-Oi,/Expressive/Vintage,93
 Oi,/Slab/Clarendon,80
+Ojuju,/Expressive/Artistic,20
 Ojuju,/Expressive/Innovative,70
+Ojuju,/Expressive/Loud,80
+Ojuju,/Expressive/Rugged,10
 Ojuju,/Expressive/Vintage,20
 Ojuju,/Sans/Humanist,50
 Old Standard TT,/Expressive/Business,68
@@ -6193,9 +5804,7 @@ Old Standard TT,/Expressive/Loud,57
 Old Standard TT,/Serif/Modern,100
 Oldenburg,/Expressive/Childlike,10
 Oldenburg,/Expressive/Cute,52
-Oldenburg,/Expressive/Innovative,98
 Oldenburg,/Expressive/Playful,31
-Oldenburg,/Expressive/Sincere,10
 Oldenburg,/Serif/Humanist Venetian,10
 Oldenburg,/Slab/Humanist,100
 Oldenburg,/Theme/Medieval,30
@@ -6207,11 +5816,7 @@ Ole,/Expressive/Fancy,44
 Ole,/Expressive/Playful,18
 Ole,/Theme/Wacky,100
 Oleo Script,/Expressive/Active,15
-Oleo Script,/Expressive/Awkward,47
-Oleo Script,/Expressive/Excited,98
-Oleo Script,/Expressive/Fancy,44
 Oleo Script,/Expressive/Loud,37
-Oleo Script,/Expressive/Playful,18
 Oleo Script,/Expressive/Stiff,20
 Oleo Script,/Script/Formal,30
 Oleo Script Swash Caps,/Expressive/Active,15
@@ -6219,19 +5824,14 @@ Oleo Script Swash Caps,/Expressive/Fancy,27
 Oleo Script Swash Caps,/Expressive/Loud,37
 Oleo Script Swash Caps,/Expressive/Stiff,20
 Oleo Script Swash Caps,/Script/Formal,30
-Onest,/Expressive/Active,15
 Onest,/Expressive/Business,47
 Onest,/Expressive/Calm,99
-Onest,/Expressive/Fancy,27
-Onest,/Expressive/Stiff,20
 Onest,/Sans/Humanist,10
 Onest,/Sans/Neo Grotesque,90
 Oooh Baby,/Expressive/Active,99
-Oooh Baby,/Expressive/Business,47
 Oooh Baby,/Expressive/Childlike,10
 Oooh Baby,/Script/Handwritten,100
 Oooh Baby,/Script/Informal,100
-Open Sans,/Expressive/Active,99
 Open Sans,/Expressive/Business,96
 Open Sans,/Expressive/Calm,99
 Open Sans,/Sans/Humanist,80
@@ -6242,34 +5842,24 @@ Oranienbaum,/Expressive/Sincere,78
 Oranienbaum,/Expressive/Stiff,30
 Oranienbaum,/Serif/Modern,100
 Oranienbaum,/Serif/Scotch,40
-Orbit,/Expressive/Business,14
 Orbit,/Expressive/Calm,59
 Orbit,/Expressive/Competent,71
 Orbit,/Expressive/Excited,41
 Orbit,/Expressive/Futuristic,99
 Orbit,/Expressive/Happy,80
-Orbit,/Expressive/Sincere,78
 Orbit,/Expressive/Stiff,80
 Orbit,/Expressive/Vintage,55
 Orbit,/Sans/Geometric,100
-Orbitron,/Expressive/Competent,71
-Orbitron,/Expressive/Excited,41
 Orbitron,/Expressive/Futuristic,100
-Orbitron,/Expressive/Happy,80
 Orbitron,/Expressive/Stiff,100
 Orbitron,/Expressive/Vintage,93
 Orbitron,/Theme/Techno,100
 Oregano,/Expressive/Active,100
 Oregano,/Expressive/Excited,71
-Oregano,/Expressive/Futuristic,100
 Oregano,/Expressive/Rugged,34
-Oregano,/Expressive/Stiff,100
-Oregano,/Expressive/Vintage,93
 Oregano,/Script/Handwritten,100
 Oregano,/Script/Informal,100
 Oregano,/Theme/Brush,100
-Orelega One,/Expressive/Active,100
-Orelega One,/Expressive/Excited,71
 Orelega One,/Expressive/Loud,48
 Orelega One,/Expressive/Rugged,28
 Orelega One,/Slab/Clarendon,100
@@ -6281,59 +5871,45 @@ Original Surfer,/Expressive/Playful,77
 Original Surfer,/Expressive/Vintage,72
 Original Surfer,/Sans/Glyphic,80
 Original Surfer,/Theme/Wacky,100
-Oswald,/Expressive/Awkward,96
 Oswald,/Expressive/Business,98
 Oswald,/Expressive/Competent,96
-Oswald,/Expressive/Playful,77
 Oswald,/Expressive/Rugged,92
 Oswald,/Expressive/Stiff,91
 Oswald,/Expressive/Vintage,48
 Oswald,/Sans/Grotesque,100
 Otomanopee One,/Expressive/Business,45
 Otomanopee One,/Expressive/Calm,19
-Otomanopee One,/Expressive/Competent,96
 Otomanopee One,/Expressive/Excited,54
 Otomanopee One,/Expressive/Happy,21
 Otomanopee One,/Expressive/Loud,55
-Otomanopee One,/Expressive/Stiff,91
-Otomanopee One,/Expressive/Vintage,48
 Otomanopee One,/Sans/Humanist,80
 Otomanopee One,/Theme/Wacky,60
 Outfit,/Expressive/Business,73
 Outfit,/Expressive/Calm,99
-Outfit,/Expressive/Excited,54
-Outfit,/Expressive/Happy,21
 Outfit,/Sans/Geometric,100
 Over the Rainbow,/Expressive/Awkward,53
 Over the Rainbow,/Expressive/Childlike,69
-Over the Rainbow,/Expressive/Competent,17
 Over the Rainbow,/Expressive/Happy,56
-Over the Rainbow,/Expressive/Vintage,60
 Over the Rainbow,/Script/Handwritten,100
 Over the Rainbow,/Script/Informal,100
-Overlock,/Expressive/Business,73
 Overlock,/Expressive/Calm,73
 Overlock,/Expressive/Cute,33
 Overlock,/Expressive/Playful,11
 Overlock,/Sans/Humanist,100
 Overlock,/Theme/Brush,20
-Overlock SC,/Expressive/Awkward,53
 Overlock SC,/Expressive/Calm,73
 Overlock SC,/Expressive/Cute,33
-Overlock SC,/Expressive/Happy,56
 Overlock SC,/Expressive/Playful,11
 Overlock SC,/Sans/Humanist,100
 Overlock SC,/Theme/Brush,20
 Overpass,/Expressive/Calm,77
 Overpass,/Expressive/Competent,17
-Overpass,/Expressive/Playful,11
 Overpass,/Expressive/Vintage,60
 Overpass,/Sans/Grotesque,90
 Overpass,/Sans/Humanist,10
 Overpass Mono,/Expressive/Calm,58
 Overpass Mono,/Expressive/Competent,45
 Overpass Mono,/Expressive/Futuristic,97
-Overpass Mono,/Expressive/Playful,11
 Overpass Mono,/Expressive/Stiff,78
 Overpass Mono,/Expressive/Vintage,37
 Overpass Mono,/Monospace/Monospace,100
@@ -6341,27 +5917,19 @@ Overpass Mono,/Sans/Grotesque,80
 Overpass Mono,/Sans/Humanist,10
 Overpass Mono,/Slab/Humanist,10
 Ovo,/Expressive/Business,46
-Ovo,/Expressive/Competent,45
-Ovo,/Expressive/Futuristic,97
 Ovo,/Expressive/Sincere,99
-Ovo,/Expressive/Stiff,78
-Ovo,/Expressive/Vintage,37
 Ovo,/Serif/Humanist Venetian,100
-Oxanium,/Expressive/Business,46
 Oxanium,/Expressive/Calm,87
 Oxanium,/Expressive/Futuristic,99
-Oxanium,/Expressive/Sincere,99
 Oxanium,/Expressive/Stiff,98
 Oxanium,/Sans/Superellipse,100
 Oxanium,/Theme/Techno,100
 Oxygen,/Expressive/Business,96
 Oxygen,/Expressive/Calm,97
-Oxygen,/Expressive/Futuristic,99
 Oxygen,/Expressive/Stiff,52
 Oxygen,/Expressive/Vintage,76
 Oxygen,/Sans/Grotesque,40
 Oxygen,/Sans/Humanist,60
-Oxygen Mono,/Expressive/Business,96
 Oxygen Mono,/Expressive/Calm,59
 Oxygen Mono,/Expressive/Futuristic,54
 Oxygen Mono,/Expressive/Stiff,78
@@ -6369,16 +5937,13 @@ Oxygen Mono,/Expressive/Vintage,76
 Oxygen Mono,/Monospace/Monospace,100
 Oxygen Mono,/Sans/Grotesque,40
 Oxygen Mono,/Sans/Humanist,60
-PT Mono,/Expressive/Business,69
 PT Mono,/Expressive/Calm,98
 PT Mono,/Expressive/Sincere,63
-PT Mono,/Expressive/Stiff,40
 PT Mono,/Expressive/Vintage,92
 PT Mono,/Monospace/Monospace,100
 PT Mono,/Slab/Humanist,100
 PT Sans,/Expressive/Business,75
 PT Sans,/Expressive/Calm,99
-PT Sans,/Expressive/Sincere,63
 PT Sans,/Expressive/Stiff,40
 PT Sans,/Expressive/Vintage,72
 PT Sans,/Sans/Humanist,100
@@ -6395,7 +5960,6 @@ PT Sans Narrow,/Expressive/Vintage,72
 PT Sans Narrow,/Sans/Humanist,100
 PT Serif,/Expressive/Business,79
 PT Serif,/Expressive/Calm,97
-PT Serif,/Expressive/Competent,88
 PT Serif,/Expressive/Sincere,100
 PT Serif,/Expressive/Stiff,40
 PT Serif,/Expressive/Vintage,73
@@ -6408,33 +5972,25 @@ PT Serif Caption,/Expressive/Vintage,73
 PT Serif Caption,/Slab/Humanist,80
 Pacifico,/Expressive/Artistic,61
 Pacifico,/Expressive/Cute,100
-Pacifico,/Expressive/Futuristic,54
 Pacifico,/Expressive/Playful,18
-Pacifico,/Expressive/Stiff,78
-Pacifico,/Expressive/Vintage,76
 Pacifico,/Script/Handwritten,50
 Pacifico,/Script/Informal,80
 Padauk,/Expressive/Business,46
 Padauk,/Expressive/Calm,98
-Padauk,/Expressive/Playful,18
 Padauk,/Expressive/Stiff,20
 Padauk,/Expressive/Vintage,67
 Padauk,/Sans/Geometric,20
 Padauk,/Sans/Grotesque,90
-Padyakke Expanded One,/Expressive/Business,46
 Padyakke Expanded One,/Expressive/Calm,96
 Padyakke Expanded One,/Expressive/Competent,80
 Padyakke Expanded One,/Expressive/Happy,24
 Padyakke Expanded One,/Expressive/Stiff,20
-Padyakke Expanded One,/Expressive/Vintage,67
 Padyakke Expanded One,/Indic/Low contrast,100
 Padyakke Expanded One,/Serif/Humanist Venetian,30
 Padyakke Expanded One,/Serif/Transitional,50
 Padyakke Expanded One,/Slab/Humanist,60
 Palanquin,/Expressive/Business,55
 Palanquin,/Expressive/Calm,99
-Palanquin,/Expressive/Competent,80
-Palanquin,/Expressive/Happy,24
 Palanquin,/Expressive/Stiff,40
 Palanquin,/Indic/Low contrast,100
 Palanquin,/Sans/Humanist,100
@@ -6444,12 +6000,9 @@ Palanquin Dark,/Expressive/Happy,17
 Palanquin Dark,/Expressive/Stiff,40
 Palanquin Dark,/Indic/Low contrast,100
 Palanquin Dark,/Sans/Humanist,100
-Palette Mosaic,/Expressive/Business,11
-Palette Mosaic,/Expressive/Happy,17
 Palette Mosaic,/Expressive/Innovative,98
 Palette Mosaic,/Expressive/Playful,70
 Palette Mosaic,/Expressive/Rugged,99
-Palette Mosaic,/Expressive/Stiff,40
 Palette Mosaic,/Theme/Distressed,100
 Palette Mosaic,/Theme/Stencil,10
 Palette Mosaic,/Theme/Wacky,80
@@ -6466,11 +6019,7 @@ Pangolin,/Script/Upright Script,100
 Pangolin,/Theme/Brush,80
 Pangolin,/Theme/Distressed,60
 Paprika,/Expressive/Artistic,18
-Paprika,/Expressive/Awkward,62
 Paprika,/Expressive/Childlike,10
-Paprika,/Expressive/Excited,31
-Paprika,/Expressive/Innovative,51
-Paprika,/Expressive/Playful,22
 Paprika,/Serif/Humanist Venetian,90
 Parisienne,/Expressive/Artistic,99
 Parisienne,/Expressive/Fancy,73
@@ -6479,55 +6028,40 @@ Parisienne,/Expressive/Sophisticated,83
 Parisienne,/Script/Formal,100
 Passero One,/Expressive/Awkward,97
 Passero One,/Expressive/Calm,81
-Passero One,/Expressive/Fancy,73
 Passero One,/Expressive/Futuristic,95
 Passero One,/Expressive/Innovative,65
-Passero One,/Expressive/Sophisticated,83
 Passero One,/Expressive/Stiff,91
 Passero One,/Theme/Techno,50
 Passero One,/Theme/Wacky,10
 Passero One,/Theme/Woodtype,20
-Passion One,/Expressive/Awkward,97
 Passion One,/Expressive/Business,38
 Passion One,/Expressive/Calm,93
 Passion One,/Expressive/Competent,66
-Passion One,/Expressive/Futuristic,95
-Passion One,/Expressive/Innovative,65
 Passion One,/Expressive/Loud,31
 Passion One,/Expressive/Stiff,76
 Passion One,/Sans/Humanist,100
 Passion One,/Theme/Woodtype,50
 Passions Conflict,/Expressive/Artistic,100
-Passions Conflict,/Expressive/Business,38
-Passions Conflict,/Expressive/Competent,66
 Passions Conflict,/Expressive/Fancy,88
-Passions Conflict,/Expressive/Stiff,76
 Passions Conflict,/Expressive/Vintage,68
 Passions Conflict,/Script/Formal,100
 Pathway Extreme,/Expressive/Business,35
 Pathway Extreme,/Expressive/Calm,80
-Pathway Extreme,/Expressive/Fancy,88
 Pathway Extreme,/Expressive/Futuristic,49
 Pathway Extreme,/Expressive/Stiff,77
-Pathway Extreme,/Expressive/Vintage,68
 Pathway Extreme,/Sans/Grotesque,50
 Pathway Extreme,/Sans/Neo Grotesque,50
 Pathway Extreme,/Sans/Superellipse,80
 Pathway Gothic One,/Expressive/Business,49
 Pathway Gothic One,/Expressive/Calm,98
 Pathway Gothic One,/Expressive/Competent,79
-Pathway Gothic One,/Expressive/Futuristic,49
-Pathway Gothic One,/Expressive/Stiff,77
 Pathway Gothic One,/Expressive/Vintage,75
 Pathway Gothic One,/Sans/Grotesque,100
 Patrick Hand,/Expressive/Awkward,74
-Patrick Hand,/Expressive/Business,49
 Patrick Hand,/Expressive/Childlike,78
-Patrick Hand,/Expressive/Competent,79
 Patrick Hand,/Expressive/Cute,35
 Patrick Hand,/Expressive/Innovative,12
 Patrick Hand,/Expressive/Playful,43
-Patrick Hand,/Expressive/Vintage,75
 Patrick Hand,/Script/Handwritten,100
 Patrick Hand,/Script/Informal,100
 Patrick Hand,/Script/Upright Script,100
@@ -6542,18 +6076,13 @@ Patrick Hand SC,/Script/Informal,100
 Patrick Hand SC,/Script/Upright Script,100
 Patrick Hand SC,/Theme/Distressed,20
 Pattaya,/Expressive/Artistic,75
-Pattaya,/Expressive/Awkward,73
 Pattaya,/Expressive/Cute,35
 Pattaya,/Expressive/Fancy,92
 Pattaya,/Expressive/Happy,21
-Pattaya,/Expressive/Innovative,12
-Pattaya,/Expressive/Playful,43
 Pattaya,/Expressive/Vintage,64
 Pattaya,/Script/Informal,40
 Patua One,/Expressive/Business,80
 Patua One,/Expressive/Calm,97
-Patua One,/Expressive/Fancy,92
-Patua One,/Expressive/Happy,21
 Patua One,/Expressive/Sincere,81
 Patua One,/Expressive/Vintage,74
 Patua One,/Serif/Transitional,100
@@ -6561,15 +6090,11 @@ Patua One,/Slab/Humanist,20
 Pavanam,/Expressive/Business,44
 Pavanam,/Expressive/Calm,99
 Pavanam,/Expressive/Competent,19
-Pavanam,/Expressive/Sincere,81
 Pavanam,/Expressive/Stiff,51
-Pavanam,/Expressive/Vintage,74
 Pavanam,/Indic/Low contrast,100
 Pavanam,/Sans/Neo Grotesque,80
 Paytone One,/Expressive/Business,42
 Paytone One,/Expressive/Calm,95
-Paytone One,/Expressive/Competent,19
-Paytone One,/Expressive/Stiff,50
 Paytone One,/Expressive/Vintage,77
 Paytone One,/Sans/Geometric,80
 Peddana,/Expressive/Business,80
@@ -6579,14 +6104,11 @@ Peddana,/Expressive/Vintage,73
 Peddana,/Indic/Traditional,100
 Peddana,/Serif/Transitional,100
 Peralta,/Expressive/Awkward,77
-Peralta,/Expressive/Business,80
 Peralta,/Expressive/Calm,43
 Peralta,/Expressive/Childlike,24
 Peralta,/Expressive/Excited,37
 Peralta,/Expressive/Innovative,15
 Peralta,/Expressive/Playful,20
-Peralta,/Expressive/Sincere,98
-Peralta,/Expressive/Vintage,73
 Peralta,/Theme/Wacky,80
 Permanent Marker,/Expressive/Active,73
 Permanent Marker,/Expressive/Awkward,76
@@ -6594,19 +6116,13 @@ Permanent Marker,/Expressive/Cute,25
 Permanent Marker,/Expressive/Excited,36
 Permanent Marker,/Expressive/Happy,12
 Permanent Marker,/Expressive/Innovative,32
-Permanent Marker,/Expressive/Playful,20
 Permanent Marker,/Expressive/Rugged,85
 Permanent Marker,/Script/Handwritten,100
 Permanent Marker,/Script/Informal,100
 Permanent Marker,/Theme/Brush,100
 Permanent Marker,/Theme/Distressed,30
-Petemoss,/Expressive/Active,73
 Petemoss,/Expressive/Artistic,99
-Petemoss,/Expressive/Awkward,76
-Petemoss,/Expressive/Excited,36
 Petemoss,/Expressive/Fancy,53
-Petemoss,/Expressive/Happy,12
-Petemoss,/Expressive/Innovative,32
 Petemoss,/Expressive/Loud,40
 Petemoss,/Expressive/Vintage,58
 Petemoss,/Script/Formal,80
@@ -6614,21 +6130,14 @@ Petit Formal Script,/Expressive/Artistic,79
 Petit Formal Script,/Expressive/Fancy,35
 Petit Formal Script,/Expressive/Loud,62
 Petit Formal Script,/Expressive/Sophisticated,86
-Petit Formal Script,/Expressive/Vintage,58
 Petit Formal Script,/Script/Formal,90
 Petrona,/Expressive/Business,59
 Petrona,/Expressive/Calm,99
-Petrona,/Expressive/Fancy,35
 Petrona,/Expressive/Sincere,80
-Petrona,/Expressive/Sophisticated,86
 Petrona,/Expressive/Stiff,30
 Petrona,/Expressive/Vintage,76
 Petrona,/Serif/Old Style Garalde,50
 Petrona,/Serif/Transitional,10
-Phetsarath,/Expressive/Business,59
-Phetsarath,/Expressive/Sincere,80
-Phetsarath,/Expressive/Stiff,30
-Phetsarath,/Expressive/Vintage,76
 Philosopher,/Expressive/Business,31
 Philosopher,/Expressive/Calm,66
 Philosopher,/Expressive/Happy,1
@@ -6643,31 +6152,22 @@ Phudu,/Sans/Humanist,40
 Piazzolla,/Expressive/Awkward,31
 Piazzolla,/Expressive/Business,57
 Piazzolla,/Expressive/Calm,98
-Piazzolla,/Expressive/Happy,2
 Piazzolla,/Expressive/Sincere,73
-Piazzolla,/Expressive/Stiff,30
-Piedra,/Expressive/Awkward,31
-Piedra,/Expressive/Business,57
 Piedra,/Expressive/Calm,59
 Piedra,/Expressive/Futuristic,21
 Piedra,/Expressive/Innovative,92
 Piedra,/Expressive/Rugged,89
-Piedra,/Expressive/Sincere,73
 Piedra,/Theme/Distressed,60
 Piedra,/Theme/Wacky,30
 Pinyon Script,/Expressive/Artistic,100
 Pinyon Script,/Expressive/Fancy,59
-Pinyon Script,/Expressive/Futuristic,21
-Pinyon Script,/Expressive/Innovative,92
 Pinyon Script,/Expressive/Loud,54
 Pinyon Script,/Expressive/Sophisticated,94
 Pinyon Script,/Expressive/Vintage,88
 Pinyon Script,/Script/Formal,100
 Pirata One,/Expressive/Artistic,80
 Pirata One,/Expressive/Calm,71
-Pirata One,/Expressive/Fancy,59
 Pirata One,/Expressive/Loud,78
-Pirata One,/Expressive/Sophisticated,94
 Pirata One,/Expressive/Stiff,61
 Pirata One,/Expressive/Vintage,93
 Pirata One,/Theme/Blackletter,100
@@ -6679,9 +6179,6 @@ Pixelify Sans,/Expressive/Stiff,76
 Pixelify Sans,/Expressive/Vintage,92
 Pixelify Sans,/Theme/Techno,100
 Plaster,/Expressive/Artistic,91
-Plaster,/Expressive/Awkward,93
-Plaster,/Expressive/Futuristic,96
-Plaster,/Expressive/Innovative,47
 Plaster,/Expressive/Loud,100
 Plaster,/Expressive/Rugged,100
 Plaster,/Expressive/Stiff,93
@@ -6693,22 +6190,17 @@ Play,/Expressive/Business,11
 Play,/Expressive/Calm,73
 Play,/Expressive/Futuristic,98
 Play,/Expressive/Stiff,97
-Play,/Expressive/Vintage,92
 Play,/Sans/Geometric,30
 Play,/Sans/Superellipse,90
 Playball,/Expressive/Artistic,65
-Playball,/Expressive/Business,11
-Playball,/Expressive/Futuristic,98
 Playball,/Expressive/Loud,74
 Playball,/Expressive/Sophisticated,74
-Playball,/Expressive/Stiff,97
 Playball,/Expressive/Vintage,49
 Playball,/Script/Formal,80
 Playfair,/Expressive/Business,79
 Playfair,/Expressive/Calm,95
 Playfair,/Expressive/Loud,78
 Playfair,/Expressive/Sincere,98
-Playfair,/Expressive/Sophisticated,74
 Playfair,/Expressive/Vintage,85
 Playfair,/Serif/Didone,100
 Playfair Display,/Expressive/Business,76
@@ -6724,38 +6216,28 @@ Playfair Display SC,/Expressive/Sincere,98
 Playfair Display SC,/Expressive/Vintage,83
 Playfair Display SC,/Serif/Didone,100
 Playpen Sans,/Expressive/Awkward,41
-Playpen Sans,/Expressive/Business,78
 Playpen Sans,/Expressive/Childlike,99
 Playpen Sans,/Expressive/Cute,43
 Playpen Sans,/Expressive/Playful,22
-Playpen Sans,/Expressive/Sincere,98
-Playpen Sans,/Expressive/Vintage,83
 Playpen Sans,/Script/Handwritten,100
 Playpen Sans,/Script/Informal,100
-Plus Jakarta Sans,/Expressive/Awkward,41
 Plus Jakarta Sans,/Expressive/Business,55
 Plus Jakarta Sans,/Expressive/Calm,99
-Plus Jakarta Sans,/Expressive/Playful,22
 Plus Jakarta Sans,/Expressive/Stiff,71
 Plus Jakarta Sans,/Sans/Geometric,100
-Podkova,/Expressive/Business,55
 Podkova,/Expressive/Calm,93
 Podkova,/Expressive/Happy,32
 Podkova,/Expressive/Sincere,9
-Podkova,/Expressive/Stiff,71
 Podkova,/Slab/Humanist,30
 PoetsenOne,/Expressive/Calm,27
 PoetsenOne,/Expressive/Childlike,70
 PoetsenOne,/Expressive/Cute,33
-PoetsenOne,/Expressive/Happy,32
 PoetsenOne,/Expressive/Playful,51
-PoetsenOne,/Expressive/Sincere,9
 PoetsenOne,/Sans/Humanist,50
 PoetsenOne,/Sans/Neo Grotesque,30
 PoetsenOne,/Sans/Rounded,60
 Poiret One,/Expressive/Business,41
 Poiret One,/Expressive/Calm,93
-Poiret One,/Expressive/Playful,51
 Poiret One,/Expressive/Stiff,62
 Poiret One,/Sans/Geometric,100
 Poller One,/Expressive/Business,41
@@ -6768,35 +6250,24 @@ Poltawski Nowy,/Expressive/Business,29
 Poltawski Nowy,/Expressive/Calm,95
 Poltawski Nowy,/Expressive/Innovative,11
 Poltawski Nowy,/Expressive/Sincere,63
-Poltawski Nowy,/Expressive/Stiff,40
 Poltawski Nowy,/Expressive/Vintage,92
 Poltawski Nowy,/Serif/Didone,30
 Poltawski Nowy,/Serif/Modern,30
 Poly,/Expressive/Business,80
 Poly,/Expressive/Calm,98
-Poly,/Expressive/Innovative,11
 Poly,/Expressive/Sincere,81
 Poly,/Expressive/Vintage,78
 Poly,/Serif/Transitional,60
 Pompiere,/Expressive/Awkward,41
-Pompiere,/Expressive/Business,80
 Pompiere,/Expressive/Calm,92
 Pompiere,/Expressive/Childlike,26
 Pompiere,/Expressive/Competent,34
 Pompiere,/Expressive/Happy,15
 Pompiere,/Expressive/Innovative,11
 Pompiere,/Expressive/Playful,51
-Pompiere,/Expressive/Sincere,81
 Pompiere,/Expressive/Stiff,40
-Pompiere,/Expressive/Vintage,78
 Pompiere,/Theme/Blobby,1
 Pompiere,/Theme/Brush,20
-Ponnala,/Expressive/Awkward,41
-Ponnala,/Expressive/Competent,34
-Ponnala,/Expressive/Happy,15
-Ponnala,/Expressive/Innovative,11
-Ponnala,/Expressive/Playful,51
-Ponnala,/Expressive/Stiff,40
 Ponnala,/Indic/Sign Painting,100
 Ponnala,/Indic/Traditional,100
 Pontano Sans,/Expressive/Calm,98
@@ -6806,19 +6277,13 @@ Pontano Sans,/Sans/Neo Grotesque,100
 Poor Story,/Expressive/Awkward,95
 Poor Story,/Expressive/Calm,61
 Poor Story,/Expressive/Childlike,53
-Poor Story,/Expressive/Competent,38
 Poor Story,/Expressive/Excited,75
 Poor Story,/Expressive/Innovative,11
 Poor Story,/Expressive/Playful,28
-Poor Story,/Expressive/Stiff,72
 Poor Story,/Theme/Distressed,10
 Poor Story,/Theme/Wacky,80
-Poppins,/Expressive/Awkward,95
 Poppins,/Expressive/Business,54
 Poppins,/Expressive/Calm,100
-Poppins,/Expressive/Excited,75
-Poppins,/Expressive/Innovative,11
-Poppins,/Expressive/Playful,28
 Poppins,/Expressive/Stiff,71
 Poppins,/Expressive/Vintage,79
 Poppins,/Indic/Low contrast,100
@@ -6853,21 +6318,15 @@ Potta One,/Expressive/Calm,61
 Potta One,/Expressive/Innovative,14
 Potta One,/Expressive/Playful,58
 Potta One,/Expressive/Rugged,13
-Potta One,/Expressive/Stiff,92
 Potta One,/Theme/Blobby,90
 Potta One,/Theme/Distressed,20
 Potta One,/Theme/Wacky,20
-Pragati Narrow,/Expressive/Awkward,95
 Pragati Narrow,/Expressive/Business,19
 Pragati Narrow,/Expressive/Calm,99
 Pragati Narrow,/Expressive/Competent,68
-Pragati Narrow,/Expressive/Innovative,14
-Pragati Narrow,/Expressive/Playful,58
 Pragati Narrow,/Indic/Low contrast,100
 Pragati Narrow,/Sans/Grotesque,70
 Praise,/Expressive/Artistic,97
-Praise,/Expressive/Business,19
-Praise,/Expressive/Competent,68
 Praise,/Script/Formal,70
 Prata,/Expressive/Business,27
 Prata,/Expressive/Calm,98
@@ -6876,107 +6335,77 @@ Prata,/Expressive/Sincere,86
 Prata,/Expressive/Vintage,79
 Prata,/Serif/Didone,100
 Preahvihear,/Expressive/Awkward,71
-Preahvihear,/Expressive/Business,27
 Preahvihear,/Expressive/Calm,81
 Preahvihear,/Expressive/Childlike,43
 Preahvihear,/Expressive/Excited,44
 Preahvihear,/Expressive/Playful,22
-Preahvihear,/Expressive/Sincere,86
-Preahvihear,/Expressive/Vintage,79
 Preahvihear,"/South East Asian (Thai, Khmer, Lao)/Chrieng (Khmer)",100
 Preahvihear,/Theme/Wacky,20
 Press Start 2P,/Expressive/Artistic,47
 Press Start 2P,/Expressive/Awkward,51
 Press Start 2P,/Expressive/Calm,45
-Press Start 2P,/Expressive/Excited,44
 Press Start 2P,/Expressive/Futuristic,78
 Press Start 2P,/Expressive/Innovative,64
-Press Start 2P,/Expressive/Playful,22
 Press Start 2P,/Expressive/Vintage,92
 Press Start 2P,/Theme/Techno,100
-Pridi,/Expressive/Awkward,51
 Pridi,/Expressive/Business,46
 Pridi,/Expressive/Calm,97
-Pridi,/Expressive/Futuristic,78
-Pridi,/Expressive/Innovative,64
 Pridi,/Expressive/Sincere,71
 Pridi,/Expressive/Stiff,51
 Pridi,/Expressive/Vintage,87
 Pridi,/Serif/Modern,50
 Pridi,/Slab/Clarendon,100
 Princess Sofia,/Expressive/Artistic,19
-Princess Sofia,/Expressive/Business,46
 Princess Sofia,/Expressive/Childlike,68
 Princess Sofia,/Expressive/Excited,72
 Princess Sofia,/Expressive/Fancy,25
 Princess Sofia,/Expressive/Happy,20
 Princess Sofia,/Expressive/Innovative,64
-Princess Sofia,/Expressive/Sincere,71
-Princess Sofia,/Expressive/Stiff,50
-Princess Sofia,/Expressive/Vintage,87
 Princess Sofia,/Script/Informal,100
 Princess Sofia,/Theme/Wacky,80
 Prociono,/Expressive/Business,42
 Prociono,/Expressive/Calm,95
-Prociono,/Expressive/Excited,72
-Prociono,/Expressive/Fancy,25
-Prociono,/Expressive/Happy,20
-Prociono,/Expressive/Innovative,64
 Prociono,/Expressive/Sincere,81
 Prociono,/Expressive/Stiff,40
 Prociono,/Expressive/Vintage,92
 Prompt,/Expressive/Business,45
 Prompt,/Expressive/Calm,99
 Prompt,/Expressive/Competent,21
-Prompt,/Expressive/Sincere,81
 Prompt,/Expressive/Stiff,40
-Prompt,/Expressive/Vintage,92
 Prompt,/Sans/Geometric,50
 Prompt,/Sans/Neo Grotesque,50
 Prompt,"/South East Asian (Thai, Khmer, Lao)/Loopless",100
-Prosto One,/Expressive/Business,45
 Prosto One,/Expressive/Calm,65
-Prosto One,/Expressive/Competent,21
 Prosto One,/Expressive/Futuristic,89
 Prosto One,/Expressive/Loud,55
 Prosto One,/Expressive/Stiff,83
 Prosto One,/Theme/Techno,100
 Proza Libre,/Expressive/Business,69
 Proza Libre,/Expressive/Calm,97
-Proza Libre,/Expressive/Futuristic,89
 Proza Libre,/Expressive/Stiff,40
 Proza Libre,/Expressive/Vintage,55
 Proza Libre,/Sans/Humanist,100
 Public Sans,/Expressive/Business,76
 Public Sans,/Expressive/Calm,99
-Public Sans,/Expressive/Sincere,100
 Public Sans,/Expressive/Stiff,72
 Public Sans,/Expressive/Vintage,92
 Public Sans,/Sans/Grotesque,100
 Puppies Play,/Expressive/Artistic,50
-Puppies Play,/Expressive/Business,76
 Puppies Play,/Expressive/Cute,54
 Puppies Play,/Expressive/Fancy,80
 Puppies Play,/Expressive/Innovative,32
 Puppies Play,/Expressive/Loud,33
-Puppies Play,/Expressive/Stiff,72
-Puppies Play,/Expressive/Vintage,92
 Puppies Play,/Script/Informal,100
 Puritan,/Expressive/Business,13
 Puritan,/Expressive/Calm,98
-Puritan,/Expressive/Fancy,80
-Puritan,/Expressive/Innovative,32
 Puritan,/Expressive/Stiff,81
 Puritan,/Expressive/Vintage,44
 Puritan,/Sans/Grotesque,100
-Purple Purse,/Expressive/Business,13
 Purple Purse,/Expressive/Calm,63
 Purple Purse,/Expressive/Innovative,41
 Purple Purse,/Expressive/Loud,90
 Purple Purse,/Expressive/Playful,32
 Purple Purse,/Expressive/Rugged,43
-Purple Purse,/Expressive/Stiff,81
-Purple Purse,/Expressive/Vintage,44
 Purple Purse,/Serif/Didone,50
 Purple Purse,/Theme/Distressed,40
 Purple Purse,/Theme/Wacky,20
@@ -7147,19 +6576,14 @@ Red Hat Display,/Expressive/Calm,100
 Red Hat Display,/Expressive/Competent,52
 Red Hat Display,/Sans/Geometric,90
 Red Hat Display,/Sans/Humanist,10
-Red Hat Mono,/Expressive/Business,71
 Red Hat Mono,/Expressive/Calm,75
 Red Hat Mono,/Expressive/Competent,91
-Red Hat Mono,/Expressive/Futuristic,72
-Red Hat Mono,/Expressive/Stiff,81
 Red Hat Mono,/Expressive/Vintage,36
 Red Hat Mono,/Sans/Geometric,60
 Red Hat Mono,/Sans/Humanist,10
 Red Hat Mono,/Slab/Geometric,20
 Red Hat Text,/Expressive/Calm,100
 Red Hat Text,/Expressive/Competent,52
-Red Hat Text,/Expressive/Innovative,100
-Red Hat Text,/Expressive/Stiff,100
 Red Hat Text,/Sans/Geometric,80
 Red Hat Text,/Sans/Humanist,20
 Red Rose,/Expressive/Business,71
@@ -7169,16 +6593,13 @@ Red Rose,/Expressive/Futuristic,72
 Red Rose,/Expressive/Stiff,81
 Red Rose,/Expressive/Vintage,92
 Red Rose,/Sans/Glyphic,100
-Redacted,/Expressive/Competent,52
 Redacted,/Expressive/Innovative,100
 Redacted,/Expressive/Rugged,99
 Redacted,/Expressive/Stiff,100
 Redacted,/Not text/Symbols,100
 Redacted Script,/Expressive/Active,93
-Redacted Script,/Expressive/Competent,91
 Redacted Script,/Expressive/Innovative,100
 Redacted Script,/Expressive/Playful,60
-Redacted Script,/Expressive/Vintage,36
 Redacted Script,/Not text/Symbols,100
 Redacted Script,/Script/Handwritten,50
 Redacted Script,/Script/Informal,50
@@ -7196,9 +6617,6 @@ Reddit Sans Condensed,/Expressive/Business,40
 Reddit Sans Condensed,/Expressive/Competent,70
 Reddit Sans Condensed,/Sans/Geometric,50
 Reddit Sans Condensed,/Sans/Humanist,50
-Redressed,/Expressive/Active,93
-Redressed,/Expressive/Innovative,100
-Redressed,/Expressive/Playful,60
 Redressed,/Expressive/Stiff,10
 Redressed,/Expressive/Vintage,77
 Redressed,/Script/Upright Script,100
@@ -7259,7 +6677,6 @@ Ribeye,/Expressive/Childlike,32
 Ribeye,/Expressive/Excited,46
 Ribeye,/Expressive/Futuristic,18
 Ribeye,/Expressive/Loud,87
-Ribeye,/Expressive/Stiff,70
 Ribeye,/Theme/Art Deco,10
 Ribeye,/Theme/Wacky,10
 Ribeye Marrow,/Expressive/Awkward,92
@@ -7268,7 +6685,6 @@ Ribeye Marrow,/Expressive/Excited,46
 Ribeye Marrow,/Expressive/Futuristic,25
 Ribeye Marrow,/Expressive/Innovative,63
 Ribeye Marrow,/Expressive/Loud,80
-Ribeye Marrow,/Expressive/Stiff,70
 Ribeye Marrow,/Theme/Art Deco,10
 Ribeye Marrow,/Theme/Inline,20
 Ribeye Marrow,/Theme/Wacky,10
@@ -7342,17 +6758,13 @@ Rock 3D,/Theme/Wacky,50
 Rock Salt,/Expressive/Artistic,21
 Rock Salt,/Expressive/Awkward,41
 Rock Salt,/Expressive/Excited,58
-Rock Salt,/Expressive/Happy,43
 Rock Salt,/Expressive/Innovative,41
-Rock Salt,/Expressive/Playful,27
 Rock Salt,/Expressive/Rugged,36
 Rock Salt,/Script/Handwritten,100
 Rock Salt,/Script/Informal,100
 RocknRoll One,/Expressive/Awkward,51
 RocknRoll One,/Expressive/Calm,66
-RocknRoll One,/Expressive/Excited,58
 RocknRoll One,/Expressive/Happy,43
-RocknRoll One,/Expressive/Innovative,41
 RocknRoll One,/Expressive/Playful,27
 RocknRoll One,/Expressive/Rugged,1
 RocknRoll One,/Sans/Grotesque,50
@@ -7442,7 +6854,6 @@ Rubik Burned,/Expressive/Excited,95
 Rubik Burned,/Expressive/Innovative,99
 Rubik Burned,/Expressive/Playful,70
 Rubik Burned,/Expressive/Rugged,100
-Rubik Burned,/Expressive/Stiff,50
 Rubik Burned,/Theme/Distressed,90
 Rubik Burned,/Theme/Wacky,50
 Rubik Dirt,/Expressive/Excited,19
@@ -7530,7 +6941,6 @@ Rubik Puddles,/Expressive/Excited,88
 Rubik Puddles,/Expressive/Innovative,99
 Rubik Puddles,/Expressive/Playful,100
 Rubik Puddles,/Expressive/Rugged,86
-Rubik Puddles,/Expressive/Stiff,70
 Rubik Puddles,/Theme/Wacky,90
 Rubik Spray Paint,/Expressive/Awkward,73
 Rubik Spray Paint,/Expressive/Excited,95
@@ -7754,7 +7164,6 @@ Satisfy,/Script/Handwritten,40
 Satisfy,/Script/Informal,70
 Sawarabi Mincho,/Expressive/Calm,91
 Sawarabi Mincho,/Expressive/Sincere,43
-Sawarabi Mincho,/Expressive/Stiff,70
 Sawarabi Mincho,/Expressive/Vintage,91
 Sawarabi Mincho,/Serif/Old Style Garalde,50
 Scada,/Expressive/Calm,98
@@ -8214,7 +7623,6 @@ Source Serif 4,/Expressive/Business,99
 Source Serif 4,/Expressive/Calm,98
 Source Serif 4,/Expressive/Loud,62
 Source Serif 4,/Expressive/Sincere,100
-Source Serif 4,/Expressive/Stiff,70
 Source Serif 4,/Expressive/Vintage,49
 Source Serif 4,/Serif/Transitional,100
 Space Grotesk,/Expressive/Business,81
@@ -8239,7 +7647,6 @@ Special Elite,/Expressive/Excited,22
 Special Elite,/Expressive/Innovative,83
 Special Elite,/Expressive/Rugged,98
 Special Elite,/Expressive/Sincere,15
-Special Elite,/Expressive/Stiff,70
 Special Elite,/Expressive/Vintage,91
 Special Elite,/Slab/Clarendon,100
 Special Elite,/Theme/Distressed,100
@@ -8533,8 +7940,12 @@ Syne Tactile,/Expressive/Playful,12
 Syne Tactile,/Expressive/Rugged,80
 Syne Tactile,/Theme/Distressed,50
 Syne Tactile,/Theme/Wacky,30
+Tac One,/Expressive/Artistic,70
+Tac One,/Expressive/Calm,50
 Tac One,/Expressive/Excited,30
 Tac One,/Expressive/Innovative,50
+Tac One,/Expressive/Loud,75
+Tac One,/Expressive/Rugged,60
 Tac One,/Expressive/Vintage,40
 Tac One,/Theme/Brush,70
 Tai Heritage Pro,/Expressive/Business,99
@@ -9341,7 +8752,6 @@ Yrsa,/Serif/Transitional,100
 Ysabeau,/Expressive/Business,94
 Ysabeau,/Expressive/Calm,93
 Ysabeau,/Expressive/Competent,52
-Ysabeau,/Expressive/Fancy,3
 Ysabeau,/Expressive/Stiff,51
 Ysabeau,/Expressive/Vintage,82
 Ysabeau,/Sans/Humanist,100
@@ -9361,7 +8771,6 @@ Ysabeau Office,/Sans/Humanist,100
 Ysabeau SC,/Expressive/Business,94
 Ysabeau SC,/Expressive/Calm,93
 Ysabeau SC,/Expressive/Competent,52
-Ysabeau SC,/Expressive/Fancy,3
 Ysabeau SC,/Expressive/Stiff,51
 Ysabeau SC,/Expressive/Vintage,82
 Ysabeau SC,/Sans/Humanist,100
@@ -9424,7 +8833,6 @@ ZCOOL QingKe HuangYou,/Sans/Superellipse,40
 ZCOOL QingKe HuangYou,/Theme/Blobby,10
 ZCOOL QingKe HuangYou,/Theme/Techno,40
 ZCOOL XiaoWei,/Expressive/Calm,92
-ZCOOL XiaoWei,/Expressive/Fancy,1
 ZCOOL XiaoWei,/Expressive/Happy,13
 ZCOOL XiaoWei,/Expressive/Loud,69
 ZCOOL XiaoWei,/Expressive/Stiff,50


### PR DESCRIPTION
My previous attempt in #7971 still included some incorrect expressive tags from the source sheet. When I was importing Kalapi's data, I forgot to add 0s to the empty cells so the original bad values were retained.