### PR TITLE
Noto Serif JP: Version 2.003-H1;hotconv 1.1.1;makeotfexe 2.6.0 added



### DIFF
--- a/ofl/notoserifjp/METADATA.pb
+++ b/ofl/notoserifjp/METADATA.pb
@@ -10,7 +10,7 @@ fonts {
   filename: "NotoSerifJP[wght].ttf"
   post_script_name: "NotoSerifJP-ExtraLight"
   full_name: "Noto Serif JP ExtraLight"
-  copyright: "(c) 2017-2023 Adobe (http://www.adobe.com/)."
+  copyright: "(c) 2017-2024 Adobe (http://www.adobe.com/)."
 }
 subsets: "cyrillic"
 subsets: "japanese"
@@ -22,6 +22,15 @@ axes {
   tag: "wght"
   min_value: 200.0
   max_value: 900.0
+}
+source {
+  repository_url: "https://www.github.com/notofonts/noto-cjk"
+  commit: "985fa52c81c1d6692ccdd82bc3656e8fb932fd89"
+  files {
+    source_file: "google-fonts/NotoSerifJP[wght].ttf"
+    dest_file: "NotoSerifJP[wght].ttf"
+  }
+  branch: "main"
 }
 is_noto: true
 languages: "ain_Kana"  # Ainu


### PR DESCRIPTION
Taken from the upstream repo https://www.github.com/notofonts/noto-cjk at commit https://www.github.com/notofonts/noto-cjk/commit/985fa52c81c1d6692ccdd82bc3656e8fb932fd89.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] `minisite_url` definition in the METADATA.pb file for commissioned projects
- [ ] `primary_script` definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [x] `subsets` definitions in the METADATA.pb reflect the actual subsets and languages present in the font files (in alphabetic order). For **CJK fonts**, only include one of the following subsets `chinese-hongkong`, `chinese-simplified`, `chinese-traditional`, `korean`, `japanese`.
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
