### PR TITLE
tags.html: add Open PR button

### DIFF
--- a/.ci/tags.html
+++ b/.ci/tags.html
@@ -13,8 +13,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <h1>Google Fonts Tagger</h1>
-    <p>When you're done editing, please save the csv and open a pull request in the Google Fonts repo that replaces the <a href="https://github.com/google/fonts/blob/main/tags/all/families.csv">families.csv</a> file.</p>
-
 
     <div id="panel">
       <div class="panel-tile">
@@ -36,6 +34,7 @@
       </div>
       <div class="panel-tile">
         <button @click="saveCSV">Save CSV</button>
+        <button @click="prCSV">Open Pull Request</button>
       </div>
       <div v-if="isEdited" id="edited-panel">Edited</div>
     </div>
@@ -134,6 +133,19 @@
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
+      },
+      prCSV() {
+        this.Families = this.Families.filter((t) => t.Family !== "");
+        console.log(this.Families);
+        let csv = Papa.unparse(this.Families,
+          {
+            columns: ["Family", "Group/Tag", "Weight"],
+            skipEmptyLines: true,
+          }
+        );
+        alert("Tag data copied to clipboard. A github pull request page will open in a new tab. Please remove the old data and paste in the new.");
+        navigator.clipboard.writeText(csv);
+        window.open("https://github.com/google/fonts/edit/main/tags/all/families.csv")
       },
       loadCSV() {
         const csvFilePath = 'https://raw.githubusercontent.com/google/fonts/main/tags/all/families.csv'; // Update this path to your CSV file


### PR DESCRIPTION
This PR adds the ability to open a PR from GF Tagger. It doesn't use any fancy auth. Instead it'll just copy the data to the clipboard and open up a Github edit window on the families.csv file.

<img width="1532" alt="Screenshot 2024-08-15 at 13 34 41" src="https://github.com/user-attachments/assets/468ca841-eb74-4a3a-80ad-c210fd9c78aa">

<img width="1532" alt="Screenshot 2024-08-15 at 13 34 48" src="https://github.com/user-attachments/assets/6f79b47d-b913-4d86-b4ba-cc423241e1c7">

<img width="1532" alt="Screenshot 2024-08-15 at 13 34 57" src="https://github.com/user-attachments/assets/047add37-2bf6-46f7-aa9d-f7259ea488b1">

<img width="1532" alt="Screenshot 2024-08-15 at 13 35 13" src="https://github.com/user-attachments/assets/25a68e65-ba2f-47f7-9e5e-92ed0cae2806">



@vv-monsalve 