### PR TITLE
Update fasthand, taprom and seaweedscript credits

### DIFF
--- a/ofl/fasthand/DESCRIPTION.en_us.html
+++ b/ofl/fasthand/DESCRIPTION.en_us.html
@@ -1,6 +1,8 @@
 <p>
-Fasthand is a Khmer font for body text. The design is inspired by a popular style of Khmer handwriting letterforms that are written quickly.
+Fasthand is a Khmer font for body text.
+The Khmer design is inspired by a popular style of Khmer handwriting letterforms that are written quickly.
+The Latin design is a copy of <a href="https://fonts.google.com/specimen/Seaweed+Script">Seaweed Script</a>, by Neapolitan.
 </p>
 <p>
-To contribute, see <a href="https://github.com/danhhong/Fasthand">github.com/danhhong/Fasthand</a>.
+To contribute, see <a href="https://github.com/danhhong/Fasthand">github.com/danhhong/Fasthand</a>
 </p>

--- a/ofl/fasthand/METADATA.pb
+++ b/ofl/fasthand/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Fasthand"
-designer: "Danh Hong"
+designer: "Danh Hong, Neapolitan"
 license: "OFL"
 category: "DISPLAY"
 date_added: "2012-05-24"

--- a/ofl/seaweedscript/DESCRIPTION.en_us.html
+++ b/ofl/seaweedscript/DESCRIPTION.en_us.html
@@ -1,1 +1,9 @@
-<p>Hear that? That's the sound of tropical ocean breezes as they whistle gently through your laptop! Grab a mai-tai, a hammock under a swaying palm tree and let your hair down as your fingers gently caress the keyboard just like seaweed! Enjoy Seaweed Script when a rustic tropical beachside script is called for and watch out for Squid!</p> <p>Designed by Dave 'Squid' Cohen of Neapolitan (a DBA of Font Diner, Inc.) To contribute to the project, contact the <a href="mailto:support@fontdiner.com">Font Diner</a>.</p>
+<p>
+Hear that?
+That's the sound of tropical ocean breezes as they whistle gently through your laptop!
+Grab a drink, a hammock under a swaying palm tree and let your hair down as your fingers gently caress the keyboard just like seaweed!
+Enjoy Seaweed Script when a rustic tropical beachside script is called for and watch out for squid!
+</p>
+<p>
+Designed by Dave 'Squid' Cohen of Neapolitan, a Font Diner brand.
+</p>

--- a/ofl/taprom/DESCRIPTION.en_us.html
+++ b/ofl/taprom/DESCRIPTION.en_us.html
@@ -1,5 +1,7 @@
 <p>
-Taprom is a Khmer font for body text. The design is inspired by a popular style of Khmer handwriting letterforms.
+Taprom is a Khmer font for body text.
+The Khmer design is inspired by a popular style of Khmer handwriting letterforms.
+The Latin design is a copy of <a href="https://fonts.google.com/specimen/Seaweed+Script">Seaweed Script</a>, by Neapolitan.
 </p>
 <p>
 To contribute, see <a href="https://github.com/danhhong/Taprom">github.com/danhhong/Taprom</a>.

--- a/ofl/taprom/METADATA.pb
+++ b/ofl/taprom/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Taprom"
-designer: "Danh Hong"
+designer: "Danh Hong, Neapolitan"
 license: "OFL"
 category: "DISPLAY"
 date_added: "2011-03-02"


### PR DESCRIPTION
A user wrote in,

> Fasthand and Taprom appear to be the exact same font released by the same author under different names, so I just wanted to double check if there's a difference between the two that may not be obvious to me.

These changes should help reduce confusion about this.