### PR TITLE
Touch Sixtyfour Convergence metadata file to get it to repush.

### DIFF
--- a/ofl/sixtyfourconvergence/METADATA.pb
+++ b/ofl/sixtyfourconvergence/METADATA.pb
@@ -19,7 +19,7 @@ subsets: "menu"
 subsets: "symbols"
 axes {
   tag: "BLED"
-  min_value: 0.0
+  min_value: 0.00
   max_value: 100.0
 }
 axes {


### PR DESCRIPTION
To get subsetter fix: https://github.com/harfbuzz/harfbuzz/pull/4831.

For #7545