### PR TITLE
Noto Serif SC: Version 2.003-H1;hotconv 1.1.1;makeotfexe 2.6.0 added



### DIFF
--- a/ofl/notoserifsc/METADATA.pb
+++ b/ofl/notoserifsc/METADATA.pb
@@ -10,7 +10,7 @@ fonts {
   filename: "NotoSerifSC[wght].ttf"
   post_script_name: "NotoSerifSC-ExtraLight"
   full_name: "Noto Serif SC ExtraLight"
-  copyright: "(c) 2017-2023 Adobe (http://www.adobe.com/)."
+  copyright: "(c) 2017-2024 Adobe (http://www.adobe.com/)."
 }
 subsets: "chinese-simplified"
 subsets: "cyrillic"
@@ -23,17 +23,25 @@ axes {
   min_value: 200.0
   max_value: 900.0
 }
+source {
+  repository_url: "https://www.github.com/notofonts/noto-cjk"
+  commit: "985fa52c81c1d6692ccdd82bc3656e8fb932fd89"
+  files {
+    source_file: "google-fonts/NotoSerifSC[wght].ttf"
+    dest_file: "NotoSerifSC[wght].ttf"
+  }
+  branch: "main"
+}
 is_noto: true
-languages: "cjy_Hans"  # Chinese, Jinyu
-languages: "gan_Hans"  # Gan Chinese
-languages: "hak_Hans"  # Hakka Chinese, Simplified
-languages: "hsn_Hans"  # Xiang Chinese
-languages: "lzh_Hans"  # Literary Chinese, Simplified
-languages: "nan_Hans"  # Min Nan Chinese, Simplified
-languages: "wuu_Hans"  # Wu Chinese
-languages: "yue_Hans"  # Cantonese
-languages: "za_Hans"   # Zhuang, Simplified Han
-languages: "zh_Hans"   # Chinese (Simplified)
+languages: "cjy_Hans"  # Jin Chinese (Simplified)
+languages: "gan_Hans"  # Gan Chinese (Simplified)
+languages: "hak_Hans"  # Hakka Chinese (Simplified)
+languages: "hsn_Hans"  # Xiang Chinese (Simplified)
+languages: "lzh_Hans"  # Literary Chinese (Simplified)
+languages: "nan_Hans"  # Southern Min Chinese (Simplified)
+languages: "wuu_Hans"  # Wu Chinese (Simplified)
+languages: "yue_Hans"  # Yue Chinese (Simplified)
+languages: "za_Hans"  # Zhuang, Simplified Han
+languages: "zh_Hans"  # Simplified Chinese
 display_name: "Noto Serif Simplified Chinese"
 primary_script: "Hans"
-primary_language: "zh_Hans"


### PR DESCRIPTION
Taken from the upstream repo https://www.github.com/notofonts/noto-cjk at commit https://www.github.com/notofonts/noto-cjk/commit/985fa52c81c1d6692ccdd82bc3656e8fb932fd89.
## PR Checklist:

- [x] Family categorization tags collected from the type design team with the Categories Form
- [ ] `minisite_url` definition in the METADATA.pb file for commissioned projects
- [ ] `primary_script` definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] `subsets` definitions in the METADATA.pb reflect the actual subsets and languages present in the font files (in alphabetic order). For **CJK fonts**, only include one of the following subsets `chinese-hongkong`, `chinese-simplified`, `chinese-traditional`, `korean`, `japanese`.
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
