### PR TITLE
[Font Category Tagginh] Updates to data for Business, Competent, Sincere, and Stiff

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -8,36 +8,44 @@ Abel,/Sans/Geometric,40
 Abel,/Sans/Humanist,10
 Abel,/Sans/Neo Grotesque,40
 Abhaya Libre,/Expressive/Business,20
-Abhaya Libre,/Expressive/Sincere,97
+Abhaya Libre,/Expressive/Vintage,57.8
 Abhaya Libre,/Serif/Modern,70
 Abhaya Libre,/Serif/Transitional,10
 Abhaya Libre,/Sinhala/Traditional,100
 Aboreto,/Expressive/Competent,32
+Aboreto,/Expressive/Loud,53
+Aboreto,/Expressive/Vintage,89.5
 Aboreto,/Sans/Glyphic,50
 Aboreto,/Sans/Humanist,70
-Abril Fatface,/Expressive/Business,30
+Abril Fatface,/Expressive/Competent,97.9
+Abril Fatface,/Expressive/Loud,82
 Abril Fatface,/Expressive/Sincere,97
+Abril Fatface,/Expressive/Vintage,74
 Abril Fatface,/Serif/Fat Face,90
 Abril Fatface,/Serif/Modern,90
 Abyssinica SIL,/Expressive/Business,48
-Abyssinica SIL,/Expressive/Sincere,98
+Abyssinica SIL,/Expressive/Vintage,82.5
 Abyssinica SIL,/Sans/Humanist,50
 Abyssinica SIL,/Serif/Old Style Garalde,10
 Aclonica,/Expressive/Artistic,1
 Aclonica,/Expressive/Calm,18
+Aclonica,/Expressive/Loud,57
 Aclonica,/Sans/Humanist,10
 Aclonica,/Theme/Techno,20
 Acme,/Expressive/Calm,64
 Acme,/Expressive/Competent,14
 Acme,/Expressive/Cute,14
 Acme,/Expressive/Excited,11
+Acme,/Expressive/Loud,47
+Acme,/Expressive/Vintage,37.8
 Acme,/Sans/Glyphic,50
 Acme,/Sans/Humanist,50
 Acme,/Theme/Wacky,20
 Actor,/Expressive/Calm,98
 Actor,/Sans/Humanist,70
 Adamina,/Expressive/Business,46
-Adamina,/Expressive/Sincere,100
+Adamina,/Expressive/Sincere,93
+Adamina,/Expressive/Vintage,71.7
 Adamina,/Serif/Old Style Garalde,80
 ADLaM Display,/Expressive/Artistic,31
 ADLaM Display,/Expressive/Calm,78
@@ -46,18 +54,18 @@ ADLaM Display,/Sans/Rounded,20
 ADLaM Display,/Theme/Wacky,20
 Adobe Blank,/Monospace/Monospace,100
 Advent Pro,/Expressive/Calm,54
-Advent Pro,/Expressive/Competent,27
 Advent Pro,/Expressive/Playful,31
 Advent Pro,/Sans/Humanist,40
 Advent Pro,/Theme/Wacky,10
 Agdasima,/Expressive/Business,27
 Agdasima,/Expressive/Calm,99
-Agdasima,/Expressive/Competent,68
 Agdasima,/Sans/Humanist,60
 Agdasima,/Theme/Techno,30
 Aguafina Script,/Expressive/Artistic,79
 Aguafina Script,/Expressive/Fancy,66
+Aguafina Script,/Expressive/Loud,65
 Aguafina Script,/Expressive/Sophisticated,79
+Aguafina Script,/Expressive/Vintage,77.3
 Aguafina Script,/Script/Formal,50
 Aguafina Script,/Script/Handwritten,10
 Aguafina Script,/Script/Informal,20
@@ -67,7 +75,10 @@ Akaya Kanadaka,/Expressive/Artistic,42
 Akaya Kanadaka,/Expressive/Awkward,47
 Akaya Kanadaka,/Expressive/Childlike,40
 Akaya Kanadaka,/Expressive/Cute,60
+Akaya Kanadaka,/Expressive/Loud,48
 Akaya Kanadaka,/Expressive/Playful,14
+Akaya Kanadaka,/Expressive/Sincere,96
+Akaya Kanadaka,/Expressive/Vintage,27.6
 Akaya Kanadaka,/Indic/Sign Painting,100
 Akaya Kanadaka,/Sans/Humanist,50
 Akaya Kanadaka,/Sans/Rounded,50
@@ -77,7 +88,10 @@ Akaya Telivigala,/Expressive/Artistic,42
 Akaya Telivigala,/Expressive/Awkward,47
 Akaya Telivigala,/Expressive/Childlike,40
 Akaya Telivigala,/Expressive/Cute,60
+Akaya Telivigala,/Expressive/Loud,48
 Akaya Telivigala,/Expressive/Playful,14
+Akaya Telivigala,/Expressive/Sincere,96
+Akaya Telivigala,/Expressive/Vintage,27.6
 Akaya Telivigala,/Indic/Sign Painting,100
 Akaya Telivigala,/Sans/Humanist,50
 Akaya Telivigala,/Sans/Rounded,50
@@ -88,14 +102,16 @@ Akronim,/Expressive/Excited,60
 Akronim,/Expressive/Innovative,97
 Akronim,/Theme/Shaded,50
 Akshar,/Expressive/Calm,99
-Akshar,/Expressive/Competent,68
+Akshar,/Expressive/Competent,88.8
 Akshar,/Indic/Low contrast,100
 Akshar,/Sans/Geometric,20
 Akshar,/Sans/Humanist,50
 Aladin,/Expressive/Artistic,14
 Aladin,/Expressive/Awkward,46
 Aladin,/Expressive/Happy,19
+Aladin,/Expressive/Loud,25
 Aladin,/Expressive/Playful,34
+Aladin,/Expressive/Vintage,88
 Aladin,/Theme/Art Nouveau,70
 Alata,/Expressive/Calm,98
 Alata,/Sans/Geometric,80
@@ -107,57 +123,76 @@ Albert Sans,/Expressive/Calm,97
 Albert Sans,/Sans/Geometric,60
 Aldrich,/Expressive/Calm,98
 Aldrich,/Expressive/Futuristic,98
-Aldrich,/Expressive/Stiff,100
 Aldrich,/Sans/Geometric,50
 Aldrich,/Sans/Grotesque,10
 Aldrich,/Sans/Superellipse,25
 Aldrich,/Theme/Techno,10
+Aldrich,/Expressive/Stiff,100
 Alef,/Expressive/Calm,97
 Alef,/Sans/Humanist,50
-Alegreya,/Expressive/Business,60
+Alegreya,/Expressive/Business,66.2
+Alegreya,/Expressive/Competent,97.7
+Alegreya,/Expressive/Loud,49
 Alegreya,/Expressive/Sincere,99
-Alegreya Sans,/Expressive/Business,38
-Alegreya Sans,/Expressive/Calm,93
-Alegreya Sans,/Sans/Humanist,100
-Alegreya Sans SC,/Expressive/Business,38
-Alegreya Sans SC,/Expressive/Calm,97
-Alegreya Sans SC,/Sans/Humanist,100
-Alegreya SC,/Expressive/Business,60
-Alegreya SC,/Expressive/Sincere,99
-Alegreya SC,/Serif/Humanist Venetian,100
+Alegreya,/Expressive/Vintage,78.2
 Alegreya,/Serif/Humanist Venetian,100
-Aleo,/Expressive/Business,56
-Aleo,/Expressive/Sincere,98
+Alegreya Sans,/Expressive/Business,54.3
+Alegreya Sans,/Expressive/Calm,93
+Alegreya Sans,/Expressive/Competent,98.5
+Alegreya Sans,/Expressive/Vintage,79
+Alegreya Sans,/Sans/Humanist,100
+Alegreya Sans SC,/Expressive/Business,54.3
+Alegreya Sans SC,/Expressive/Calm,97
+Alegreya Sans SC,/Expressive/Competent,98.5
+Alegreya Sans SC,/Expressive/Vintage,79
+Alegreya Sans SC,/Sans/Humanist,100
+Alegreya SC,/Expressive/Business,66.2
+Alegreya SC,/Expressive/Competent,97.7
+Alegreya SC,/Expressive/Loud,49
+Alegreya SC,/Expressive/Sincere,99
+Alegreya SC,/Expressive/Vintage,78.2
+Alegreya SC,/Serif/Humanist Venetian,100
+Aleo,/Expressive/Business,56.1
 Aleo,/Slab/Humanist,100
+Alex Brush,/Expressive/Artistic,99
+Alex Brush,/Expressive/Cute,11
+Alex Brush,/Expressive/Fancy,76
+Alex Brush,/Expressive/Loud,52
+Alex Brush,/Expressive/Sophisticated,68
+Alex Brush,/Expressive/Vintage,53
+Alex Brush,/Script/Formal,70
 Alexandria,/Arabic/Kufi,100
 Alexandria,/Expressive/Artistic,31
 Alexandria,/Expressive/Calm,99
 Alexandria,/Sans/Geometric,40
 Alexandria,/Sans/Humanist,20
-Alex Brush,/Expressive/Artistic,99
-Alex Brush,/Expressive/Cute,11
-Alex Brush,/Expressive/Fancy,76
-Alex Brush,/Expressive/Sophisticated,68
-Alex Brush,/Script/Formal,70
-Alfa Slab One,/Expressive/Business,80
+Alfa Slab One,/Expressive/Loud,100
 Alfa Slab One,/Expressive/Rugged,58
-Alfa Slab One,/Expressive/Sincere,91
+Alfa Slab One,/Expressive/Vintage,56.4
 Alfa Slab One,/Slab/Geometric,50
 Alfa Slab One,/Slab/Humanist,50
 Alice,/Expressive/Business,30
-Alice,/Expressive/Sincere,95
+Alice,/Expressive/Loud,19
+Alice,/Expressive/Vintage,76.7
 Alice,/Serif/Old Style Garalde,70
+Alike,/Expressive/Business,81
+Alike,/Expressive/Loud,54
+Alike,/Expressive/Sincere,95
+Alike,/Expressive/Vintage,46.5
+Alike,/Serif/Old Style Garalde,70
 Alike Angular,/Expressive/Playful,31
 Alike Angular,/Expressive/Rugged,40
-Alike Angular,/Expressive/Sincere,91
+Alike Angular,/Expressive/Sincere,97
+Alike Angular,/Expressive/Vintage,73
 Alike Angular,/Serif/Old Style Garalde,70
-Alike,/Expressive/Business,80
-Alike,/Expressive/Sincere,100
-Alike,/Serif/Old Style Garalde,70
 Alkalami,/Arabic/West African,100
-Alkalami,/Expressive/Sincere,99
+Alkalami,/Expressive/Loud,28
+Alkalami,/Expressive/Vintage,79.3
 Alkatra,/Expressive/Active,51
 Alkatra,/Expressive/Cute,13
+Alkatra,/Expressive/Loud,55
+Alkatra,/Expressive/Sincere,93
+Alkatra,/Expressive/Vintage,33.4
 Alkatra,/Script/Handwritten,50
 Alkatra,/Script/Informal,70
 Allan,/Expressive/Calm,57
@@ -168,150 +203,161 @@ Allan,/Script/Informal,70
 Allerta,/Expressive/Calm,98
 Allerta,/Expressive/Competent,38
 Allerta Stencil,/Expressive/Calm,91
-Allerta Stencil,/Expressive/Competent,49
 Allerta Stencil,/Expressive/Innovative,11
 Allerta Stencil,/Theme/Stencil,100
 Allison,/Expressive/Artistic,99
 Allison,/Expressive/Childlike,38
 Allison,/Expressive/Fancy,77
 Allison,/Expressive/Rugged,42
+Allison,/Expressive/Vintage,58.9
 Allison,/Script/Formal,20
 Allison,/Script/Handwritten,30
 Allison,/Script/Informal,80
 Allura,/Expressive/Artistic,99
 Allura,/Expressive/Fancy,69
 Allura,/Expressive/Sophisticated,65
+Allura,/Expressive/Vintage,62.3
 Allura,/Script/Formal,90
 Almarai,/Arabic/Kufi,100
-Almarai,/Expressive/Business,93
+Almarai,/Expressive/Business,95.8
 Almarai,/Expressive/Calm,99
 Almarai,/Expressive/Competent,11
-Almarai,/Expressive/Stiff,53
+Almarai,/Expressive/Vintage,77
 Almarai,/Sans/Neo Grotesque,100
-Almendra Display,/Expressive/Artistic,29
-Almendra Display,/Expressive/Sincere,91
-Almendra Display,/Theme/Blackletter,100
+Almarai,/Expressive/Stiff,53
 Almendra,/Expressive/Artistic,29
-Almendra,/Expressive/Sincere,91
-Almendra SC,/Expressive/Artistic,29
-Almendra SC,/Expressive/Sincere,91
-Almendra SC,/Serif/Humanist Venetian,80
+Almendra,/Expressive/Loud,81
+Almendra,/Expressive/Sincere,92
+Almendra,/Expressive/Vintage,98
 Almendra,/Serif/Humanist Venetian,100
-Alumni Sans Collegiate One,/Expressive/Calm,91
-Alumni Sans Collegiate One,/Expressive/Competent,95
-Alumni Sans Collegiate One,/Expressive/Futuristic,77
-Alumni Sans Collegiate One,/Expressive/Innovative,93
-Alumni Sans Collegiate One,/Expressive/Rugged,98
-Alumni Sans Collegiate One,/Expressive/Stiff,20
-Alumni Sans,/Expressive/Business,73
+Almendra Display,/Expressive/Artistic,29
+Almendra Display,/Expressive/Sincere,92
+Almendra Display,/Expressive/Vintage,98
+Almendra Display,/Theme/Blackletter,100
+Almendra SC,/Expressive/Artistic,29
+Almendra SC,/Expressive/Loud,48
+Almendra SC,/Expressive/Sincere,92
+Almendra SC,/Expressive/Vintage,99
+Almendra SC,/Serif/Humanist Venetian,80
+Alumni Sans,/Expressive/Business,73.1
 Alumni Sans,/Expressive/Calm,97
-Alumni Sans,/Expressive/Competent,99
-Alumni Sans Inline One,/Expressive/Calm,91
-Alumni Sans Inline One,/Expressive/Competent,95
-Alumni Sans Inline One,/Expressive/Futuristic,77
-Alumni Sans Inline One,/Expressive/Innovative,93
-Alumni Sans Inline One,/Expressive/Rugged,78
-Alumni Sans Pinstripe,/Expressive/Calm,97
-Alumni Sans Pinstripe,/Expressive/Competent,86
-Alumni Sans Pinstripe,/Sans/Geometric,10
-Alumni Sans Pinstripe,/Sans/Humanist,10
+Alumni Sans,/Expressive/Competent,95.7
 Alumni Sans,/Sans/Geometric,20
 Alumni Sans,/Sans/Humanist,20
+Alumni Sans Collegiate One,/Expressive/Calm,91
+Alumni Sans Collegiate One,/Expressive/Futuristic,77
+Alumni Sans Collegiate One,/Expressive/Innovative,93
+Alumni Sans Collegiate One,/Expressive/Loud,100
+Alumni Sans Collegiate One,/Expressive/Rugged,98
+Alumni Sans Collegiate One,/Expressive/Stiff,20
+Alumni Sans Inline One,/Expressive/Calm,91
+Alumni Sans Inline One,/Expressive/Futuristic,77
+Alumni Sans Inline One,/Expressive/Innovative,93
+Alumni Sans Inline One,/Expressive/Loud,99
+Alumni Sans Inline One,/Expressive/Rugged,78
+Alumni Sans Pinstripe,/Expressive/Calm,97
+Alumni Sans Pinstripe,/Sans/Geometric,10
+Alumni Sans Pinstripe,/Sans/Humanist,10
 Amarante,/Expressive/Artistic,53
 Amarante,/Expressive/Awkward,41
-Amarante,/Expressive/Sincere,91
+Amarante,/Expressive/Loud,45
+Amarante,/Expressive/Sincere,94
+Amarante,/Expressive/Vintage,73
 Amarante,/Sans/Glyphic,30
 Amarante,/Theme/Art Nouveau,100
 Amaranth,/Expressive/Calm,96
 Amaranth,/Expressive/Childlike,20
+Amaranth,/Expressive/Vintage,48.4
 Amaranth,/Sans/Humanist,100
 Amatic SC,/Expressive/Awkward,41
 Amatic SC,/Expressive/Childlike,88
 Amatic SC,/Expressive/Happy,33
 Amatic SC,/Expressive/Innovative,27
+Amatic SC,/Expressive/Vintage,36.4
 Amatic SC,/Script/Handwritten,100
-Amethysta,/Expressive/Business,76
+Amethysta,/Expressive/Business,88.9
 Amethysta,/Expressive/Calm,96
-Amethysta,/Expressive/Sincere,99
+Amethysta,/Expressive/Vintage,28.3
 Amethysta,/Serif/Old Style Garalde,70
 Amethysta,/Serif/Transitional,20
 Amiko,/Expressive/Calm,98
 Amiko,/Sans/Humanist,100
 Amiri,/Arabic/Naskh,100
-Amiri,/Expressive/Business,71
+Amiri,/Expressive/Business,81.4
 Amiri,/Expressive/Calm,96
-Amiri,/Expressive/Sincere,98
-Amiri Quran,/Arabic/Naskh,100
-Amiri Quran,/Expressive/Business,71
-Amiri Quran,/Expressive/Calm,96
-Amiri Quran,/Expressive/Sincere,96
-Amiri Quran,/Serif/Old Style Garalde,100
 Amiri,/Serif/Old Style Garalde,100
+Amiri Quran,/Arabic/Naskh,100
+Amiri Quran,/Expressive/Business,81.4
+Amiri Quran,/Expressive/Calm,96
+Amiri Quran,/Serif/Old Style Garalde,100
 Amita,/Expressive/Artistic,40
 Amita,/Expressive/Cute,11
 Amita,/Expressive/Happy,14
+Amita,/Expressive/Loud,40
+Amita,/Expressive/Vintage,73.4
 Amita,/Script/Informal,20
 Amita,/Script/Upright Script,20
 Anaheim,/Expressive/Calm,98
-Anaheim,/Expressive/Stiff,30
 Anaheim,/Sans/Humanist,100
-Andada Pro,/Expressive/Business,39
+Anaheim,/Expressive/Stiff,30
+Andada Pro,/Expressive/Business,65.6
 Andada Pro,/Expressive/Calm,97
-Andada Pro,/Expressive/Sincere,95
 Andada Pro,/Slab/Humanist,100
 Andika,/Expressive/Calm,95
 Andika,/Expressive/Happy,3
 Andika,/Sans/Humanist,100
 Anek Bangla,/Expressive/Business,32
 Anek Bangla,/Expressive/Calm,96
-Anek Bangla,/Expressive/Competent,100
+Anek Bangla,/Expressive/Competent,28
 Anek Bangla,/Sans/Humanist,100
 Anek Devanagari,/Expressive/Business,32
 Anek Devanagari,/Expressive/Calm,96
-Anek Devanagari,/Expressive/Competent,100
+Anek Devanagari,/Expressive/Competent,28
 Anek Devanagari,/Sans/Humanist,100
 Anek Gujarati,/Expressive/Business,32
 Anek Gujarati,/Expressive/Calm,96
-Anek Gujarati,/Expressive/Competent,100
+Anek Gujarati,/Expressive/Competent,28
 Anek Gujarati,/Sans/Humanist,100
 Anek Gurmukhi,/Expressive/Business,32
 Anek Gurmukhi,/Expressive/Calm,96
-Anek Gurmukhi,/Expressive/Competent,100
+Anek Gurmukhi,/Expressive/Competent,28
 Anek Gurmukhi,/Sans/Humanist,100
 Anek Kannada,/Expressive/Business,32
 Anek Kannada,/Expressive/Calm,96
-Anek Kannada,/Expressive/Competent,100
+Anek Kannada,/Expressive/Competent,28
 Anek Kannada,/Sans/Humanist,100
 Anek Latin,/Expressive/Business,32
 Anek Latin,/Expressive/Calm,96
-Anek Latin,/Expressive/Competent,100
+Anek Latin,/Expressive/Competent,28
 Anek Latin,/Sans/Humanist,100
 Anek Malayalam,/Expressive/Business,32
 Anek Malayalam,/Expressive/Calm,96
-Anek Malayalam,/Expressive/Competent,100
+Anek Malayalam,/Expressive/Competent,28
 Anek Malayalam,/Sans/Humanist,100
 Anek Odia,/Expressive/Business,32
 Anek Odia,/Expressive/Calm,96
-Anek Odia,/Expressive/Competent,100
+Anek Odia,/Expressive/Competent,28
 Anek Odia,/Sans/Humanist,100
 Anek Tamil,/Expressive/Business,32
 Anek Tamil,/Expressive/Calm,96
-Anek Tamil,/Expressive/Competent,100
+Anek Tamil,/Expressive/Competent,28
 Anek Tamil,/Sans/Humanist,100
 Anek Telugu,/Expressive/Business,32
 Anek Telugu,/Expressive/Calm,96
-Anek Telugu,/Expressive/Competent,100
+Anek Telugu,/Expressive/Competent,28
 Anek Telugu,/Sans/Humanist,100
 Angkor,/Expressive/Business,27
 Angkor,/Expressive/Calm,98
+Angkor,/Expressive/Loud,99
 Angkor,/Expressive/Rugged,38
-Angkor,/Expressive/Sincere,91
+Angkor,/Expressive/Vintage,78.7
 Angkor,/Slab/Humanist,20
 Angkor,"/South East Asian (Thai, Khmer, Lao)/Looped",100
 Annie Use Your Telescope,/Expressive/Artistic,22
 Annie Use Your Telescope,/Expressive/Awkward,55
 Annie Use Your Telescope,/Expressive/Childlike,48
 Annie Use Your Telescope,/Expressive/Playful,37
+Annie Use Your Telescope,/Expressive/Vintage,35.6
 Annie Use Your Telescope,/Script/Handwritten,100
 Anonymous Pro,/Expressive/Business,16
 Anonymous Pro,/Expressive/Calm,98
@@ -319,166 +365,191 @@ Anonymous Pro,/Expressive/Sincere,45
 Anonymous Pro,/Monospace/Monospace,100
 Anonymous Pro,/Sans/Geometric,20
 Anonymous Pro,/Sans/Humanist,50
-Antic Didone,/Expressive/Calm,95
-Antic Didone,/Expressive/Sincere,96
-Antic Didone,/Serif/Modern,70
+Anta,/Expressive/Futuristic,100
+Anta,/Sans/Geometric,100
+Anta,/Theme/Techno,100
 Antic,/Expressive/Calm,97
 Antic,/Expressive/Playful,11
 Antic,/Sans/Humanist,100
+Antic Didone,/Expressive/Calm,95
+Antic Didone,/Serif/Modern,70
 Antic Slab,/Expressive/Calm,95
-Antic Slab,/Expressive/Sincere,97
+Antic Slab,/Expressive/Sincere,91
 Antic Slab,/Slab/Geometric,70
-Anton,/Expressive/Business,59
 Anton,/Expressive/Calm,99
-Anton,/Expressive/Competent,95
+Anton,/Expressive/Competent,99.7
+Anton,/Expressive/Loud,88
 Anton,/Expressive/Rugged,78
-Antonio,/Expressive/Business,59
-Antonio,/Expressive/Calm,99
-Antonio,/Expressive/Competent,95
-Antonio,/Expressive/Rugged,66
-Antonio,/Sans/Grotesque,20
-Antonio,/Sans/Humanist,60
+Anton,/Expressive/Vintage,71
 Anton,/Sans/Grotesque,30
 Anton,/Sans/Neo Grotesque,70
+Antonio,/Expressive/Business,90.2
+Antonio,/Expressive/Calm,99
+Antonio,/Expressive/Competent,99.7
+Antonio,/Expressive/Loud,52
+Antonio,/Expressive/Rugged,66
+Antonio,/Expressive/Vintage,64
+Antonio,/Sans/Grotesque,20
+Antonio,/Sans/Humanist,60
 Anuphan,/Expressive/Business,50
 Anuphan,/Expressive/Calm,98
 Anuphan,/Expressive/Competent,31
 Anuphan,/Sans/Geometric,60
 Anuphan,"/South East Asian (Thai, Khmer, Lao)/Loopless",100
 Anybody,/Expressive/Calm,98
-Anybody,/Expressive/Competent,54
-Anybody,/Expressive/Stiff,30
+Anybody,/Expressive/Competent,79.2
+Anybody,/Expressive/Vintage,37
 Anybody,/Sans/Superellipse,100
+Anybody,/Expressive/Stiff,30
 Aoboshi One,/Expressive/Artistic,11
 Aoboshi One,/Expressive/Calm,88
-Aoboshi One,/Expressive/Sincere,92
-Arapey,/Expressive/Sincere,97
+Aoboshi One,/Expressive/Vintage,92
+AR One Sans,/Expressive/Calm,97
+AR One Sans,/Expressive/Competent,68
+AR One Sans,/Sans/Geometric,30
+AR One Sans,/Sans/Humanist,50
+Arapey,/Expressive/Business,51.9
+Arapey,/Expressive/Loud,42
+Arapey,/Expressive/Sincere,96
+Arapey,/Expressive/Vintage,74.5
 Arapey,/Serif/Modern,30
 Arapey,/Serif/Transitional,60
 Arbutus,/Expressive/Innovative,38
+Arbutus,/Expressive/Loud,79
 Arbutus,/Expressive/Playful,30
-Arbutus Slab,/Expressive/Business,36
-Arbutus Slab,/Expressive/Sincere,99
+Arbutus,/Expressive/Vintage,93
 Arbutus,/Slab/Humanist,50
+Arbutus,/Theme/Woodtype,100
+Arbutus Slab,/Expressive/Business,62.2
+Arbutus Slab,/Expressive/Vintage,77.2
 Arbutus Slab,/Slab/Clarendon,50
 Arbutus Slab,/Slab/Humanist,10
-Arbutus,/Theme/Woodtype,100
 Architects Daughter,/Expressive/Artistic,62
 Architects Daughter,/Expressive/Awkward,71
 Architects Daughter,/Expressive/Childlike,49
 Architects Daughter,/Expressive/Cute,20
 Architects Daughter,/Expressive/Playful,28
+Architects Daughter,/Expressive/Sincere,97
+Architects Daughter,/Expressive/Vintage,37.5
+Archivo,/Expressive/Business,90.7
+Archivo,/Expressive/Calm,99
+Archivo,/Expressive/Competent,94.5
+Archivo,/Sans/Grotesque,70
 Archivo Black,/Expressive/Business,19
 Archivo Black,/Expressive/Calm,99
-Archivo Black,/Expressive/Competent,39
-Archivo Black,/Expressive/Stiff,30
+Archivo Black,/Expressive/Competent,94.5
 Archivo Black,/Sans/Grotesque,70
-Archivo,/Expressive/Business,18
-Archivo,/Expressive/Calm,99
-Archivo,/Expressive/Competent,55
+Archivo Black,/Expressive/Stiff,30
 Archivo Narrow,/Expressive/Business,19
 Archivo Narrow,/Expressive/Calm,99
-Archivo Narrow,/Expressive/Competent,58
+Archivo Narrow,/Expressive/Competent,94.5
 Archivo Narrow,/Sans/Grotesque,70
-Archivo,/Sans/Grotesque,70
-Aref Ruqaa,/Arabic/Ruqah,100
-Aref Ruqaa,/Expressive/Artistic,40
-Aref Ruqaa,/Expressive/Childlike,13
-Aref Ruqaa,/Expressive/Playful,11
-Aref Ruqaa,/Expressive/Sincere,50
-Aref Ruqaa Ink,/Arabic/Ruqah,100
-Aref Ruqaa Ink,/Expressive/Artistic,32
-Aref Ruqaa Ink,/Expressive/Childlike,13
-Aref Ruqaa Ink,/Expressive/Playful,11
-Aref Ruqaa Ink,/Expressive/Sincere,50
-Aref Ruqaa Ink,/Serif/Humanist Venetian,60
-Aref Ruqaa,/Serif/Humanist Venetian,60
 Are You Serious,/Expressive/Artistic,38
 Are You Serious,/Expressive/Awkward,35
 Are You Serious,/Expressive/Innovative,54
 Are You Serious,/Expressive/Playful,40
 Are You Serious,/Expressive/Rugged,16
 Are You Serious,/Theme/Wacky,40
+Aref Ruqaa,/Arabic/Ruqah,100
+Aref Ruqaa,/Expressive/Artistic,40
+Aref Ruqaa,/Expressive/Childlike,13
+Aref Ruqaa,/Expressive/Playful,11
+Aref Ruqaa,/Expressive/Sincere,50
+Aref Ruqaa,/Serif/Humanist Venetian,60
+Aref Ruqaa Ink,/Arabic/Ruqah,100
+Aref Ruqaa Ink,/Expressive/Artistic,32
+Aref Ruqaa Ink,/Expressive/Childlike,13
+Aref Ruqaa Ink,/Expressive/Playful,11
+Aref Ruqaa Ink,/Expressive/Sincere,50
+Aref Ruqaa Ink,/Serif/Humanist Venetian,60
 Arima,/Expressive/Artistic,11
 Arima,/Expressive/Calm,74
 Arima,/Expressive/Cute,14
 Arima,/Script/Upright Script,30
-Arimo,/Expressive/Business,47
+Arimo,/Expressive/Business,92.1
 Arimo,/Expressive/Calm,98
 Arizonia,/Expressive/Artistic,99
 Arizonia,/Expressive/Fancy,47
 Arizonia,/Expressive/Sophisticated,77
+Arizonia,/Expressive/Vintage,68.7
 Arizonia,/Script/Informal,50
 Armata,/Expressive/Calm,93
 Armata,/Expressive/Futuristic,47
-Armata,/Expressive/Stiff,58
 Armata,/Sans/Geometric,10
 Armata,/Sans/Humanist,50
 Armata,/Sans/Superellipse,20
-AR One Sans,/Expressive/Calm,97
-AR One Sans,/Expressive/Competent,68
-AR One Sans,/Sans/Geometric,30
-AR One Sans,/Sans/Humanist,50
+Armata,/Expressive/Stiff,58
 Arsenal,/Expressive/Business,37
 Arsenal,/Expressive/Calm,96
+Arsenal,/Expressive/Competent,97.4
+Arsenal,/Expressive/Loud,38
+Arsenal,/Expressive/Sincere,92
 Arsenal,/Sans/Grotesque,50
 Arsenal,/Sans/Humanist,50
 Artifika,/Expressive/Artistic,32
 Artifika,/Expressive/Childlike,23
-Artifika,/Expressive/Sincere,56
+Artifika,/Expressive/Sincere,55.5
+Artifika,/Expressive/Vintage,69.2
 Artifika,/Script/Upright Script,50
 Arvo,/Expressive/Business,25
 Arvo,/Expressive/Calm,99
 Arvo,/Expressive/Happy,15
-Arvo,/Expressive/Sincere,96
-Arvo,/Expressive/Stiff,30
+Arvo,/Expressive/Vintage,84.5
 Arvo,/Slab/Geometric,100
-Arya,/Expressive/Business,35
+Arvo,/Expressive/Stiff,30
+Arya,/Expressive/Business,60.7
 Arya,/Expressive/Calm,98
+Arya,/Expressive/Competent,95.6
+Arya,/Expressive/Loud,37
+Arya,/Expressive/Vintage,58.7
 Arya,/Indic/Contemporary,50
 Arya,/Indic/Reverse-contrast,100
 Arya,/Indic/Sign Painting,10
 Arya,/Sans/Geometric,25
 Arya,/Sans/Humanist,75
-Asap Condensed,/Expressive/Business,58
-Asap Condensed,/Expressive/Calm,95
-Asap Condensed,/Expressive/Competent,99
-Asap Condensed,/Expressive/Cute,12
-Asap Condensed,/Indic/Sign Painting,40
-Asap Condensed,/Indic/Traditional,50
-Asap Condensed,/Sans/Humanist,75
-Asap Condensed,/Sans/Rounded,80
-Asap,/Expressive/Business,58
+Asap,/Expressive/Business,58.1
 Asap,/Expressive/Calm,97
 Asap,/Expressive/Competent,31
 Asap,/Expressive/Cute,12
 Asap,/Sans/Humanist,75
 Asap,/Sans/Rounded,80
-Asar,/Expressive/Business,30
+Asap Condensed,/Expressive/Business,50.3
+Asap Condensed,/Expressive/Calm,95
+Asap Condensed,/Expressive/Competent,96.2
+Asap Condensed,/Expressive/Cute,12
+Asap Condensed,/Indic/Sign Painting,40
+Asap Condensed,/Indic/Traditional,50
+Asap Condensed,/Sans/Humanist,75
+Asap Condensed,/Sans/Rounded,80
+Asar,/Expressive/Business,60.9
 Asar,/Expressive/Calm,99
 Asar,/Expressive/Happy,3
-Asar,/Expressive/Sincere,99
+Asar,/Expressive/Vintage,58.9
 Asar,/Serif/Humanist Venetian,60
 Asset,/Expressive/Business,39
 Asset,/Expressive/Calm,76
+Asset,/Expressive/Loud,100
 Asset,/Expressive/Playful,22
 Asset,/Expressive/Rugged,49
-Asset,/Expressive/Sincere,91
+Asset,/Expressive/Vintage,94
 Asset,/Serif/Fat Face,100
 Assistant,/Expressive/Business,33
 Assistant,/Expressive/Calm,98
-Assistant,/Expressive/Stiff,41
 Assistant,/Sans/Geometric,60
 Assistant,/Sans/Humanist,30
+Assistant,/Expressive/Stiff,41
 Astloch,/Expressive/Artistic,33
 Astloch,/Expressive/Calm,16
 Astloch,/Expressive/Innovative,93
 Astloch,/Expressive/Playful,58
+Astloch,/Expressive/Vintage,91
 Astloch,/Theme/Blackletter,100
 Asul,/Expressive/Business,13
 Asul,/Expressive/Calm,93
 Asul,/Expressive/Happy,12
-Asul,/Expressive/Sincere,93
+Asul,/Expressive/Loud,17
+Asul,/Expressive/Sincere,96
+Asul,/Expressive/Vintage,57.4
 Asul,/Sans/Glyphic,100
 Athiti,/Expressive/Awkward,11
 Athiti,/Expressive/Calm,92
@@ -494,6 +565,7 @@ Atma,/Expressive/Childlike,98
 Atma,/Expressive/Cute,21
 Atma,/Expressive/Excited,76
 Atma,/Expressive/Playful,99
+Atma,/Expressive/Vintage,67.5
 Atma,/Indic/Contemporary,60
 Atma,/Indic/Sign Painting,10
 Atma,/Theme/Wacky,100
@@ -501,43 +573,48 @@ Atomic Age,/Expressive/Artistic,51
 Atomic Age,/Expressive/Awkward,91
 Atomic Age,/Expressive/Calm,18
 Atomic Age,/Expressive/Futuristic,87
-Atomic Age,/Expressive/Stiff,97
+Atomic Age,/Expressive/Vintage,76
 Atomic Age,/Script/Upright Script,20
+Atomic Age,/Expressive/Stiff,97
 Aubrey,/Expressive/Artistic,33
 Aubrey,/Expressive/Awkward,61
 Aubrey,/Expressive/Calm,46
 Aubrey,/Expressive/Excited,73
 Aubrey,/Expressive/Innovative,72
+Aubrey,/Expressive/Vintage,92
 Aubrey,/Theme/Art Nouveau,100
 Audiowide,/Expressive/Excited,31
 Audiowide,/Expressive/Futuristic,100
-Audiowide,/Expressive/Stiff,99
 Audiowide,/Theme/Techno,100
+Audiowide,/Expressive/Stiff,99
 Autour One,/Expressive/Awkward,11
 Autour One,/Expressive/Childlike,72
 Autour One,/Expressive/Cute,59
 Autour One,/Expressive/Happy,31
 Autour One,/Expressive/Playful,72
-Autour One,/Expressive/Sincere,11
+Autour One,/Expressive/Sincere,10.5
 Autour One,/Script/Handwritten,100
 Autour One,/Theme/Wacky,30
 Average,/Expressive/Business,37
 Average,/Expressive/Calm,96
-Average,/Expressive/Sincere,98
-Average Sans,/Expressive/Business,35
-Average Sans,/Expressive/Calm,97
-Average Sans,/Sans/Geometric,50
-Average Sans,/Sans/Humanist,50
+Average,/Expressive/Vintage,58
 Average,/Serif/Old Style Garalde,50
 Average,/Serif/Transitional,50
+Average Sans,/Expressive/Business,35
+Average Sans,/Expressive/Calm,97
+Average Sans,/Expressive/Vintage,57
+Average Sans,/Sans/Geometric,50
+Average Sans,/Sans/Humanist,50
 Averia Gruesa Libre,/Expressive/Awkward,61
 Averia Gruesa Libre,/Expressive/Childlike,30
 Averia Gruesa Libre,/Expressive/Innovative,12
 Averia Gruesa Libre,/Expressive/Playful,32
+Averia Gruesa Libre,/Expressive/Vintage,58.3
 Averia Libre,/Expressive/Awkward,61
 Averia Libre,/Expressive/Childlike,30
 Averia Libre,/Expressive/Innovative,12
 Averia Libre,/Expressive/Playful,32
+Averia Libre,/Expressive/Vintage,58.3
 Averia Libre,/Sans/Rounded,100
 Averia Libre,/Theme/Blobby,10
 Averia Libre,/Theme/Distressed,5
@@ -546,6 +623,7 @@ Averia Sans Libre,/Expressive/Calm,15
 Averia Sans Libre,/Expressive/Childlike,30
 Averia Sans Libre,/Expressive/Innovative,12
 Averia Sans Libre,/Expressive/Playful,32
+Averia Sans Libre,/Expressive/Vintage,38.7
 Averia Sans Libre,/Sans/Rounded,100
 Averia Sans Libre,/Theme/Blobby,10
 Averia Serif Libre,/Expressive/Awkward,41
@@ -554,25 +632,28 @@ Averia Serif Libre,/Expressive/Childlike,23
 Averia Serif Libre,/Expressive/Innovative,12
 Averia Serif Libre,/Expressive/Playful,11
 Averia Serif Libre,/Expressive/Sincere,20
+Averia Serif Libre,/Expressive/Vintage,78
 Azeret Mono,/Expressive/Calm,95
-Azeret Mono,/Expressive/Stiff,30
 Azeret Mono,/Monospace/Monospace,100
+Azeret Mono,/Expressive/Stiff,30
 B612,/Expressive/Calm,94
 B612,/Expressive/Competent,39
+B612,/Sans/Geometric,20
+B612,/Sans/Humanist,20
 B612 Mono,/Expressive/Awkward,41
 B612 Mono,/Expressive/Calm,93
 B612 Mono,/Monospace/Monospace,100
 B612 Mono,/Sans/Geometric,20
 B612 Mono,/Sans/Humanist,20
-B612,/Sans/Geometric,20
-B612,/Sans/Humanist,20
 Babylonica,/Expressive/Artistic,99
 Babylonica,/Expressive/Fancy,73
 Babylonica,/Expressive/Playful,71
+Babylonica,/Expressive/Vintage,76.7
 Babylonica,/Script/Informal,60
 Babylonica,/Theme/Distressed,100
-Bacasime Antique,/Expressive/Business,39
-Bacasime Antique,/Expressive/Sincere,97
+Bacasime Antique,/Expressive/Business,54
+Bacasime Antique,/Expressive/Sincere,96
+Bacasime Antique,/Expressive/Vintage,72.1
 Bacasime Antique,/Serif/Transitional,100
 Bad Script,/Expressive/Active,99
 Bad Script,/Expressive/Artistic,31
@@ -602,17 +683,20 @@ Bai Jamjuree,/Expressive/Artistic,10
 Bai Jamjuree,/Expressive/Business,42
 Bai Jamjuree,/Expressive/Calm,75
 Bai Jamjuree,/Expressive/Futuristic,62
-Bai Jamjuree,/Expressive/Stiff,94
+Bai Jamjuree,/Expressive/Vintage,82
 Bai Jamjuree,/Sans/Superellipse,100
 Bai Jamjuree,"/South East Asian (Thai, Khmer, Lao)/Looped",100
+Bai Jamjuree,/Expressive/Stiff,94
 Bakbak One,/Expressive/Calm,58
 Bakbak One,/Expressive/Futuristic,23
-Bakbak One,/Expressive/Stiff,20
+Bakbak One,/Expressive/Loud,62
 Bakbak One,/Sans/Geometric,30
 Bakbak One,/Sans/Superellipse,70
+Bakbak One,/Expressive/Stiff,20
 Ballet,/Expressive/Artistic,100
 Ballet,/Expressive/Fancy,100
 Ballet,/Expressive/Sophisticated,100
+Ballet,/Expressive/Vintage,99
 Ballet,/Script/Formal,100
 Baloo 2,/Expressive/Calm,93
 Baloo 2,/Sans/Rounded,100
@@ -641,70 +725,94 @@ Balsamiq Sans,/Expressive/Innovative,12
 Balsamiq Sans,/Expressive/Playful,64
 Balsamiq Sans,/Sans/Rounded,100
 Balthazar,/Expressive/Artistic,31
+Balthazar,/Expressive/Competent,96.6
 Balthazar,/Expressive/Sincere,71
+Balthazar,/Expressive/Vintage,92
 Bangers,/Expressive/Active,23
 Bangers,/Expressive/Awkward,74
 Bangers,/Expressive/Calm,78
 Bangers,/Expressive/Childlike,10
+Bangers,/Expressive/Loud,88
 Bangers,/Expressive/Playful,39
+Bangers,/Expressive/Sincere,94
 Bangers,/Expressive/Stiff,10
-Barlow Condensed,/Expressive/Calm,98
-Barlow Condensed,/Expressive/Competent,84
-Barlow Condensed,/Sans/Grotesque,80
-Barlow Condensed,/Sans/Rounded,80
 Barlow,/Expressive/Calm,99
+Barlow,/Expressive/Competent,95.3
 Barlow,/Sans/Grotesque,80
 Barlow,/Sans/Rounded,80
+Barlow Condensed,/Expressive/Calm,98
+Barlow Condensed,/Expressive/Competent,95.3
+Barlow Condensed,/Sans/Grotesque,80
+Barlow Condensed,/Sans/Rounded,80
 Barlow Semi Condensed,/Expressive/Calm,99
-Barlow Semi Condensed,/Expressive/Competent,78
+Barlow Semi Condensed,/Expressive/Competent,95.3
 Barlow Semi Condensed,/Sans/Grotesque,80
 Barlow Semi Condensed,/Sans/Rounded,80
 Barriecito,/Expressive/Awkward,70
 Barriecito,/Expressive/Calm,14
+Barriecito,/Expressive/Loud,92
 Barriecito,/Expressive/Playful,100
 Barriecito,/Expressive/Rugged,32
+Barriecito,/Expressive/Vintage,25.6
 Barriecito,/Theme/Wacky,70
 Barrio,/Expressive/Awkward,70
 Barrio,/Expressive/Calm,15
+Barrio,/Expressive/Loud,92
 Barrio,/Expressive/Playful,100
 Barrio,/Expressive/Rugged,32
+Barrio,/Expressive/Vintage,25.6
 Barrio,/Theme/Wacky,70
 Basic,/Expressive/Calm,97
 Basic,/Sans/Geometric,40
-Baskervville,/Expressive/Business,60
-Baskervville,/Expressive/Sincere,97
+Baskervville,/Expressive/Business,67.8
+Baskervville,/Expressive/Competent,99
+Baskervville,/Expressive/Loud,50
+Baskervville,/Expressive/Sincere,99
+Baskervville,/Expressive/Vintage,85
 Baskervville,/Serif/Transitional,100
 Battambang,/Expressive/Business,73
-Battambang,/Expressive/Sincere,98
+Battambang,/Expressive/Vintage,75.4
 Battambang,/Slab/Geometric,70
 Battambang,"/South East Asian (Thai, Khmer, Lao)/Looped",100
 Baumans,/Expressive/Artistic,92
 Baumans,/Expressive/Calm,74
 Baumans,/Expressive/Futuristic,58
-Baumans,/Expressive/Stiff,60
 Baumans,/Sans/Geometric,80
 Baumans,/Theme/Techno,30
+Baumans,/Expressive/Stiff,60
 Bayon,/Expressive/Calm,78
 Bayon,/Sans/Grotesque,40
 Bayon,"/South East Asian (Thai, Khmer, Lao)/Loopless",100
+Be Vietnam Pro,/Expressive/Calm,99
+Be Vietnam Pro,/Expressive/Competent,11
+Be Vietnam Pro,/Expressive/Vintage,78.4
+Be Vietnam Pro,/Sans/Neo Grotesque,100
+Be Vietnam Pro,/Expressive/Stiff,30
 Beau Rivage,/Expressive/Artistic,80
 Beau Rivage,/Expressive/Fancy,57
+Beau Rivage,/Expressive/Loud,42
 Beau Rivage,/Expressive/Sophisticated,77
+Beau Rivage,/Expressive/Vintage,91
 Beau Rivage,/Script/Formal,100
-Bebas Neue,/Expressive/Business,59
+Bebas Neue,/Expressive/Business,65.8
 Bebas Neue,/Expressive/Calm,100
+Bebas Neue,/Expressive/Competent,97.8
 Bebas Neue,/Expressive/Rugged,68
 Bebas Neue,/Sans/Neo Grotesque,100
 Belanosima,/Expressive/Calm,93
 Belanosima,/Expressive/Happy,51
+Belanosima,/Expressive/Loud,89
 Belanosima,/Expressive/Rugged,33
+Belanosima,/Expressive/Vintage,79.2
 Belanosima,/Sans/Grotesque,30
 Belanosima,/Sans/Rounded,50
 Belgrano,/Expressive/Business,22
 Belgrano,/Expressive/Calm,79
-Belgrano,/Expressive/Sincere,97
 Bellefair,/Expressive/Calm,94
-Bellefair,/Expressive/Sincere,94
+Bellefair,/Expressive/Competent,98.4
+Bellefair,/Expressive/Loud,41
+Bellefair,/Expressive/Sincere,92
+Bellefair,/Expressive/Vintage,91
 Bellefair,/Hebrew/Normal,100
 Bellefair,/Serif/Humanist Venetian,25
 Bellefair,/Serif/Old Style Garalde,75
@@ -724,44 +832,49 @@ Bellota Text,/Sans/Geometric,20
 Bellota Text,/Sans/Humanist,80
 BenchNine,/Expressive/Business,39
 BenchNine,/Expressive/Calm,99
-BenchNine,/Expressive/Competent,79
-BenchNine,/Expressive/Stiff,42
+BenchNine,/Expressive/Competent,96.3
 BenchNine,/Sans/Grotesque,10
 BenchNine,/Sans/Humanist,70
 BenchNine,/Sans/Rounded,20
-Benne,/Expressive/Business,19
+BenchNine,/Expressive/Stiff,42
+Benne,/Expressive/Business,73.2
 Benne,/Expressive/Calm,94
-Benne,/Expressive/Sincere,100
+Benne,/Expressive/Loud,45
+Benne,/Expressive/Vintage,77.4
 Benne,/Indic/Traditional,100
 Benne,/Serif/Old Style Garalde,100
 Bentham,/Expressive/Business,37
 Bentham,/Expressive/Calm,95
-Bentham,/Expressive/Sincere,100
+Bentham,/Expressive/Loud,58
+Bentham,/Expressive/Sincere,99
+Bentham,/Expressive/Vintage,74.6
 Bentham,/Serif/Modern,100
 Berkshire Swash,/Expressive/Calm,63
 Berkshire Swash,/Expressive/Cute,32
+Berkshire Swash,/Expressive/Loud,70
 Berkshire Swash,/Expressive/Playful,33
-Berkshire Swash,/Expressive/Sincere,11
+Berkshire Swash,/Expressive/Sincere,10.5
+Berkshire Swash,/Expressive/Vintage,43.9
 Berkshire Swash,/Sans/Humanist,50
 Berkshire Swash,/Script/Upright Script,50
-Besley,/Expressive/Business,39
+Besley,/Expressive/Business,65.2
 Besley,/Expressive/Calm,94
-Besley,/Expressive/Sincere,97
+Besley,/Expressive/Loud,32
+Besley,/Expressive/Sincere,93
+Besley,/Expressive/Vintage,74.4
 Besley,/Slab/Clarendon,100
 Beth Ellen,/Expressive/Artistic,30
 Beth Ellen,/Expressive/Childlike,10
+Beth Ellen,/Expressive/Vintage,84.5
 Beth Ellen,/Script/Handwritten,100
-Bevan,/Expressive/Business,59
+Bevan,/Expressive/Business,59.8
 Bevan,/Expressive/Calm,76
+Bevan,/Expressive/Loud,99
 Bevan,/Expressive/Rugged,37
-Bevan,/Expressive/Sincere,91
-Bevan,/Expressive/Stiff,20
+Bevan,/Expressive/Vintage,79.8
 Bevan,/Slab/Geometric,40
 Bevan,/Slab/Humanist,60
-Be Vietnam Pro,/Expressive/Calm,99
-Be Vietnam Pro,/Expressive/Competent,11
-Be Vietnam Pro,/Expressive/Stiff,30
-Be Vietnam Pro,/Sans/Neo Grotesque,100
+Bevan,/Expressive/Stiff,20
 Bhavuka,/Expressive/Calm,52
 Bhavuka,/Expressive/Childlike,10
 Bhavuka,/Expressive/Cute,56
@@ -771,32 +884,21 @@ Bhavuka,/Sans/Humanist,80
 BhuTuka Expanded One,/Expressive/Calm,75
 BhuTuka Expanded One,/Expressive/Happy,19
 BhuTuka Expanded One,/Expressive/Playful,41
-BhuTuka Expanded One,/Expressive/Sincere,50
+BhuTuka Expanded One,/Expressive/Sincere,50.1
+BhuTuka Expanded One,/Expressive/Vintage,55.3
 BhuTuka Expanded One,/Indic/Low contrast,100
 BhuTuka Expanded One,/Slab/Humanist,100
-Bigelow Rules,/Expressive/Innovative,33
-Bigelow Rules,/Expressive/Playful,47
-Bigelow Rules,/Expressive/Sincere,30
-Bigelow Rules,/Serif/Modern,40
-Bigelow Rules,/Theme/Wacky,60
-Bigshot One,/Expressive/Calm,76
-Bigshot One,/Expressive/Excited,11
-Bigshot One,/Expressive/Futuristic,48
-Bigshot One,/Expressive/Rugged,75
-Bigshot One,/Expressive/Sincere,52
-Bigshot One,/Serif/Fat Face,20
-Bigshot One,/Serif/Scotch,80
 Big Shoulders Display,/Expressive/Calm,79
-Big Shoulders Display,/Expressive/Competent,98
+Big Shoulders Display,/Expressive/Competent,96.9
 Big Shoulders Display,/Expressive/Futuristic,56
 Big Shoulders Display,/Expressive/Playful,11
-Big Shoulders Display,/Expressive/Stiff,30
 Big Shoulders Display,/Sans/Geometric,20
 Big Shoulders Display,/Sans/Grotesque,40
 Big Shoulders Display,/Sans/Humanist,20
 Big Shoulders Display,/Sans/Superellipse,20
+Big Shoulders Display,/Expressive/Stiff,30
 Big Shoulders Inline Display,/Expressive/Calm,59
-Big Shoulders Inline Display,/Expressive/Competent,99
+Big Shoulders Inline Display,/Expressive/Competent,96.9
 Big Shoulders Inline Display,/Expressive/Futuristic,56
 Big Shoulders Inline Display,/Expressive/Innovative,71
 Big Shoulders Inline Display,/Sans/Geometric,15
@@ -805,7 +907,7 @@ Big Shoulders Inline Display,/Sans/Humanist,15
 Big Shoulders Inline Display,/Sans/Superellipse,20
 Big Shoulders Inline Display,/Theme/Inline,20
 Big Shoulders Inline Text,/Expressive/Calm,59
-Big Shoulders Inline Text,/Expressive/Competent,97
+Big Shoulders Inline Text,/Expressive/Competent,96.9
 Big Shoulders Inline Text,/Expressive/Futuristic,56
 Big Shoulders Inline Text,/Expressive/Innovative,71
 Big Shoulders Inline Text,/Sans/Geometric,15
@@ -814,7 +916,6 @@ Big Shoulders Inline Text,/Sans/Humanist,15
 Big Shoulders Inline Text,/Sans/Superellipse,20
 Big Shoulders Inline Text,/Theme/Inline,20
 Big Shoulders Stencil Display,/Expressive/Calm,59
-Big Shoulders Stencil Display,/Expressive/Competent,99
 Big Shoulders Stencil Display,/Expressive/Futuristic,56
 Big Shoulders Stencil Display,/Expressive/Innovative,56
 Big Shoulders Stencil Display,/Sans/Geometric,15
@@ -823,7 +924,6 @@ Big Shoulders Stencil Display,/Sans/Humanist,15
 Big Shoulders Stencil Display,/Sans/Superellipse,20
 Big Shoulders Stencil Display,/Theme/Stencil,20
 Big Shoulders Stencil Text,/Expressive/Calm,59
-Big Shoulders Stencil Text,/Expressive/Competent,100
 Big Shoulders Stencil Text,/Expressive/Futuristic,56
 Big Shoulders Stencil Text,/Expressive/Innovative,56
 Big Shoulders Stencil Text,/Sans/Geometric,10
@@ -832,64 +932,84 @@ Big Shoulders Stencil Text,/Sans/Humanist,10
 Big Shoulders Stencil Text,/Sans/Superellipse,20
 Big Shoulders Stencil Text,/Theme/Stencil,30
 Big Shoulders Text,/Expressive/Calm,79
-Big Shoulders Text,/Expressive/Competent,92
+Big Shoulders Text,/Expressive/Competent,96.9
 Big Shoulders Text,/Expressive/Futuristic,56
 Big Shoulders Text,/Sans/Geometric,20
 Big Shoulders Text,/Sans/Grotesque,40
 Big Shoulders Text,/Sans/Humanist,20
 Big Shoulders Text,/Sans/Superellipse,20
+Bigelow Rules,/Expressive/Innovative,33
+Bigelow Rules,/Expressive/Playful,47
+Bigelow Rules,/Expressive/Sincere,30.1
+Bigelow Rules,/Expressive/Vintage,26.5
+Bigelow Rules,/Serif/Modern,40
+Bigelow Rules,/Theme/Wacky,60
+Bigshot One,/Expressive/Calm,76
+Bigshot One,/Expressive/Excited,11
+Bigshot One,/Expressive/Futuristic,48
+Bigshot One,/Expressive/Loud,59
+Bigshot One,/Expressive/Rugged,75
+Bigshot One,/Expressive/Sincere,51.5
+Bigshot One,/Serif/Fat Face,20
+Bigshot One,/Serif/Scotch,80
 Bilbo,/Expressive/Active,27
 Bilbo,/Expressive/Artistic,78
 Bilbo,/Expressive/Excited,46
 Bilbo,/Expressive/Sophisticated,38
+Bilbo,/Expressive/Vintage,53
 Bilbo,/Script/Handwritten,100
 Bilbo Swash Caps,/Expressive/Active,27
 Bilbo Swash Caps,/Expressive/Artistic,80
 Bilbo Swash Caps,/Expressive/Excited,46
 Bilbo Swash Caps,/Expressive/Sophisticated,38
+Bilbo Swash Caps,/Expressive/Vintage,53.8
 Bilbo Swash Caps,/Script/Formal,10
 Bilbo Swash Caps,/Script/Handwritten,90
+BioRhyme,/Expressive/Calm,74
+BioRhyme,/Expressive/Sincere,55
+BioRhyme,/Expressive/Vintage,67
+BioRhyme,/Slab/Geometric,40
+BioRhyme,/Slab/Humanist,60
+BioRhyme,/Expressive/Stiff,30
 BioRhyme Expanded,/Expressive/Calm,55
 BioRhyme Expanded,/Expressive/Playful,51
 BioRhyme Expanded,/Expressive/Sincere,32
+BioRhyme Expanded,/Expressive/Vintage,46.5
 BioRhyme Expanded,/Slab/Geometric,20
 BioRhyme Expanded,/Slab/Humanist,80
-BioRhyme,/Expressive/Calm,74
-BioRhyme,/Expressive/Sincere,55
-BioRhyme,/Expressive/Stiff,30
-BioRhyme,/Slab/Geometric,40
-BioRhyme,/Slab/Humanist,60
-Birthstone Bounce,/Expressive/Artistic,80
-Birthstone Bounce,/Expressive/Excited,60
-Birthstone Bounce,/Expressive/Fancy,73
-Birthstone Bounce,/Script/Formal,30
-Birthstone Bounce,/Script/Handwritten,70
 Birthstone,/Expressive/Artistic,79
 Birthstone,/Expressive/Cute,42
 Birthstone,/Expressive/Sophisticated,77
+Birthstone,/Expressive/Vintage,77.4
 Birthstone,/Script/Formal,20
 Birthstone,/Script/Handwritten,80
+Birthstone Bounce,/Expressive/Artistic,80
+Birthstone Bounce,/Expressive/Excited,60
+Birthstone Bounce,/Expressive/Fancy,73
+Birthstone Bounce,/Expressive/Vintage,58.9
+Birthstone Bounce,/Script/Formal,30
+Birthstone Bounce,/Script/Handwritten,70
 Biryani,/Expressive/Calm,99
 Biryani,/Expressive/Competent,12
-Biryani,/Expressive/Stiff,54
 Biryani,/Indic/Low contrast,100
 Biryani,/Sans/Geometric,30
 Biryani,/Sans/Humanist,70
-Bitter,/Expressive/Business,57
+Biryani,/Expressive/Stiff,54
+Bitter,/Expressive/Business,97.6
 Bitter,/Expressive/Calm,98
-Bitter,/Expressive/Sincere,93
-Bitter,/Expressive/Stiff,20
+Bitter,/Expressive/Competent,98.8
 Bitter,/Serif/Humanist Venetian,20
 Bitter,/Serif/Scotch,80
+Bitter,/Expressive/Stiff,20
 BIZ UDGothic,/Expressive/Calm,93
 BIZ UDGothic,/Expressive/Competent,32
 BIZ UDMincho,/Expressive/Calm,94
-BIZ UDMincho,/Expressive/Sincere,70
+BIZ UDMincho,/Expressive/Sincere,70.1
 BIZ UDPGothic,/Expressive/Business,31
 BIZ UDPGothic,/Expressive/Calm,99
 BIZ UDPGothic,/Expressive/Stiff,10
 BIZ UDPMincho,/Expressive/Calm,98
-BIZ UDPMincho,/Expressive/Sincere,90
+BIZ UDPMincho,/Expressive/Vintage,77.4
 Black And White Picture,/Expressive/Awkward,33
 Black And White Picture,/Expressive/Childlike,10
 Black And White Picture,/Expressive/Cute,16
@@ -901,16 +1021,21 @@ Black Han Sans,/Expressive/Calm,79
 Black Han Sans,/Expressive/Playful,12
 Black Han Sans,/Expressive/Rugged,48
 Black Han Sans,/Expressive/Stiff,30
+Black Ops One,/Expressive/Loud,90
 Black Ops One,/Expressive/Rugged,100
-Black Ops One,/Expressive/Stiff,100
+Black Ops One,/Expressive/Vintage,69.3
 Black Ops One,/Sans/Geometric,50
 Black Ops One,/Theme/Stencil,50
+Black Ops One,/Expressive/Stiff,100
 Blaka,/Arabic/Kufi,100
 Blaka,/Expressive/Artistic,80
 Blaka,/Expressive/Awkward,33
 Blaka,/Expressive/Excited,53
 Blaka,/Expressive/Innovative,48
+Blaka,/Expressive/Loud,97
 Blaka,/Expressive/Rugged,49
+Blaka,/Expressive/Vintage,98.5
+Blaka,/Theme/Blackletter,100
 Blaka,/Expressive/Stiff,30
 Blaka Hollow,/Arabic/Kufi,100
 Blaka Hollow,/Expressive/Artistic,80
@@ -918,35 +1043,43 @@ Blaka Hollow,/Expressive/Awkward,33
 Blaka Hollow,/Expressive/Excited,21
 Blaka Hollow,/Expressive/Happy,32
 Blaka Hollow,/Expressive/Innovative,69
+Blaka Hollow,/Expressive/Loud,98
 Blaka Hollow,/Expressive/Rugged,49
-Blaka Hollow,/Expressive/Stiff,30
+Blaka Hollow,/Expressive/Vintage,98
 Blaka Hollow,/Theme/Blackletter,50
 Blaka Hollow,/Theme/Inline,50
+Blaka Hollow,/Expressive/Stiff,30
 Blaka Ink,/Arabic/Kufi,100
 Blaka Ink,/Expressive/Artistic,10
 Blaka Ink,/Expressive/Awkward,33
 Blaka Ink,/Expressive/Excited,27
 Blaka Ink,/Expressive/Innovative,100
 Blaka Ink,/Expressive/Rugged,49
-Blaka Ink,/Expressive/Stiff,30
+Blaka Ink,/Expressive/Vintage,37.3
 Blaka Ink,/Theme/Blackletter,100
-Blaka,/Theme/Blackletter,100
-Blinker,/Expressive/Business,55
+Blaka Ink,/Expressive/Stiff,30
+Blinker,/Expressive/Business,55.8
 Blinker,/Expressive/Calm,89
 Blinker,/Expressive/Futuristic,77
 Blinker,/Sans/Humanist,40
 Blinker,/Sans/Superellipse,100
+Bodoni Moda,/Expressive/Business,77.7
+Bodoni Moda,/Expressive/Competent,98.1
 Bodoni Moda,/Expressive/Futuristic,16
+Bodoni Moda,/Expressive/Loud,71
 Bodoni Moda,/Expressive/Rugged,55
 Bodoni Moda,/Expressive/Sincere,99
+Bodoni Moda,/Expressive/Vintage,84.5
 Bodoni Moda,/Serif/Modern,100
 Bodoni Moda,/Theme/Blackletter,100
 Bokor,/Expressive/Artistic,96
 Bokor,/Expressive/Futuristic,38
 Bokor,/Expressive/Rugged,87
+Bokor,/Expressive/Vintage,99
 Bokor,/Expressive/Stiff,41
+Bona Nova,/Expressive/Business,72.1
 Bona Nova,/Expressive/Calm,96
-Bona Nova,/Expressive/Sincere,99
+Bona Nova,/Expressive/Vintage,74.3
 Bona Nova,/Serif/Humanist Venetian,100
 Bonbon,/Expressive/Active,72
 Bonbon,/Expressive/Artistic,56
@@ -967,6 +1100,7 @@ Bonheur Royale,/Expressive/Childlike,40
 Bonheur Royale,/Expressive/Fancy,94
 Bonheur Royale,/Expressive/Rugged,36
 Bonheur Royale,/Expressive/Sophisticated,94
+Bonheur Royale,/Expressive/Vintage,78.3
 Bonheur Royale,/Script/Formal,100
 Bonheur Royale,/Script/Handwritten,80
 Boogaloo,/Expressive/Artistic,12
@@ -976,6 +1110,8 @@ Boogaloo,/Expressive/Cute,27
 Boogaloo,/Expressive/Excited,32
 Boogaloo,/Expressive/Happy,54
 Boogaloo,/Expressive/Playful,55
+Boogaloo,/Expressive/Sincere,94
+Boogaloo,/Expressive/Vintage,67.4
 Boogaloo,/Script/Informal,100
 Boogaloo,/Script/Upright Script,50
 Boogaloo,/Theme/Wacky,30
@@ -984,73 +1120,82 @@ Borel,/Expressive/Calm,22
 Borel,/Expressive/Childlike,87
 Borel,/Expressive/Cute,100
 Borel,/Expressive/Playful,53
-Borel,/Expressive/Stiff,10
+Borel,/Expressive/Vintage,35
 Borel,/Script/Formal,50
 Borel,/Script/Upright Script,100
+Borel,/Expressive/Stiff,10
 Bowlby One,/Expressive/Business,34
 Bowlby One,/Expressive/Calm,76
 Bowlby One,/Expressive/Happy,13
 Bowlby One,/Expressive/Innovative,71
+Bowlby One,/Expressive/Loud,99
 Bowlby One,/Expressive/Playful,35
 Bowlby One,/Expressive/Rugged,54
-Bowlby One,/Expressive/Stiff,75
+Bowlby One,/Expressive/Vintage,72.3
 Bowlby One,/Sans/Grotesque,100
+Bowlby One,/Theme/Distressed,40
+Bowlby One,/Expressive/Stiff,75
 Bowlby One SC,/Expressive/Business,34
 Bowlby One SC,/Expressive/Calm,76
 Bowlby One SC,/Expressive/Happy,13
 Bowlby One SC,/Expressive/Innovative,71
+Bowlby One SC,/Expressive/Loud,99
 Bowlby One SC,/Expressive/Playful,35
 Bowlby One SC,/Expressive/Rugged,54
-Bowlby One SC,/Expressive/Stiff,75
+Bowlby One SC,/Expressive/Vintage,72.3
 Bowlby One SC,/Sans/Grotesque,100
 Bowlby One SC,/Theme/Distressed,40
-Bowlby One,/Theme/Distressed,40
+Bowlby One SC,/Expressive/Stiff,75
 Braah One,/Expressive/Calm,91
 Braah One,/Expressive/Futuristic,34
 Braah One,/Expressive/Happy,51
 Braah One,/Expressive/Playful,32
-Braah One,/Expressive/Stiff,91
 Braah One,/Sans/Geometric,50
 Braah One,/Sans/Humanist,50
-Brawler,/Expressive/Business,57
+Braah One,/Expressive/Stiff,91
+Brawler,/Expressive/Business,57.7
 Brawler,/Expressive/Calm,98
-Brawler,/Expressive/Sincere,100
+Brawler,/Expressive/Sincere,96
 Brawler,/Serif/Old Style Garalde,50
 Brawler,/Serif/Scotch,50
 Bree Serif,/Expressive/Calm,56
 Bree Serif,/Expressive/Excited,31
 Bree Serif,/Expressive/Innovative,31
+Bree Serif,/Expressive/Loud,45
 Bree Serif,/Expressive/Playful,91
 Bree Serif,/Expressive/Sincere,49
-Bree Serif,/Expressive/Stiff,10
 Bree Serif,/Slab/Humanist,100
+Bree Serif,/Expressive/Stiff,10
 Bricolage Grotesque,/Expressive/Calm,89
 Bricolage Grotesque,/Expressive/Playful,32
 Bricolage Grotesque,/Expressive/Rugged,47
 Bricolage Grotesque,/Sans/Neo Grotesque,100
 Bruno Ace,/Expressive/Calm,86
-Bruno Ace,/Expressive/Competent,72
 Bruno Ace,/Expressive/Futuristic,98
 Bruno Ace,/Expressive/Innovative,13
-Bruno Ace,/Expressive/Stiff,100
+Bruno Ace,/Expressive/Vintage,84
 Bruno Ace,/Sans/Superellipse,100
+Bruno Ace,/Expressive/Stiff,100
 Bruno Ace SC,/Expressive/Calm,86
-Bruno Ace SC,/Expressive/Competent,72
 Bruno Ace SC,/Expressive/Futuristic,99
 Bruno Ace SC,/Expressive/Innovative,13
-Bruno Ace SC,/Expressive/Stiff,100
+Bruno Ace SC,/Expressive/Vintage,84
 Bruno Ace SC,/Sans/Superellipse,100
-Brygada 1918,/Expressive/Business,74
+Bruno Ace SC,/Expressive/Stiff,100
+Brygada 1918,/Expressive/Business,74.4
 Brygada 1918,/Expressive/Calm,60
-Brygada 1918,/Expressive/Sincere,98
-Brygada 1918,/Expressive/Stiff,10
+Brygada 1918,/Expressive/Sincere,92
+Brygada 1918,/Expressive/Vintage,84.5
 Brygada 1918,/Serif/Transitional,100
+Brygada 1918,/Expressive/Stiff,10
 Bubblegum Sans,/Expressive/Childlike,90
 Bubblegum Sans,/Expressive/Cute,32
 Bubblegum Sans,/Expressive/Excited,62
 Bubblegum Sans,/Expressive/Happy,43
 Bubblegum Sans,/Expressive/Innovative,13
 Bubblegum Sans,/Expressive/Playful,92
+Bubblegum Sans,/Expressive/Sincere,91
+Bubblegum Sans,/Expressive/Vintage,65.8
 Bubblegum Sans,/Script/Handwritten,100
 Bubblegum Sans,/Script/Informal,100
 Bubbler One,/Expressive/Awkward,33
@@ -1067,80 +1212,80 @@ Buda,/Expressive/Playful,32
 Buda,/Sans/Humanist,50
 Buda,/Serif/Humanist Venetian,50
 Buda,/Theme/Wacky,50
-Buenard,/Expressive/Business,58
-Buenard,/Expressive/Sincere,98
+Buenard,/Expressive/Business,58.9
+Buenard,/Expressive/Sincere,97
+Buenard,/Expressive/Vintage,78.9
 Buenard,/Serif/Humanist Venetian,40
 Buenard,/Serif/Old Style Garalde,90
-Bungee Color,/Theme/Inline,100
-Bungee Color,/Theme/Woodtype,10
 Bungee,/Expressive/Calm,64
-Bungee,/Expressive/Competent,93
 Bungee,/Expressive/Futuristic,96
 Bungee,/Expressive/Innovative,31
 Bungee,/Expressive/Playful,32
 Bungee,/Expressive/Rugged,99
+Bungee,/Expressive/Vintage,71.2
+Bungee,/Sans/Geometric,70
+Bungee,/Sans/Humanist,5
+Bungee,/Sans/Rounded,60
+Bungee,/Theme/Woodtype,10
 Bungee,/Expressive/Stiff,97
+Bungee Color,/Theme/Inline,100
+Bungee Color,/Theme/Woodtype,10
 Bungee Hairline,/Expressive/Calm,92
-Bungee Hairline,/Expressive/Competent,94
 Bungee Hairline,/Expressive/Futuristic,96
 Bungee Hairline,/Expressive/Innovative,31
 Bungee Hairline,/Expressive/Playful,32
-Bungee Hairline,/Expressive/Stiff,97
+Bungee Hairline,/Expressive/Vintage,71.2
 Bungee Hairline,/Sans/Geometric,70
 Bungee Hairline,/Sans/Humanist,5
 Bungee Hairline,/Sans/Rounded,60
 Bungee Hairline,/Theme/Woodtype,10
-Bungee Inline,/Expressive/Competent,97
+Bungee Hairline,/Expressive/Stiff,97
 Bungee Inline,/Expressive/Futuristic,96
 Bungee Inline,/Expressive/Innovative,57
 Bungee Inline,/Expressive/Playful,33
 Bungee Inline,/Expressive/Rugged,99
-Bungee Inline,/Expressive/Stiff,97
+Bungee Inline,/Expressive/Vintage,71.2
 Bungee Inline,/Sans/Geometric,70
 Bungee Inline,/Sans/Humanist,5
 Bungee Inline,/Sans/Rounded,60
 Bungee Inline,/Theme/Inline,100
 Bungee Inline,/Theme/Woodtype,10
-Bungee Outline,/Expressive/Competent,97
+Bungee Inline,/Expressive/Stiff,97
 Bungee Outline,/Expressive/Futuristic,96
 Bungee Outline,/Expressive/Innovative,57
 Bungee Outline,/Expressive/Playful,34
-Bungee Outline,/Expressive/Stiff,96
+Bungee Outline,/Expressive/Vintage,71.2
 Bungee Outline,/Sans/Geometric,70
 Bungee Outline,/Sans/Humanist,5
 Bungee Outline,/Sans/Rounded,60
 Bungee Outline,/Theme/Woodtype,10
-Bungee,/Sans/Geometric,70
-Bungee,/Sans/Humanist,5
-Bungee,/Sans/Rounded,60
-Bungee Shade,/Expressive/Competent,98
+Bungee Outline,/Expressive/Stiff,96
 Bungee Shade,/Expressive/Futuristic,96
 Bungee Shade,/Expressive/Innovative,99
 Bungee Shade,/Expressive/Playful,34
-Bungee Shade,/Expressive/Stiff,94
+Bungee Shade,/Expressive/Vintage,71.2
 Bungee Shade,/Sans/Geometric,70
 Bungee Shade,/Sans/Humanist,5
 Bungee Shade,/Sans/Rounded,60
 Bungee Shade,/Theme/Woodtype,10
-Bungee Spice,/Expressive/Competent,98
+Bungee Shade,/Expressive/Stiff,94
 Bungee Spice,/Expressive/Futuristic,96
 Bungee Spice,/Expressive/Innovative,100
 Bungee Spice,/Expressive/Playful,40
-Bungee Spice,/Expressive/Stiff,92
+Bungee Spice,/Expressive/Vintage,71.2
 Bungee Spice,/Sans/Geometric,70
 Bungee Spice,/Sans/Humanist,5
 Bungee Spice,/Sans/Rounded,60
-Bungee,/Theme/Woodtype,10
-Bungee Tint,/Expressive/Business,80
-Bungee Tint,/Expressive/Competent,90
+Bungee Spice,/Expressive/Stiff,92
+Bungee Tint,/Expressive/Futuristic,95
 Bungee Tint,/Expressive/Innovative,100
 Bungee Tint,/Expressive/Playful,60
-Bungee Tint,/Expressive/Futuristic,95
 Bungee Tint,/Sans/Geometric,70
 Bungee Tint,/Sans/Rounded,60
 Butcherman,/Expressive/Awkward,59
 Butcherman,/Expressive/Innovative,91
 Butcherman,/Expressive/Playful,80
+Butcherman,/Expressive/Vintage,79.4
 Butcherman,/Theme/Blobby,1
 Butcherman,/Theme/Distressed,10
 Butcherman,/Theme/Wacky,100
@@ -1156,23 +1301,25 @@ Butterfly Kids,/Script/Handwritten,100
 Butterfly Kids,/Script/Informal,100
 Butterfly Kids,/Theme/Blobby,5
 Butterfly Kids,/Theme/Distressed,40
-Cabin Condensed,/Expressive/Business,77
-Cabin Condensed,/Expressive/Calm,90
-Cabin Condensed,/Expressive/Competent,98
-Cabin Condensed,/Expressive/Futuristic,31
-Cabin Condensed,/Sans/Humanist,100
 Cabin,/Expressive/Business,36
 Cabin,/Expressive/Calm,100
 Cabin,/Sans/Humanist,100
+Cabin Condensed,/Expressive/Business,85.5
+Cabin Condensed,/Expressive/Calm,90
+Cabin Condensed,/Expressive/Competent,89.2
+Cabin Condensed,/Expressive/Futuristic,31
+Cabin Condensed,/Sans/Humanist,100
 Cabin Sketch,/Expressive/Innovative,91
 Cabin Sketch,/Expressive/Playful,54
 Cabin Sketch,/Expressive/Rugged,100
+Cabin Sketch,/Expressive/Vintage,67.4
 Cabin Sketch,/Sans/Humanist,100
 Cabin Sketch,/Theme/Distressed,100
 Caesar Dressing,/Expressive/Happy,79
 Caesar Dressing,/Expressive/Innovative,51
 Caesar Dressing,/Expressive/Playful,25
 Caesar Dressing,/Expressive/Rugged,71
+Caesar Dressing,/Expressive/Vintage,98.5
 Caesar Dressing,/Script/Handwritten,10
 Caesar Dressing,/Theme/Distressed,20
 Caesar Dressing,/Theme/Wacky,100
@@ -1185,32 +1332,34 @@ Cagliostro,/Script/Handwritten,10
 Cairo,/Expressive/Calm,78
 Cairo,/Expressive/Competent,18
 Cairo,/Expressive/Futuristic,98
+Cairo,/Sans/Geometric,20
+Cairo,/Sans/Humanist,20
+Cairo,/Sans/Superellipse,100
 Cairo Play,/Expressive/Calm,79
 Cairo Play,/Expressive/Competent,18
 Cairo Play,/Expressive/Futuristic,98
 Cairo Play,/Sans/Geometric,20
 Cairo Play,/Sans/Humanist,20
 Cairo Play,/Sans/Superellipse,100
-Cairo,/Sans/Geometric,20
-Cairo,/Sans/Humanist,20
-Cairo,/Sans/Superellipse,100
-Caladea,/Expressive/Business,29
+Caladea,/Expressive/Business,63.6
 Caladea,/Expressive/Calm,98
 Caladea,/Expressive/Playful,11
-Caladea,/Expressive/Sincere,98
+Caladea,/Expressive/Sincere,93
+Caladea,/Expressive/Vintage,70.4
 Caladea,/Serif/Modern,70
-Calistoga,/Expressive/Business,66
+Calistoga,/Expressive/Business,66.8
 Calistoga,/Expressive/Calm,79
 Calistoga,/Expressive/Rugged,34
-Calistoga,/Expressive/Sincere,91
-Calistoga,/Expressive/Stiff,60
+Calistoga,/Expressive/Vintage,64.7
 Calistoga,/Serif/Transitional,80
+Calistoga,/Expressive/Stiff,60
 Calligraffitti,/Expressive/Active,69
 Calligraffitti,/Expressive/Artistic,78
 Calligraffitti,/Expressive/Awkward,62
 Calligraffitti,/Expressive/Childlike,62
 Calligraffitti,/Expressive/Happy,18
 Calligraffitti,/Expressive/Playful,22
+Calligraffitti,/Expressive/Vintage,44
 Calligraffitti,/Script/Handwritten,80
 Calligraffitti,/Script/Informal,80
 Cambay,/Expressive/Business,35
@@ -1219,37 +1368,46 @@ Cambay,/Indic/Low contrast,100
 Cambay,/Sans/Humanist,100
 Cambo,/Expressive/Business,29
 Cambo,/Expressive/Calm,97
-Cambo,/Expressive/Sincere,93
+Cambo,/Expressive/Sincere,92
+Cambo,/Expressive/Vintage,70.8
 Cambo,/Serif/Modern,70
 Candal,/Expressive/Business,36
 Candal,/Expressive/Calm,95
 Candal,/Expressive/Childlike,10
 Candal,/Expressive/Happy,1
+Candal,/Expressive/Loud,97
 Candal,/Expressive/Playful,31
+Candal,/Expressive/Vintage,70.4
 Candal,/Sans/Humanist,100
 Candal,/Theme/Woodtype,20
 Cantarell,/Expressive/Business,36
 Cantarell,/Expressive/Calm,99
 Cantarell,/Expressive/Competent,20
 Cantarell,/Sans/Humanist,100
-Cantata One,/Expressive/Business,68
+Cantata One,/Expressive/Business,68.7
 Cantata One,/Expressive/Calm,98
-Cantata One,/Expressive/Sincere,92
+Cantata One,/Expressive/Competent,98.6
+Cantata One,/Expressive/Loud,48
+Cantata One,/Expressive/Sincere,97
+Cantata One,/Expressive/Vintage,72.6
 Cantata One,/Serif/Modern,100
 Cantora One,/Expressive/Business,25
 Cantora One,/Expressive/Calm,56
 Cantora One,/Expressive/Excited,11
 Cantora One,/Expressive/Happy,3
 Cantora One,/Expressive/Playful,21
+Cantora One,/Expressive/Vintage,67.8
 Cantora One,/Sans/Glyphic,40
 Cantora One,/Sans/Humanist,100
 Caprasimo,/Expressive/Artistic,21
-Caprasimo,/Expressive/Business,58
+Caprasimo,/Expressive/Business,50.6
 Caprasimo,/Expressive/Calm,94
 Caprasimo,/Expressive/Cute,14
 Caprasimo,/Expressive/Happy,11
+Caprasimo,/Expressive/Loud,97
 Caprasimo,/Expressive/Playful,32
-Caprasimo,/Expressive/Sincere,91
+Caprasimo,/Expressive/Sincere,93
+Caprasimo,/Expressive/Vintage,84.5
 Caprasimo,/Serif/Transitional,100
 Capriola,/Expressive/Calm,91
 Capriola,/Expressive/Childlike,70
@@ -1265,15 +1423,18 @@ Caramel,/Expressive/Artistic,97
 Caramel,/Expressive/Fancy,73
 Caramel,/Expressive/Playful,11
 Caramel,/Expressive/Sophisticated,40
+Caramel,/Expressive/Vintage,76.8
 Caramel,/Script/Formal,70
 Caramel,/Script/Handwritten,10
 Carattere,/Expressive/Artistic,99
 Carattere,/Expressive/Sophisticated,77
+Carattere,/Expressive/Vintage,77.3
 Carattere,/Script/Formal,80
 Carattere,/Script/Handwritten,20
-Cardo,/Expressive/Business,39
+Cardo,/Expressive/Business,55
 Cardo,/Expressive/Calm,97
-Cardo,/Expressive/Sincere,100
+Cardo,/Expressive/Sincere,99
+Cardo,/Expressive/Vintage,77.8
 Cardo,/Serif/Old Style Garalde,100
 Carlito,/Expressive/Calm,100
 Carlito,/Sans/Humanist,20
@@ -1283,69 +1444,81 @@ Carme,/Expressive/Calm,99
 Carme,/Expressive/Excited,2
 Carme,/Sans/Humanist,20
 Carme,/Sans/Neo Grotesque,80
-Carrois Gothic,/Expressive/Business,77
+Carrois Gothic,/Expressive/Business,84
 Carrois Gothic,/Expressive/Calm,99
-Carrois Gothic,/Expressive/Competent,31
-Carrois Gothic,/Expressive/Stiff,10
+Carrois Gothic,/Expressive/Competent,96.1
+Carrois Gothic,/Expressive/Vintage,81.5
 Carrois Gothic,/Sans/Neo Grotesque,100
-Carrois Gothic SC,/Expressive/Business,77
+Carrois Gothic,/Expressive/Stiff,10
+Carrois Gothic SC,/Expressive/Business,84
 Carrois Gothic SC,/Expressive/Calm,99
-Carrois Gothic SC,/Expressive/Competent,31
-Carrois Gothic SC,/Expressive/Stiff,10
+Carrois Gothic SC,/Expressive/Competent,96.1
+Carrois Gothic SC,/Expressive/Vintage,81.5
 Carrois Gothic SC,/Sans/Neo Grotesque,100
+Carrois Gothic SC,/Expressive/Stiff,10
 Carter One,/Expressive/Calm,53
 Carter One,/Expressive/Excited,62
+Carter One,/Expressive/Loud,98
+Carter One,/Expressive/Vintage,58.7
 Carter One,/Sans/Glyphic,40
 Carter One,/Sans/Humanist,80
 Carter One,/Script/Handwritten,30
-Castoro,/Expressive/Business,58
+Castoro,/Expressive/Business,58.6
 Castoro,/Expressive/Calm,97
-Castoro,/Expressive/Sincere,100
+Castoro,/Expressive/Competent,99.6
+Castoro,/Expressive/Sincere,98
+Castoro,/Expressive/Vintage,78.9
 Castoro,/Serif/Old Style Garalde,20
 Castoro,/Serif/Transitional,100
 Castoro Titling,/Expressive/Business,34
 Castoro Titling,/Expressive/Calm,96
-Castoro Titling,/Expressive/Sincere,100
+Castoro Titling,/Expressive/Sincere,98
+Castoro Titling,/Expressive/Vintage,91
 Castoro Titling,/Serif/Old Style Garalde,50
 Castoro Titling,/Serif/Transitional,50
 Catamaran,/Expressive/Calm,98
-Catamaran,/Expressive/Stiff,20
 Catamaran,/Indic/Low contrast,100
 Catamaran,/Sans/Humanist,30
 Catamaran,/Sans/Neo Grotesque,80
+Catamaran,/Expressive/Stiff,20
 Caudex,/Expressive/Artistic,18
 Caudex,/Expressive/Playful,12
 Caudex,/Expressive/Sincere,68
+Caudex,/Expressive/Vintage,81
 Caudex,/Script/Handwritten,20
 Caudex,/Script/Upright Script,10
 Caudex,/Serif/Humanist Venetian,80
-Caveat Brush,/Expressive/Artistic,31
-Caveat Brush,/Expressive/Awkward,77
-Caveat Brush,/Expressive/Childlike,100
-Caveat Brush,/Expressive/Cute,17
-Caveat Brush,/Expressive/Playful,65
-Caveat Brush,/Script/Handwritten,100
-Caveat Brush,/Script/Informal,100
-Caveat Brush,/Script/Upright Script,100
 Caveat,/Expressive/Active,88
 Caveat,/Expressive/Artistic,12
 Caveat,/Expressive/Awkward,51
 Caveat,/Expressive/Childlike,87
 Caveat,/Expressive/Cute,24
 Caveat,/Expressive/Playful,35
+Caveat,/Expressive/Sincere,100
 Caveat,/Script/Handwritten,100
 Caveat,/Script/Informal,100
+Caveat Brush,/Expressive/Artistic,31
+Caveat Brush,/Expressive/Awkward,77
+Caveat Brush,/Expressive/Childlike,100
+Caveat Brush,/Expressive/Cute,17
+Caveat Brush,/Expressive/Playful,65
+Caveat Brush,/Expressive/Sincere,99
+Caveat Brush,/Script/Handwritten,100
+Caveat Brush,/Script/Informal,100
+Caveat Brush,/Script/Upright Script,100
 Cedarville Cursive,/Expressive/Active,36
 Cedarville Cursive,/Expressive/Artistic,31
 Cedarville Cursive,/Expressive/Awkward,41
 Cedarville Cursive,/Expressive/Happy,34
 Cedarville Cursive,/Expressive/Playful,37
+Cedarville Cursive,/Expressive/Sincere,99
 Cedarville Cursive,/Expressive/Sophisticated,22
 Cedarville Cursive,/Script/Handwritten,100
 Cedarville Cursive,/Script/Informal,100
 Ceviche One,/Expressive/Active,12
 Ceviche One,/Expressive/Artistic,18
 Ceviche One,/Expressive/Awkward,31
+Ceviche One,/Expressive/Loud,89
 Ceviche One,/Expressive/Playful,38
 Ceviche One,/Expressive/Rugged,11
 Ceviche One,/Sans/Glyphic,20
@@ -1353,59 +1526,64 @@ Ceviche One,/Script/Informal,80
 Ceviche One,/Theme/Wacky,20
 Chakra Petch,/Expressive/Calm,75
 Chakra Petch,/Expressive/Futuristic,99
-Chakra Petch,/Expressive/Stiff,99
 Chakra Petch,/Sans/Geometric,10
 Chakra Petch,"/South East Asian (Thai, Khmer, Lao)/Looped",100
 Chakra Petch,/Theme/Inline,30
 Chakra Petch,/Theme/Techno,100
+Chakra Petch,/Expressive/Stiff,99
 Changa,/Arabic/Kufi,100
 Changa,/Expressive/Calm,58
 Changa,/Expressive/Futuristic,78
-Changa,/Expressive/Stiff,56
-Changa One,/Expressive/Business,55
-Changa One,/Expressive/Calm,100
-Changa One,/Expressive/Playful,11
-Changa One,/Expressive/Stiff,57
-Changa One,/Sans/Humanist,20
-Changa One,/Sans/Superellipse,50
-Changa One,/Theme/Techno,40
 Changa,/Sans/Geometric,10
 Changa,/Sans/Superellipse,50
 Changa,/Theme/Techno,40
+Changa,/Expressive/Stiff,56
+Changa One,/Expressive/Business,55.1
+Changa One,/Expressive/Calm,100
+Changa One,/Expressive/Playful,11
+Changa One,/Sans/Humanist,20
+Changa One,/Sans/Superellipse,50
+Changa One,/Theme/Techno,40
+Changa One,/Expressive/Stiff,57
 Chango,/Expressive/Artistic,18
 Chango,/Expressive/Calm,58
 Chango,/Expressive/Childlike,10
 Chango,/Expressive/Cute,33
+Chango,/Expressive/Loud,97
 Chango,/Expressive/Playful,35
-Chango,/Expressive/Stiff,10
+Chango,/Expressive/Vintage,48
 Chango,/Sans/Geometric,30
 Chango,/Sans/Rounded,30
 Chango,/Theme/Blobby,12
 Chango,/Theme/Woodtype,80
-Charis SIL,/Expressive/Business,80
+Chango,/Expressive/Stiff,10
+Charis SIL,/Expressive/Business,86.9
 Charis SIL,/Expressive/Calm,98
-Charis SIL,/Expressive/Sincere,100
+Charis SIL,/Expressive/Sincere,93
+Charis SIL,/Expressive/Vintage,63
 Charis SIL,/Serif/Transitional,100
 Charm,/Expressive/Artistic,59
 Charm,/Expressive/Excited,11
+Charm,/Expressive/Vintage,63.4
+Charm,/Script/Formal,100
+Charm,"/South East Asian (Thai, Khmer, Lao)/Looped",100
 Charmonman,/Expressive/Artistic,47
 Charmonman,/Expressive/Fancy,23
 Charmonman,/Expressive/Playful,11
 Charmonman,/Expressive/Sophisticated,22
+Charmonman,/Expressive/Vintage,66.4
 Charmonman,/Script/Formal,70
 Charmonman,/Script/Informal,10
 Charmonman,"/South East Asian (Thai, Khmer, Lao)/Looped",100
-Charm,/Script/Formal,100
-Charm,"/South East Asian (Thai, Khmer, Lao)/Looped",100
 Chathura,/Expressive/Calm,78
 Chathura,/Expressive/Futuristic,37
 Chathura,/Expressive/Playful,11
-Chathura,/Expressive/Stiff,30
 Chathura,/Indic/Low contrast,100
 Chathura,/Indic/Sign Painting,20
 Chathura,/Sans/Geometric,10
 Chathura,/Sans/Superellipse,80
 Chathura,/Theme/Techno,40
+Chathura,/Expressive/Stiff,30
 Chau Philomene One,/Expressive/Awkward,11
 Chau Philomene One,/Expressive/Calm,38
 Chau Philomene One,/Expressive/Childlike,21
@@ -1417,7 +1595,10 @@ Chau Philomene One,/Sans/Superellipse,50
 Chau Philomene One,/Theme/Woodtype,20
 Chela One,/Expressive/Calm,37
 Chela One,/Expressive/Happy,3
+Chela One,/Expressive/Loud,81
 Chela One,/Expressive/Playful,18
+Chela One,/Expressive/Sincere,97
+Chela One,/Expressive/Vintage,73.9
 Chela One,/Theme/Brush,100
 Chelsea Market,/Expressive/Awkward,18
 Chelsea Market,/Expressive/Calm,13
@@ -1429,23 +1610,28 @@ Chelsea Market,/Sans/Geometric,50
 Chelsea Market,/Theme/Distressed,100
 Chelsea Market,/Theme/Wacky,20
 Chenla,/Expressive/Calm,79
+Chenla,/Expressive/Vintage,84.5
 Chenla,"/South East Asian (Thai, Khmer, Lao)/Chrieng (Khmer)",100
 Cherish,/Expressive/Artistic,80
 Cherish,/Expressive/Fancy,76
 Cherish,/Expressive/Sophisticated,75
+Cherish,/Expressive/Vintage,67.6
 Cherish,/Script/Formal,80
 Cherish,/Theme/Distressed,30
 Cherry Bomb One,/Expressive/Awkward,76
 Cherry Bomb One,/Expressive/Calm,72
 Cherry Bomb One,/Expressive/Childlike,16
 Cherry Bomb One,/Expressive/Cute,98
+Cherry Bomb One,/Expressive/Loud,89
 Cherry Bomb One,/Expressive/Playful,78
+Cherry Bomb One,/Expressive/Vintage,66.8
 Cherry Bomb One,/Theme/Blobby,100
 Cherry Bomb One,/Theme/Wacky,20
 Cherry Cream Soda,/Expressive/Awkward,51
 Cherry Cream Soda,/Expressive/Calm,14
 Cherry Cream Soda,/Expressive/Childlike,20
 Cherry Cream Soda,/Expressive/Playful,35
+Cherry Cream Soda,/Expressive/Vintage,77
 Cherry Cream Soda,/Theme/Brush,40
 Cherry Cream Soda,/Theme/Wacky,10
 Cherry Cream Soda,/Theme/Woodtype,30
@@ -1459,84 +1645,98 @@ Chewy,/Expressive/Awkward,72
 Chewy,/Expressive/Childlike,99
 Chewy,/Expressive/Cute,32
 Chewy,/Expressive/Happy,27
+Chewy,/Expressive/Loud,81
 Chewy,/Expressive/Playful,67
+Chewy,/Expressive/Vintage,68.7
 Chewy,/Theme/Blobby,70
 Chewy,/Theme/Brush,80
 Chewy,/Theme/Distressed,10
 Chicle,/Expressive/Awkward,56
 Chicle,/Expressive/Childlike,95
 Chicle,/Expressive/Cute,33
+Chicle,/Expressive/Loud,87
 Chicle,/Expressive/Playful,36
+Chicle,/Expressive/Vintage,90.5
 Chicle,/Theme/Art Nouveau,25
 Chicle,/Theme/Blobby,70
 Chilanka,/Expressive/Awkward,11
 Chilanka,/Expressive/Childlike,98
 Chilanka,/Expressive/Cute,56
 Chilanka,/Expressive/Playful,35
+Chilanka,/Expressive/Vintage,26.4
 Chilanka,/Script/Handwritten,100
 Chilanka,/Theme/Brush,80
 Chivo,/Expressive/Calm,98
 Chivo,/Expressive/Competent,13
+Chivo,/Sans/Grotesque,100
 Chivo,/Expressive/Stiff,41
 Chivo Mono,/Expressive/Calm,98
-Chivo Mono,/Expressive/Stiff,10
 Chivo Mono,/Sans/Grotesque,100
-Chivo,/Sans/Grotesque,100
+Chivo Mono,/Expressive/Stiff,10
 Chokokutai,/Expressive/Awkward,100
 Chokokutai,/Expressive/Excited,75
 Chokokutai,/Expressive/Futuristic,85
 Chokokutai,/Expressive/Innovative,76
 Chokokutai,/Expressive/Playful,78
-Chokokutai,/Expressive/Stiff,53
 Chokokutai,/Slab/Geometric,10
 Chokokutai,/Theme/Techno,70
 Chokokutai,/Theme/Wacky,80
-Chonburi,/Expressive/Business,73
+Chokokutai,/Expressive/Stiff,53
 Chonburi,/Expressive/Calm,95
-Chonburi,/Expressive/Sincere,55
+Chonburi,/Expressive/Loud,93
+Chonburi,/Expressive/Sincere,54.5
+Chonburi,/Expressive/Vintage,77.9
 Chonburi,/Serif/Modern,100
 Chonburi,"/South East Asian (Thai, Khmer, Lao)/Loopless",100
 Chonburi,/Theme/Woodtype,80
+Cinzel,/Expressive/Artistic,18
+Cinzel,/Expressive/Business,51.7
+Cinzel,/Expressive/Calm,97
+Cinzel,/Expressive/Vintage,91
+Cinzel,/Serif/Old Style Garalde,100
+Cinzel,/Expressive/Stiff,45
 Cinzel Decorative,/Expressive/Artistic,31
+Cinzel Decorative,/Expressive/Business,51.7
 Cinzel Decorative,/Expressive/Calm,73
-Cinzel Decorative,/Expressive/Sincere,99
+Cinzel Decorative,/Expressive/Vintage,91
 Cinzel Decorative,/Serif/Old Style Garalde,100
 Cinzel Decorative,/Theme/Medieval,40
-Cinzel,/Expressive/Artistic,18
-Cinzel,/Expressive/Calm,97
-Cinzel,/Expressive/Sincere,100
-Cinzel,/Expressive/Stiff,45
-Cinzel,/Serif/Old Style Garalde,100
 Clicker Script,/Expressive/Artistic,70
 Clicker Script,/Expressive/Cute,25
 Clicker Script,/Expressive/Fancy,42
 Clicker Script,/Expressive/Happy,53
+Clicker Script,/Expressive/Sincere,93
+Clicker Script,/Expressive/Vintage,55.6
 Clicker Script,/Script/Informal,80
 Clicker Script,/Script/Upright Script,40
 Climate Crisis,/Expressive/Futuristic,14
 Climate Crisis,/Expressive/Innovative,77
+Climate Crisis,/Expressive/Loud,100
 Climate Crisis,/Expressive/Playful,37
 Climate Crisis,/Expressive/Rugged,74
-Climate Crisis,/Expressive/Stiff,76
 Climate Crisis,/Sans/Geometric,70
 Climate Crisis,/Sans/Humanist,30
+Climate Crisis,/Expressive/Stiff,76
 Coda,/Expressive/Calm,74
 Coda,/Expressive/Futuristic,76
-Coda,/Expressive/Stiff,78
 Coda,/Sans/Geometric,10
 Coda,/Sans/Superellipse,80
 Coda,/Theme/Techno,20
+Coda,/Expressive/Stiff,78
 Codystar,/Expressive/Excited,62
 Codystar,/Expressive/Innovative,92
 Codystar,/Expressive/Playful,20
 Codystar,/Expressive/Rugged,18
+Codystar,/Expressive/Vintage,38.7
 Codystar,/Sans/Rounded,100
 Codystar,/Theme/Distressed,20
 Codystar,/Theme/Inline,30
 Coiny,/Expressive/Calm,74
 Coiny,/Expressive/Childlike,10
 Coiny,/Expressive/Cute,24
+Coiny,/Expressive/Loud,84
 Coiny,/Expressive/Playful,52
+Coiny,/Expressive/Vintage,62.7
 Coiny,/Sans/Geometric,50
 Coiny,/Theme/Blobby,60
 Combo,/Expressive/Awkward,98
@@ -1552,46 +1752,52 @@ Combo,/Theme/Wacky,50
 Comfortaa,/Expressive/Calm,99
 Comfortaa,/Expressive/Childlike,50
 Comfortaa,/Expressive/Cute,17
+Comfortaa,/Expressive/Vintage,53.4
 Comfortaa,/Sans/Geometric,100
 Comfortaa,/Sans/Rounded,100
+Comforter,/Expressive/Artistic,99
+Comforter,/Expressive/Excited,46
+Comforter,/Expressive/Vintage,56.5
+Comforter,/Script/Handwritten,10
+Comforter,/Script/Informal,80
 Comforter Brush,/Expressive/Artistic,99
 Comforter Brush,/Expressive/Excited,46
 Comforter Brush,/Expressive/Rugged,26
+Comforter Brush,/Expressive/Vintage,56.5
 Comforter Brush,/Script/Handwritten,10
 Comforter Brush,/Script/Informal,80
 Comforter Brush,/Theme/Distressed,80
-Comforter,/Expressive/Artistic,99
-Comforter,/Expressive/Excited,46
-Comforter,/Script/Handwritten,10
-Comforter,/Script/Informal,80
 Comic Neue,/Expressive/Awkward,12
 Comic Neue,/Expressive/Calm,59
 Comic Neue,/Expressive/Childlike,97
 Comic Neue,/Expressive/Cute,68
 Comic Neue,/Expressive/Happy,45
 Comic Neue,/Expressive/Playful,47
+Comic Neue,/Expressive/Sincere,98
+Comic Neue,/Expressive/Vintage,63
 Comic Neue,/Sans/Rounded,80
 Comic Neue,/Theme/Brush,40
 Coming Soon,/Expressive/Awkward,31
 Coming Soon,/Expressive/Childlike,99
 Coming Soon,/Expressive/Cute,17
 Coming Soon,/Expressive/Playful,18
+Coming Soon,/Expressive/Sincere,99
 Coming Soon,/Sans/Rounded,80
 Coming Soon,/Script/Handwritten,100
 Coming Soon,/Theme/Brush,40
-Comme,/Expressive/Business,77
+Comme,/Expressive/Business,73.8
 Comme,/Expressive/Calm,99
-Comme,/Expressive/Stiff,52
 Comme,/Sans/Humanist,100
-Commissioner,/Expressive/Business,33
+Comme,/Expressive/Stiff,52
+Commissioner,/Expressive/Business,97.1
 Commissioner,/Expressive/Calm,99
 Commissioner,/Expressive/Competent,52
 Commissioner,/Expressive/Innovative,11
 Commissioner,/Sans/Humanist,100
 Commissioner,/Serif/Fat Face,10
 Concert One,/Expressive/Calm,72
-Concert One,/Expressive/Competent,98
 Concert One,/Expressive/Cute,32
+Concert One,/Expressive/Loud,79
 Concert One,/Expressive/Playful,91
 Concert One,/Sans/Geometric,20
 Concert One,/Sans/Grotesque,80
@@ -1602,62 +1808,70 @@ Condiment,/Expressive/Awkward,23
 Condiment,/Expressive/Excited,95
 Condiment,/Expressive/Happy,63
 Condiment,/Expressive/Rugged,51
+Condiment,/Expressive/Vintage,68.7
 Condiment,/Script/Handwritten,60
 Condiment,/Script/Informal,100
 Contrail One,/Expressive/Active,13
 Contrail One,/Expressive/Calm,63
-Contrail One,/Expressive/Competent,97
 Contrail One,/Sans/Humanist,100
 Convergence,/Expressive/Calm,76
 Convergence,/Expressive/Childlike,30
 Cookie,/Expressive/Artistic,59
 Cookie,/Expressive/Cute,76
+Cookie,/Expressive/Sincere,92
 Cookie,/Expressive/Sophisticated,78
+Cookie,/Expressive/Vintage,47
 Cookie,/Script/Formal,100
 Cookie,/Script/Handwritten,80
 Cookie,/Script/Upright Script,40
 Copse,/Expressive/Business,34
 Copse,/Expressive/Calm,83
-Copse,/Expressive/Sincere,93
-Copse,/Expressive/Stiff,51
+Copse,/Expressive/Sincere,92
 Copse,/Serif/Transitional,40
 Copse,/Slab/Clarendon,20
 Copse,/Slab/Humanist,100
+Copse,/Expressive/Stiff,51
 Corben,/Expressive/Calm,58
 Corben,/Expressive/Playful,18
-Corben,/Expressive/Sincere,90
+Corben,/Expressive/Sincere,93
 Corben,/Serif/Fat Face,50
 Corben,/Serif/Modern,50
 Corinthia,/Expressive/Active,32
 Corinthia,/Expressive/Artistic,99
 Corinthia,/Expressive/Fancy,95
 Corinthia,/Expressive/Sophisticated,92
+Corinthia,/Expressive/Vintage,77.9
 Corinthia,/Script/Formal,100
 Corinthia,/Script/Handwritten,80
-Cormorant,/Expressive/Business,59
+Cormorant,/Expressive/Business,67.7
 Cormorant,/Expressive/Calm,85
-Cormorant,/Expressive/Sincere,100
-Cormorant Garamond,/Expressive/Business,59
-Cormorant Garamond,/Expressive/Calm,85
-Cormorant Garamond,/Expressive/Sincere,100
-Cormorant Garamond,/Serif/Old Style Garalde,100
-Cormorant Infant,/Expressive/Business,59
-Cormorant Infant,/Expressive/Calm,85
-Cormorant Infant,/Expressive/Sincere,100
-Cormorant Infant,/Serif/Old Style Garalde,80
-Cormorant SC,/Expressive/Business,59
-Cormorant SC,/Expressive/Calm,85
-Cormorant SC,/Expressive/Sincere,100
-Cormorant SC,/Serif/Old Style Garalde,100
+Cormorant,/Expressive/Sincere,99
+Cormorant,/Expressive/Vintage,81
 Cormorant,/Serif/Old Style Garalde,100
-Cormorant Unicase,/Expressive/Business,59
+Cormorant Garamond,/Expressive/Business,67.7
+Cormorant Garamond,/Expressive/Calm,85
+Cormorant Garamond,/Expressive/Sincere,99
+Cormorant Garamond,/Expressive/Vintage,84.5
+Cormorant Garamond,/Serif/Old Style Garalde,100
+Cormorant Infant,/Expressive/Business,67.7
+Cormorant Infant,/Expressive/Calm,85
+Cormorant Infant,/Expressive/Sincere,99
+Cormorant Infant,/Expressive/Vintage,83.5
+Cormorant Infant,/Serif/Old Style Garalde,80
+Cormorant SC,/Expressive/Business,67.7
+Cormorant SC,/Expressive/Calm,85
+Cormorant SC,/Expressive/Sincere,99
+Cormorant SC,/Expressive/Vintage,84.5
+Cormorant SC,/Serif/Old Style Garalde,100
+Cormorant Unicase,/Expressive/Business,50.7
 Cormorant Unicase,/Expressive/Calm,85
-Cormorant Unicase,/Expressive/Sincere,99
+Cormorant Unicase,/Expressive/Vintage,28
 Cormorant Unicase,/Serif/Old Style Garalde,80
 Cormorant Unicase,/Theme/Medieval,30
-Cormorant Upright,/Expressive/Business,59
+Cormorant Upright,/Expressive/Business,61.9
 Cormorant Upright,/Expressive/Calm,68
-Cormorant Upright,/Expressive/Sincere,96
+Cormorant Upright,/Expressive/Sincere,99
+Cormorant Upright,/Expressive/Vintage,84.5
 Cormorant Upright,/Serif/Old Style Garalde,80
 Courgette,/Expressive/Active,77
 Courgette,/Expressive/Artistic,48
@@ -1665,17 +1879,22 @@ Courgette,/Expressive/Childlike,10
 Courgette,/Expressive/Cute,13
 Courgette,/Expressive/Happy,4
 Courgette,/Expressive/Playful,17
+Courgette,/Expressive/Sincere,92
 Courgette,/Script/Handwritten,10
 Courgette,/Script/Informal,80
 Courier Prime,/Expressive/Calm,98
 Courier Prime,/Expressive/Childlike,10
+Courier Prime,/Expressive/Competent,99.8
 Courier Prime,/Expressive/Sincere,76
+Courier Prime,/Expressive/Vintage,84
 Courier Prime,/Monospace/Monospace,100
 Courier Prime,/Slab/Clarendon,70
 Cousine,/Expressive/Calm,98
-Cousine,/Expressive/Stiff,20
+Cousine,/Expressive/Competent,98
+Cousine,/Expressive/Vintage,83
 Cousine,/Monospace/Monospace,100
 Cousine,/Sans/Neo Grotesque,80
+Cousine,/Expressive/Stiff,20
 Coustard,/Expressive/Calm,76
 Coustard,/Expressive/Playful,1
 Coustard,/Expressive/Rugged,5
@@ -1688,6 +1907,7 @@ Covered By Your Grace,/Expressive/Awkward,12
 Covered By Your Grace,/Expressive/Childlike,56
 Covered By Your Grace,/Expressive/Cute,8
 Covered By Your Grace,/Expressive/Playful,17
+Covered By Your Grace,/Expressive/Vintage,68.7
 Covered By Your Grace,/Script/Handwritten,100
 Covered By Your Grace,/Script/Informal,100
 Covered By Your Grace,/Theme/Brush,100
@@ -1700,76 +1920,89 @@ Crafty Girls,/Expressive/Playful,38
 Crafty Girls,/Script/Handwritten,100
 Crafty Girls,/Script/Informal,100
 Crafty Girls,/Theme/Brush,100
-Creepster Caps,/Expressive/Awkward,78
-Creepster Caps,/Expressive/Calm,56
-Creepster Caps,/Expressive/Excited,57
-Creepster Caps,/Expressive/Innovative,93
-Creepster Caps,/Expressive/Playful,47
-Creepster Caps,/Expressive/Rugged,88
-Creepster Caps,/Theme/Blobby,5
-Creepster Caps,/Theme/Distressed,80
-Creepster Caps,/Theme/Wacky,20
 Creepster,/Expressive/Awkward,78
 Creepster,/Expressive/Calm,56
 Creepster,/Expressive/Excited,57
 Creepster,/Expressive/Innovative,93
 Creepster,/Expressive/Playful,47
 Creepster,/Expressive/Rugged,88
+Creepster,/Expressive/Vintage,73.4
 Creepster,/Theme/Blobby,5
 Creepster,/Theme/Distressed,80
 Creepster,/Theme/Wacky,20
-Crete Round,/Expressive/Business,55
+Creepster Caps,/Expressive/Awkward,78
+Creepster Caps,/Expressive/Calm,56
+Creepster Caps,/Expressive/Excited,57
+Creepster Caps,/Expressive/Innovative,93
+Creepster Caps,/Expressive/Playful,47
+Creepster Caps,/Expressive/Rugged,88
+Creepster Caps,/Expressive/Vintage,73.4
+Creepster Caps,/Theme/Blobby,5
+Creepster Caps,/Theme/Distressed,80
+Creepster Caps,/Theme/Wacky,20
+Crete Round,/Expressive/Business,55.7
 Crete Round,/Expressive/Calm,97
 Crete Round,/Expressive/Happy,1
-Crete Round,/Expressive/Sincere,98
-Crete Round,/Expressive/Stiff,51
 Crete Round,/Slab/Clarendon,100
-Crimson Pro,/Expressive/Business,79
+Crete Round,/Expressive/Stiff,51
+Crimson Pro,/Expressive/Business,86.8
 Crimson Pro,/Expressive/Calm,97
-Crimson Pro,/Expressive/Sincere,97
+Crimson Pro,/Expressive/Competent,97.6
+Crimson Pro,/Expressive/Sincere,94
+Crimson Pro,/Expressive/Vintage,70.6
 Crimson Pro,/Serif/Old Style Garalde,100
-Crimson Text,/Expressive/Business,79
+Crimson Text,/Expressive/Business,86.8
 Crimson Text,/Expressive/Calm,97
-Crimson Text,/Expressive/Sincere,99
+Crimson Text,/Expressive/Competent,97.6
+Crimson Text,/Expressive/Sincere,94
+Crimson Text,/Expressive/Vintage,70.6
 Crimson Text,/Serif/Old Style Garalde,100
 Croissant One,/Expressive/Artistic,30
 Croissant One,/Expressive/Childlike,10
 Croissant One,/Expressive/Cute,41
 Croissant One,/Expressive/Playful,22
 Croissant One,/Expressive/Sincere,18
+Croissant One,/Expressive/Vintage,87
 Croissant One,/Script/Informal,80
 Croissant One,/Script/Upright Script,80
 Croissant One,/Serif/Modern,60
 Crushed,/Expressive/Calm,75
 Crushed,/Expressive/Innovative,13
+Crushed,/Expressive/Loud,31
 Crushed,/Expressive/Playful,36
-Crushed,/Expressive/Stiff,10
+Crushed,/Expressive/Vintage,43.4
 Crushed,/Theme/Art Nouveau,20
 Crushed,/Theme/Wacky,10
+Crushed,/Expressive/Stiff,10
 Cuprum,/Expressive/Business,38
 Cuprum,/Expressive/Calm,99
-Cuprum,/Expressive/Competent,64
-Cuprum,/Expressive/Stiff,78
+Cuprum,/Expressive/Competent,95.5
 Cuprum,/Sans/Neo Grotesque,100
+Cuprum,/Expressive/Stiff,78
 Cute Font,/Expressive/Cute,2
 Cute Font,/Expressive/Futuristic,96
 Cute Font,/Expressive/Innovative,34
-Cute Font,/Expressive/Stiff,77
+Cute Font,/Expressive/Loud,52
+Cute Font,/Expressive/Vintage,56.3
 Cute Font,/Theme/Techno,100
 Cute Font,/Theme/Wacky,10
+Cute Font,/Expressive/Stiff,77
 Cutive,/Expressive/Business,11
 Cutive,/Expressive/Calm,75
 Cutive,/Expressive/Sincere,73
+Cutive,/Expressive/Vintage,77.3
+Cutive,/Slab/Clarendon,80
+Cutive,/Slab/Humanist,10
 Cutive Mono,/Expressive/Calm,75
 Cutive Mono,/Expressive/Sincere,55
+Cutive Mono,/Expressive/Vintage,84.5
 Cutive Mono,/Monospace/Monospace,100
 Cutive Mono,/Slab/Clarendon,80
 Cutive Mono,/Slab/Humanist,10
-Cutive,/Slab/Clarendon,80
-Cutive,/Slab/Humanist,10
 Dai Banna SIL,/Expressive/Business,32
 Dai Banna SIL,/Expressive/Calm,94
 Dai Banna SIL,/Expressive/Sincere,78
+Dai Banna SIL,/Expressive/Vintage,75.4
 Dai Banna SIL,/Serif/Old Style Garalde,40
 Dai Banna SIL,/Serif/Transitional,40
 Damion,/Expressive/Artistic,31
@@ -1777,10 +2010,14 @@ Damion,/Expressive/Childlike,10
 Damion,/Expressive/Cute,70
 Damion,/Expressive/Excited,22
 Damion,/Expressive/Playful,71
+Damion,/Expressive/Sincere,94
+Damion,/Expressive/Vintage,78.4
 Dancing Script,/Expressive/Artistic,80
 Dancing Script,/Expressive/Cute,31
 Dancing Script,/Expressive/Happy,94
+Dancing Script,/Expressive/Sincere,93
 Dancing Script,/Expressive/Sophisticated,62
+Dancing Script,/Expressive/Vintage,84.5
 Dangrek,/Expressive/Calm,68
 Dangrek,/Expressive/Childlike,10
 Dangrek,/Expressive/Cute,55
@@ -1794,10 +2031,11 @@ Darumadrop One,/Expressive/Cute,20
 Darumadrop One,/Expressive/Innovative,92
 Darumadrop One,/Expressive/Playful,67
 Darumadrop One,/Expressive/Rugged,23
+Darumadrop One,/Expressive/Vintage,34
 Darumadrop One,/Theme/Distressed,80
 Darumadrop One,/Theme/Wacky,20
 David Libre,/Expressive/Calm,93
-David Libre,/Expressive/Sincere,99
+David Libre,/Expressive/Vintage,83
 David Libre,/Serif/Old Style Garalde,100
 Dawning of a New Day,/Expressive/Active,35
 Dawning of a New Day,/Expressive/Artistic,31
@@ -1805,7 +2043,8 @@ Dawning of a New Day,/Expressive/Cute,31
 Dawning of a New Day,/Expressive/Excited,32
 Dawning of a New Day,/Expressive/Happy,57
 Dawning of a New Day,/Expressive/Playful,94
-Days One,/Expressive/Business,71
+Dawning of a New Day,/Expressive/Vintage,56.5
+Days One,/Expressive/Business,35
 Days One,/Expressive/Calm,84
 Days One,/Expressive/Futuristic,12
 Days One,/Expressive/Stiff,73
@@ -1818,6 +2057,7 @@ Dela Gothic One,/Expressive/Awkward,35
 Dela Gothic One,/Expressive/Calm,69
 Dela Gothic One,/Expressive/Playful,12
 Dela Gothic One,/Expressive/Rugged,37
+Dela Gothic One,/Expressive/Vintage,44
 Dela Gothic One,/Sans/Geometric,10
 Dela Gothic One,/Sans/Grotesque,80
 Dela Gothic One,/Theme/Wacky,10
@@ -1827,6 +2067,8 @@ Delicious Handrawn,/Expressive/Cute,79
 Delicious Handrawn,/Expressive/Excited,22
 Delicious Handrawn,/Expressive/Happy,36
 Delicious Handrawn,/Expressive/Playful,96
+Delicious Handrawn,/Expressive/Sincere,99
+Delicious Handrawn,/Expressive/Vintage,48.9
 Delius,/Expressive/Calm,57
 Delius,/Expressive/Childlike,36
 Delius,/Expressive/Cute,100
@@ -1840,7 +2082,9 @@ Delius Unicase,/Expressive/Childlike,35
 Delius Unicase,/Expressive/Cute,99
 Delius Unicase,/Expressive/Playful,38
 Della Respira,/Expressive/Artistic,71
-Della Respira,/Expressive/Sincere,50
+Della Respira,/Expressive/Sincere,50.1
+Della Respira,/Expressive/Vintage,88.5
+Denk One,/Expressive/Competent,77
 Denk One,/Expressive/Excited,71
 Denk One,/Expressive/Futuristic,73
 Denk One,/Expressive/Innovative,54
@@ -1850,105 +2094,124 @@ Devonshire,/Expressive/Artistic,66
 Devonshire,/Expressive/Excited,38
 Devonshire,/Expressive/Happy,48
 Devonshire,/Expressive/Playful,16
+Devonshire,/Expressive/Vintage,28.9
 Devonshire,/Script/Handwritten,100
 Devonshire,/Script/Informal,100
 Devonshire,/Script/Upright Script,80
 Dhurjati,/Expressive/Business,1
 Dhurjati,/Expressive/Calm,79
 Dhurjati,/Expressive/Rugged,29
-Dhurjati,/Expressive/Stiff,58
 Dhurjati,/Sans/Superellipse,50
 Dhurjati,/Theme/Woodtype,60
-Dhyana,/Expressive/Business,79
+Dhurjati,/Expressive/Stiff,58
+Dhyana,/Expressive/Business,68.4
 Dhyana,/Expressive/Calm,98
-Dhyana,/Expressive/Stiff,42
 Dhyana,/Sans/Humanist,100
+Dhyana,/Expressive/Stiff,42
 Didact Gothic,/Expressive/Business,34
 Didact Gothic,/Expressive/Calm,100
+Didact Gothic,/Expressive/Vintage,84.5
 Didact Gothic,/Sans/Geometric,100
 Digital Numbers,/Expressive/Calm,99
 Digital Numbers,/Expressive/Futuristic,20
 Digital Numbers,/Expressive/Innovative,73
+Digital Numbers,/Expressive/Loud,51
 Digital Numbers,/Expressive/Playful,11
+Digital Numbers,/Expressive/Vintage,84.5
 Digital Numbers,/Monospace/Monospace,100
 Digital Numbers,/Theme/Techno,100
 Diphylleia,/Expressive/Artistic,22
 Diphylleia,/Expressive/Cute,31
 Diphylleia,/Expressive/Playful,11
+Diphylleia,/Expressive/Vintage,75.4
 Diphylleia,/Script/Informal,20
 Diphylleia,/Script/Upright Script,40
 Diphylleia,/Serif/Transitional,20
 Diplomata,/Expressive/Calm,79
+Diplomata,/Expressive/Competent,97.5
 Diplomata,/Expressive/Innovative,93
+Diplomata,/Expressive/Loud,99
 Diplomata,/Expressive/Rugged,46
+Diplomata,/Expressive/Vintage,94
+Diplomata,/Serif/Didone,100
+Diplomata,/Theme/Inline,100
 Diplomata SC,/Expressive/Calm,79
+Diplomata SC,/Expressive/Competent,97.5
 Diplomata SC,/Expressive/Innovative,93
+Diplomata SC,/Expressive/Loud,99
 Diplomata SC,/Expressive/Rugged,46
+Diplomata SC,/Expressive/Vintage,94
 Diplomata SC,/Script/Informal,20
 Diplomata SC,/Script/Upright Script,40
 Diplomata SC,/Serif/Didone,100
-Diplomata,/Serif/Didone,100
-Diplomata,/Theme/Inline,100
 DM Mono,/Expressive/Business,23
 DM Mono,/Expressive/Calm,99
-DM Mono,/Expressive/Sincere,70
-DM Mono,/Expressive/Stiff,30
+DM Mono,/Expressive/Sincere,70.1
+DM Mono,/Expressive/Vintage,48
 DM Mono,/Monospace/Monospace,100
 DM Mono,/Sans/Geometric,100
 DM Mono,/Sans/Neo Grotesque,10
+DM Mono,/Expressive/Stiff,30
+DM Sans,/Expressive/Business,92.2
 DM Sans,/Expressive/Calm,99
 DM Sans,/Expressive/Competent,24
-DM Sans,/Expressive/Stiff,52
 DM Sans,/Sans/Geometric,100
 DM Sans,/Sans/Neo Grotesque,10
-DM Serif Display,/Expressive/Business,95
+DM Sans,/Expressive/Stiff,52
+DM Serif Display,/Expressive/Business,100
 DM Serif Display,/Expressive/Calm,94
-DM Serif Display,/Expressive/Sincere,93
-DM Serif Display,/Expressive/Stiff,30
+DM Serif Display,/Expressive/Vintage,78.9
 DM Serif Display,/Serif/Transitional,100
-DM Serif Text,/Expressive/Business,97
+DM Serif Display,/Expressive/Stiff,30
+DM Serif Text,/Expressive/Business,100
 DM Serif Text,/Expressive/Calm,94
-DM Serif Text,/Expressive/Sincere,94
-DM Serif Text,/Expressive/Stiff,30
+DM Serif Text,/Expressive/Vintage,78.9
 DM Serif Text,/Serif/Transitional,100
+DM Serif Text,/Expressive/Stiff,30
 Do Hyeon,/Expressive/Calm,17
 Do Hyeon,/Expressive/Futuristic,79
 Do Hyeon,/Expressive/Playful,31
-Do Hyeon,/Expressive/Stiff,92
 Do Hyeon,/Sans/Geometric,20
 Do Hyeon,/Sans/Humanist,20
 Do Hyeon,/Sans/Superellipse,100
+Do Hyeon,/Expressive/Stiff,92
 Dokdo,/Expressive/Active,51
 Dokdo,/Expressive/Awkward,92
 Dokdo,/Expressive/Childlike,96
 Dokdo,/Expressive/Excited,52
 Dokdo,/Expressive/Happy,60
+Dokdo,/Expressive/Loud,34
 Dokdo,/Expressive/Playful,100
 Dokdo,/Expressive/Rugged,72
 Dokdo,/Theme/Brush,100
+Domine,/Expressive/Business,72.6
 Domine,/Expressive/Playful,11
-Domine,/Expressive/Sincere,95
-Domine,/Expressive/Stiff,10
+Domine,/Expressive/Vintage,63.2
 Domine,/Serif/Modern,100
 Domine,/Serif/Transitional,20
-Donegal One,/Expressive/Business,37
+Domine,/Expressive/Stiff,10
+Donegal One,/Expressive/Business,61.5
 Donegal One,/Expressive/Calm,92
 Donegal One,/Expressive/Excited,11
-Donegal One,/Expressive/Sincere,99
+Donegal One,/Expressive/Sincere,91
+Donegal One,/Expressive/Vintage,78.4
 Donegal One,/Serif/Transitional,80
 Dongle,/Expressive/Calm,93
 Dongle,/Expressive/Cute,14
 Dongle,/Expressive/Playful,10
+Dongle,/Expressive/Vintage,39.2
 Dongle,/Sans/Geometric,100
 Dongle,/Sans/Rounded,100
 Doppio One,/Expressive/Calm,99
-Doppio One,/Expressive/Stiff,78
 Doppio One,/Sans/Humanist,100
+Doppio One,/Expressive/Stiff,78
 Dorsa,/Expressive/Artistic,10
 Dorsa,/Expressive/Awkward,21
 Dorsa,/Expressive/Calm,90
+Dorsa,/Expressive/Competent,96.7
 Dorsa,/Expressive/Futuristic,39
 Dorsa,/Expressive/Playful,31
+Dorsa,/Expressive/Vintage,69.3
 Dorsa,/Theme/Art Deco,40
 Dosis,/Expressive/Calm,79
 Dosis,/Expressive/Childlike,10
@@ -1959,18 +2222,23 @@ Dosis,/Sans/Rounded,100
 DotGothic16,/Expressive/Awkward,51
 DotGothic16,/Expressive/Futuristic,98
 DotGothic16,/Expressive/Innovative,46
-DotGothic16,/Expressive/Stiff,10
+DotGothic16,/Expressive/Vintage,75
 DotGothic16,/Sans/Glyphic,80
 DotGothic16,/Sans/Grotesque,30
 DotGothic16,/Theme/Techno,100
+DotGothic16,/Expressive/Stiff,10
 Dr Sugiyama,/Expressive/Artistic,80
+Dr Sugiyama,/Expressive/Loud,76
+Dr Sugiyama,/Expressive/Vintage,58.9
 Dr Sugiyama,/Script/Handwritten,30
 Dr Sugiyama,/Script/Informal,50
 Dr Sugiyama,/Script/Upright Script,100
+Duru Sans,/Expressive/Business,95.1
 Duru Sans,/Expressive/Calm,99
-Duru Sans,/Expressive/Stiff,55
 Duru Sans,/Sans/Humanist,100
+Duru Sans,/Expressive/Stiff,55
 Dynalight,/Expressive/Artistic,99
+Dynalight,/Expressive/Vintage,92
 Dynalight,/Script/Formal,100
 DynaPuff,/Expressive/Awkward,41
 DynaPuff,/Expressive/Calm,18
@@ -1984,6 +2252,7 @@ DynaPuff,/Theme/Blobby,100
 DynaPuff,/Theme/Wacky,50
 Eagle Lake,/Expressive/Artistic,92
 Eagle Lake,/Expressive/Calm,37
+Eagle Lake,/Expressive/Vintage,98
 Eagle Lake,/Script/Formal,50
 Eagle Lake,/Script/Handwritten,70
 Eagle Lake,/Theme/Medieval,50
@@ -1997,37 +2266,20 @@ East Sea Dokdo,/Script/Handwritten,100
 Eater,/Expressive/Awkward,97
 Eater,/Expressive/Excited,100
 Eater,/Expressive/Innovative,92
+Eater,/Expressive/Vintage,67.8
 Eater,/Theme/Wacky,100
-EB Garamond,/Expressive/Business,40
+EB Garamond,/Expressive/Business,79.6
+EB Garamond,/Expressive/Sincere,100
+EB Garamond,/Expressive/Vintage,82.5
 EB Garamond,/Serif/Old Style Garalde,100
 Economica,/Expressive/Business,48
 Economica,/Expressive/Calm,82
-Economica,/Expressive/Competent,74
 Economica,/Expressive/Futuristic,68
-Economica,/Expressive/Stiff,79
 Economica,/Sans/Humanist,80
 Economica,/Sans/Superellipse,100
-Eczar,/Expressive/Sincere,95
+Economica,/Expressive/Stiff,79
+Eczar,/Expressive/Vintage,81
 Eczar,/Serif/Old Style Garalde,60
-Edu NSW ACT Foundation,/Expressive/Active,59
-Edu NSW ACT Foundation,/Expressive/Childlike,90
-Edu NSW ACT Foundation,/Script/Handwritten,100
-Edu NSW ACT Foundation,/Script/Informal,60
-Edu QLD Beginner,/Expressive/Active,95
-Edu QLD Beginner,/Expressive/Childlike,90
-Edu QLD Beginner,/Expressive/Cute,15
-Edu QLD Beginner,/Script/Handwritten,100
-Edu QLD Beginner,/Script/Informal,60
-Edu SA Beginner,/Expressive/Active,94
-Edu SA Beginner,/Expressive/Childlike,90
-Edu SA Beginner,/Expressive/Cute,20
-Edu SA Beginner,/Script/Handwritten,100
-Edu SA Beginner,/Script/Informal,60
-Edu TAS Beginner,/Expressive/Active,95
-Edu TAS Beginner,/Expressive/Childlike,90
-Edu TAS Beginner,/Expressive/Cute,15
-Edu TAS Beginner,/Script/Handwritten,100
-Edu TAS Beginner,/Script/Informal,60
 Edu AU VIC WA NT Arrows,/Expressive/Childlike,90
 Edu AU VIC WA NT Arrows,/Expressive/Cute,15
 Edu AU VIC WA NT Arrows,/Script/Handwritten,100
@@ -2084,77 +2336,109 @@ Edu AU VIC WA NT Starters Guide,/Expressive/Active,60
 Edu AU VIC WA NT Starters Guide,/Expressive/Childlike,90
 Edu AU VIC WA NT Starters Guide,/Script/Handwritten,100
 Edu AU VIC WA NT Starters Guide,/Script/Informal,60
+Edu NSW ACT Foundation,/Expressive/Active,59
+Edu NSW ACT Foundation,/Expressive/Childlike,90
+Edu NSW ACT Foundation,/Expressive/Sincere,100
+Edu NSW ACT Foundation,/Script/Handwritten,100
+Edu NSW ACT Foundation,/Script/Informal,60
+Edu QLD Beginner,/Expressive/Active,95
+Edu QLD Beginner,/Expressive/Childlike,90
+Edu QLD Beginner,/Expressive/Cute,15
+Edu QLD Beginner,/Expressive/Sincere,100
+Edu QLD Beginner,/Script/Handwritten,100
+Edu QLD Beginner,/Script/Informal,60
+Edu SA Beginner,/Expressive/Active,94
+Edu SA Beginner,/Expressive/Childlike,90
+Edu SA Beginner,/Expressive/Cute,20
+Edu SA Beginner,/Expressive/Sincere,100
+Edu SA Beginner,/Script/Handwritten,100
+Edu SA Beginner,/Script/Informal,60
+Edu TAS Beginner,/Expressive/Active,95
+Edu TAS Beginner,/Expressive/Childlike,90
+Edu TAS Beginner,/Expressive/Cute,15
+Edu TAS Beginner,/Expressive/Sincere,100
+Edu TAS Beginner,/Script/Handwritten,100
+Edu TAS Beginner,/Script/Informal,60
 Edu VIC WA NT Beginner,/Expressive/Active,96
+Edu VIC WA NT Beginner,/Expressive/Sincere,100
 Edu VIC WA NT Beginner,/Script/Handwritten,100
 Edu VIC WA NT Beginner,/Script/Informal,60
-Ek Mukta,/Expressive/Business,44
+Ek Mukta,/Expressive/Business,89
 Ek Mukta,/Expressive/Calm,100
 Ek Mukta,/Expressive/Competent,41
-Ek Mukta,/Expressive/Stiff,53
 Ek Mukta,/Indic/Contemporary,100
 Ek Mukta,/Sans/Humanist,100
-Electrolize,/Expressive/Calm,59
-Electrolize,/Expressive/Futuristic,100
-Electrolize,/Expressive/Stiff,99
-Electrolize,/Sans/Geometric,80
-Electrolize,/Theme/Techno,100
+Ek Mukta,/Expressive/Stiff,53
 El Messiri,/Expressive/Calm,73
 El Messiri,/Expressive/Innovative,11
 El Messiri,/Sans/Glyphic,80
+Electrolize,/Expressive/Calm,59
+Electrolize,/Expressive/Futuristic,100
+Electrolize,/Sans/Geometric,80
+Electrolize,/Theme/Techno,100
+Electrolize,/Expressive/Stiff,99
 Elsie,/Expressive/Business,12
 Elsie,/Expressive/Calm,69
 Elsie,/Expressive/Playful,21
-Elsie,/Expressive/Sincere,61
+Elsie,/Expressive/Sincere,60.5
+Elsie,/Expressive/Vintage,67.3
 Elsie,/Serif/Didone,90
 Elsie Swash Caps,/Expressive/Business,11
 Elsie Swash Caps,/Expressive/Calm,68
 Elsie Swash Caps,/Expressive/Happy,24
 Elsie Swash Caps,/Expressive/Playful,22
-Elsie Swash Caps,/Expressive/Sincere,61
+Elsie Swash Caps,/Expressive/Sincere,60.5
+Elsie Swash Caps,/Expressive/Vintage,67.3
 Elsie Swash Caps,/Serif/Didone,100
 Emblema One,/Expressive/Active,13
+Emblema One,/Expressive/Loud,97
+Emblema One,/Expressive/Vintage,53.8
 Emblema One,/Theme/Stencil,100
 Emblema One,/Theme/Woodtype,80
 Emilys Candy,/Expressive/Awkward,44
 Emilys Candy,/Expressive/Childlike,71
 Emilys Candy,/Expressive/Excited,38
 Emilys Candy,/Expressive/Happy,46
+Emilys Candy,/Expressive/Loud,73
 Emilys Candy,/Expressive/Playful,20
 Emilys Candy,/Serif/Modern,80
 Emilys Candy,/Theme/Distressed,20
 Emilys Candy,/Theme/Wacky,80
-Encode Sans Condensed,/Expressive/Business,17
-Encode Sans Condensed,/Expressive/Calm,99
-Encode Sans Condensed,/Expressive/Competent,73
-Encode Sans Condensed,/Expressive/Stiff,76
-Encode Sans Condensed,/Sans/Humanist,100
-Encode Sans Expanded,/Expressive/Business,17
-Encode Sans Expanded,/Expressive/Calm,99
-Encode Sans Expanded,/Expressive/Competent,15
-Encode Sans Expanded,/Expressive/Stiff,76
-Encode Sans Expanded,/Sans/Humanist,100
-Encode Sans,/Expressive/Business,57
+Encode Sans,/Expressive/Business,93.4
 Encode Sans,/Expressive/Calm,99
-Encode Sans,/Expressive/Competent,66
-Encode Sans,/Expressive/Stiff,76
+Encode Sans,/Expressive/Competent,95.4
 Encode Sans,/Sans/Humanist,100
-Encode Sans SC,/Expressive/Business,57
+Encode Sans,/Expressive/Stiff,76
+Encode Sans Condensed,/Expressive/Business,93.2
+Encode Sans Condensed,/Expressive/Calm,99
+Encode Sans Condensed,/Expressive/Competent,95.4
+Encode Sans Condensed,/Sans/Humanist,100
+Encode Sans Condensed,/Expressive/Stiff,76
+Encode Sans Expanded,/Expressive/Business,93.2
+Encode Sans Expanded,/Expressive/Calm,99
+Encode Sans Expanded,/Expressive/Competent,95.4
+Encode Sans Expanded,/Sans/Humanist,100
+Encode Sans Expanded,/Expressive/Stiff,76
+Encode Sans SC,/Expressive/Business,93.4
 Encode Sans SC,/Expressive/Calm,99
-Encode Sans SC,/Expressive/Competent,66
-Encode Sans SC,/Expressive/Stiff,76
+Encode Sans SC,/Expressive/Competent,95.4
 Encode Sans SC,/Sans/Humanist,100
-Encode Sans Semi Condensed,/Expressive/Business,17
+Encode Sans SC,/Expressive/Stiff,76
+Encode Sans Semi Condensed,/Expressive/Business,93.2
 Encode Sans Semi Condensed,/Expressive/Calm,99
-Encode Sans Semi Condensed,/Expressive/Competent,59
-Encode Sans Semi Condensed,/Expressive/Stiff,76
+Encode Sans Semi Condensed,/Expressive/Competent,95.4
 Encode Sans Semi Condensed,/Sans/Humanist,100
-Encode Sans Semi Expanded,/Expressive/Business,17
+Encode Sans Semi Condensed,/Expressive/Stiff,76
+Encode Sans Semi Expanded,/Expressive/Business,93.2
 Encode Sans Semi Expanded,/Expressive/Calm,99
-Encode Sans Semi Expanded,/Expressive/Competent,59
-Encode Sans Semi Expanded,/Expressive/Stiff,76
+Encode Sans Semi Expanded,/Expressive/Competent,95.4
 Encode Sans Semi Expanded,/Sans/Humanist,100
+Encode Sans Semi Expanded,/Expressive/Stiff,76
 Engagement,/Expressive/Artistic,94
+Engagement,/Expressive/Loud,61
 Engagement,/Expressive/Playful,22
+Engagement,/Expressive/Sincere,94
+Engagement,/Expressive/Vintage,91
 Engagement,/Script/Formal,100
 Engagement,/Script/Upright Script,100
 Englebert,/Expressive/Awkward,51
@@ -2162,92 +2446,107 @@ Englebert,/Expressive/Childlike,42
 Englebert,/Expressive/Cute,68
 Englebert,/Expressive/Playful,48
 Englebert,/Theme/Wacky,50
-Enriqueta,/Expressive/Business,96
+Enriqueta,/Expressive/Business,97.7
 Enriqueta,/Expressive/Calm,97
-Enriqueta,/Expressive/Stiff,40
 Enriqueta,/Slab/Humanist,80
+Enriqueta,/Expressive/Stiff,40
 Ephesis,/Expressive/Artistic,99
 Ephesis,/Expressive/Excited,13
 Ephesis,/Expressive/Happy,31
+Ephesis,/Expressive/Sincere,92
+Ephesis,/Expressive/Vintage,54.7
 Ephesis,/Script/Formal,100
 Epilogue,/Expressive/Calm,99
 Epilogue,/Expressive/Competent,13
-Epilogue,/Expressive/Stiff,71
 Epilogue,/Sans/Geometric,80
+Epilogue,/Expressive/Stiff,71
 Erica One,/Expressive/Business,63
 Erica One,/Expressive/Calm,88
+Erica One,/Expressive/Loud,100
 Erica One,/Expressive/Rugged,79
 Erica One,/Sans/Humanist,50
 Erica One,/Sans/Neo Grotesque,70
 Erica One,/Theme/Woodtype,80
-Esteban,/Expressive/Business,53
+Esteban,/Expressive/Business,53.3
 Esteban,/Expressive/Calm,96
 Esteban,/Expressive/Playful,14
-Esteban,/Expressive/Sincere,93
+Esteban,/Expressive/Vintage,82
 Esteban,/Serif/Transitional,100
 Esteban,/Theme/Distressed,20
 Estonia,/Expressive/Artistic,77
 Estonia,/Expressive/Rugged,66
+Estonia,/Expressive/Vintage,59.4
 Estonia,/Script/Informal,40
 Estonia,/Theme/Distressed,100
 Euphoria Script,/Expressive/Artistic,40
 Euphoria Script,/Expressive/Fancy,43
 Euphoria Script,/Expressive/Happy,16
+Euphoria Script,/Expressive/Sincere,94
+Euphoria Script,/Expressive/Vintage,43.9
 Euphoria Script,/Script/Formal,20
 Euphoria Script,/Script/Informal,60
 Ewert,/Expressive/Innovative,42
+Ewert,/Expressive/Vintage,93.5
 Ewert,/Theme/Shaded,100
 Ewert,/Theme/Woodtype,20
-Exo 2,/Expressive/Calm,76
-Exo 2,/Expressive/Competent,51
-Exo 2,/Expressive/Futuristic,79
-Exo 2,/Expressive/Stiff,88
-Exo 2,/Sans/Humanist,30
-Exo 2,/Sans/Superellipse,100
 Exo,/Expressive/Calm,75
 Exo,/Expressive/Competent,33
 Exo,/Expressive/Futuristic,78
-Exo,/Expressive/Stiff,88
 Exo,/Sans/Humanist,30
 Exo,/Sans/Superellipse,100
+Exo,/Expressive/Stiff,88
+Exo 2,/Expressive/Calm,76
+Exo 2,/Expressive/Competent,51
+Exo 2,/Expressive/Futuristic,79
+Exo 2,/Sans/Humanist,30
+Exo 2,/Sans/Superellipse,100
+Exo 2,/Expressive/Stiff,88
 Expletus Sans,/Expressive/Awkward,78
 Expletus Sans,/Expressive/Calm,69
-Expletus Sans,/Expressive/Competent,53
 Expletus Sans,/Expressive/Innovative,11
 Expletus Sans,/Expressive/Rugged,51
-Expletus Sans,/Expressive/Stiff,40
 Expletus Sans,/Sans/Humanist,20
 Expletus Sans,/Sans/Superellipse,100
 Expletus Sans,/Theme/Stencil,100
+Expletus Sans,/Expressive/Stiff,40
 Explora,/Expressive/Artistic,98
 Explora,/Expressive/Sophisticated,78
+Explora,/Expressive/Vintage,64.3
 Explora,/Script/Formal,100
 Fahkwang,/Expressive/Calm,97
+Fahkwang,/Expressive/Competent,98.7
+Fahkwang,/Expressive/Loud,61
 Fahkwang,/Sans/Grotesque,20
 Familjen Grotesk,/Expressive/Calm,99
 Familjen Grotesk,/Expressive/Competent,19
 Familjen Grotesk,/Sans/Neo Grotesque,100
-Fanwood Text,/Expressive/Business,57
+Fanwood Text,/Expressive/Business,57.6
 Fanwood Text,/Expressive/Calm,97
-Fanwood Text,/Expressive/Sincere,93
+Fanwood Text,/Expressive/Sincere,97
 Fanwood Text,/Serif/Transitional,100
-Farro,/Expressive/Business,61
+Farro,/Expressive/Business,41
 Farro,/Expressive/Calm,93
 Farro,/Expressive/Competent,23
-Farro,/Expressive/Stiff,54
+Farro,/Expressive/Vintage,85
 Farro,/Sans/Glyphic,100
 Farro,/Sans/Humanist,80
+Farro,/Expressive/Stiff,54
 Farsan,/Expressive/Active,96
 Farsan,/Expressive/Childlike,70
 Farsan,/Script/Handwritten,100
 Fascinate,/Expressive/Artistic,100
+Fascinate,/Expressive/Loud,97
+Fascinate,/Expressive/Vintage,92
+Fascinate,/Theme/Art Deco,100
 Fascinate Inline,/Expressive/Artistic,100
 Fascinate Inline,/Expressive/Innovative,95
+Fascinate Inline,/Expressive/Loud,97
+Fascinate Inline,/Expressive/Vintage,92
 Fascinate Inline,/Theme/Art Deco,100
 Fascinate Inline,/Theme/Inline,100
-Fascinate,/Theme/Art Deco,100
 Faster One,/Expressive/Innovative,94
 Faster One,/Expressive/Rugged,83
+Faster One,/Expressive/Vintage,62
 Fasthand,/Expressive/Cute,16
 Fasthand,/Script/Handwritten,100
 Fasthand,/Script/Informal,100
@@ -2255,12 +2554,14 @@ Fauna One,/Expressive/Business,3
 Fauna One,/Expressive/Calm,57
 Fauna One,/Expressive/Sincere,40
 Fauna One,/Slab/Humanist,100
-Faustina,/Expressive/Business,99
-Faustina,/Expressive/Sincere,99
+Faustina,/Expressive/Business,99.1
+Faustina,/Expressive/Sincere,94
+Faustina,/Expressive/Vintage,49.8
 Faustina,/Serif/Scotch,100
 Federant,/Expressive/Awkward,31
 Federant,/Expressive/Futuristic,36
 Federant,/Expressive/Happy,18
+Federant,/Expressive/Vintage,71.2
 Federant,/Sans/Humanist,20
 Federant,/Sans/Superellipse,100
 Federo,/Expressive/Artistic,50
@@ -2270,8 +2571,10 @@ Felipa,/Expressive/Artistic,60
 Felipa,/Expressive/Fancy,33
 Felipa,/Expressive/Sincere,62
 Felipa,/Expressive/Sophisticated,92
+Felipa,/Expressive/Vintage,91.5
 Felipa,/Script/Formal,100
 Fenix,/Expressive/Sincere,50
+Fenix,/Expressive/Vintage,69.3
 Fenix,/Serif/Humanist Venetian,20
 Fenix,/Serif/Old Style Garalde,20
 Festive,/Expressive/Artistic,100
@@ -2281,6 +2584,7 @@ Festive,/Expressive/Fancy,97
 Festive,/Script/Handwritten,30
 Festive,/Script/Informal,100
 Festive,/Theme/Wacky,40
+Figtree,/Expressive/Business,93
 Figtree,/Expressive/Calm,100
 Figtree,/Sans/Geometric,100
 Finger Paint,/Expressive/Childlike,99
@@ -2288,39 +2592,44 @@ Finger Paint,/Expressive/Happy,59
 Finger Paint,/Expressive/Innovative,92
 Finger Paint,/Expressive/Playful,92
 Finger Paint,/Expressive/Rugged,72
-Finlandica,/Expressive/Business,55
+Finlandica,/Expressive/Business,52
 Finlandica,/Expressive/Calm,96
-Finlandica,/Expressive/Competent,94
+Finlandica,/Expressive/Competent,89.8
 Finlandica,/Sans/Humanist,100
-Fira Code,/Expressive/Competent,95
+Fira Code,/Expressive/Competent,100
 Fira Code,/Monospace/Monospace,100
 Fira Code,/Sans/Humanist,80
 Fira Code,/Slab/Humanist,30
-Fira Mono,/Expressive/Competent,92
+Fira Mono,/Expressive/Competent,100
 Fira Mono,/Monospace/Monospace,100
 Fira Mono,/Sans/Humanist,80
 Fira Mono,/Slab/Humanist,30
-Fira Sans Condensed,/Expressive/Calm,98
-Fira Sans Condensed,/Expressive/Competent,93
+Fira Sans,/Expressive/Business,97
 Fira Sans,/Expressive/Calm,96
-Fira Sans,/Expressive/Competent,73
-Fira Sans Extra Condensed,/Expressive/Calm,99
-Fira Sans Extra Condensed,/Expressive/Competent,93
+Fira Sans,/Expressive/Competent,100
+Fira Sans,/Expressive/Sincere,96
 Fira Sans,/Sans/Humanist,100
+Fira Sans Condensed,/Expressive/Business,97
+Fira Sans Condensed,/Expressive/Calm,98
+Fira Sans Condensed,/Expressive/Competent,100
+Fira Sans Condensed,/Expressive/Sincere,96
+Fira Sans Extra Condensed,/Expressive/Business,52.1
+Fira Sans Extra Condensed,/Expressive/Calm,99
+Fira Sans Extra Condensed,/Expressive/Competent,100
+Fira Sans Extra Condensed,/Expressive/Sincere,96
 Fjalla One,/Expressive/Calm,76
-Fjalla One,/Expressive/Competent,98
+Fjalla One,/Expressive/Competent,99.7
 Fjalla One,/Sans/Grotesque,100
 Fjalla One,/Sans/Superellipse,100
 Fjord One,/Expressive/Business,34
-Fjord One,/Expressive/Sincere,99
+Fjord One,/Expressive/Sincere,94
 Fjord One,/Serif/Scotch,80
 Flamenco,/Expressive/Business,41
 Flamenco,/Expressive/Calm,92
-Flamenco,/Expressive/Competent,62
 Flamenco,/Expressive/Cute,24
-Flamenco,/Expressive/Stiff,40
 Flamenco,/Sans/Geometric,50
 Flamenco,/Slab/Humanist,50
+Flamenco,/Expressive/Stiff,40
 Flavors,/Expressive/Awkward,47
 Flavors,/Expressive/Childlike,99
 Flavors,/Expressive/Excited,80
@@ -2330,47 +2639,53 @@ Flavors,/Expressive/Rugged,99
 Fleur De Leah,/Expressive/Artistic,100
 Fleur De Leah,/Expressive/Fancy,100
 Fleur De Leah,/Expressive/Sophisticated,98
+Fleur De Leah,/Expressive/Vintage,66.4
 Fleur De Leah,/Script/Formal,60
 Fleur De Leah,/Script/Informal,40
 Flow Block,/Not text/Symbols,100
 Flow Circular,/Not text/Symbols,100
 Flow Rounded,/Not text/Symbols,100
-Foldit,/Expressive/Competent,100
 Foldit,/Expressive/Innovative,100
 Foldit,/Expressive/Rugged,99
-Foldit,/Expressive/Stiff,93
 Foldit,/Theme/Shaded,100
+Foldit,/Expressive/Stiff,93
 Fondamento,/Expressive/Active,56
 Fondamento,/Expressive/Calm,38
+Fondamento,/Expressive/Vintage,92
 Fondamento,/Script/Handwritten,100
 Fontdiner Swanky,/Expressive/Awkward,100
 Fontdiner Swanky,/Expressive/Excited,50
 Fontdiner Swanky,/Expressive/Happy,83
+Fontdiner Swanky,/Expressive/Loud,72
+Fontdiner Swanky,/Expressive/Vintage,58.4
 Fontdiner Swanky,/Theme/Wacky,100
-Forum,/Expressive/Sincere,91
+Forum,/Expressive/Sincere,95
 Forum,/Serif/Modern,100
 Fragment Mono,/Expressive/Business,42
 Fragment Mono,/Expressive/Calm,98
-Fragment Mono,/Expressive/Stiff,64
 Fragment Mono,/Sans/Grotesque,100
+Fragment Mono,/Expressive/Stiff,64
 Francois One,/Expressive/Business,20
 Francois One,/Expressive/Calm,99
-Francois One,/Expressive/Competent,79
-Francois One,/Expressive/Stiff,30
+Francois One,/Expressive/Competent,99.7
 Francois One,/Sans/Grotesque,20
 Francois One,/Sans/Humanist,10
 Francois One,/Sans/Neo Grotesque,80
-Frank Ruhl Libre,/Expressive/Business,46
+Francois One,/Expressive/Stiff,30
+Frank Ruhl Libre,/Expressive/Business,67
 Frank Ruhl Libre,/Expressive/Calm,96
-Frank Ruhl Libre,/Expressive/Sincere,100
+Frank Ruhl Libre,/Expressive/Loud,54
+Frank Ruhl Libre,/Expressive/Vintage,81
 Frank Ruhl Libre,/Serif/Modern,80
 Fraunces,/Expressive/Artistic,50
 Fraunces,/Expressive/Calm,69
 Fraunces,/Expressive/Cute,13
 Fraunces,/Expressive/Happy,2
 Fraunces,/Expressive/Innovative,51
+Fraunces,/Expressive/Loud,57
 Fraunces,/Expressive/Playful,61
 Fraunces,/Expressive/Sincere,90
+Fraunces,/Expressive/Vintage,84.5
 Fraunces,/Serif/Old Style Garalde,100
 Fraunces,/Theme/Wacky,20
 Fraunces,/Theme/Woodtype,50
@@ -2378,8 +2693,10 @@ Freckle Face,/Expressive/Awkward,69
 Freckle Face,/Expressive/Childlike,32
 Freckle Face,/Expressive/Excited,49
 Freckle Face,/Expressive/Innovative,64
+Freckle Face,/Expressive/Loud,79
 Freckle Face,/Expressive/Playful,77
 Freckle Face,/Expressive/Rugged,83
+Freckle Face,/Expressive/Vintage,54
 Freckle Face,/Theme/Distressed,100
 Freckle Face,/Theme/Techno,30
 Freckle Face,/Theme/Wacky,70
@@ -2389,23 +2706,23 @@ Fredericka the Great,/Expressive/Innovative,72
 Fredericka the Great,/Expressive/Playful,22
 Fredericka the Great,/Expressive/Rugged,87
 Fredericka the Great,/Expressive/Sincere,1
+Fredericka the Great,/Expressive/Vintage,27
 Fredericka the Great,/Serif/Didone,100
 Fredericka the Great,/Theme/Brush,10
 Fredericka the Great,/Theme/Distressed,80
 Fredericka the Great,/Theme/Wacky,20
 Fredoka,/Expressive/Calm,99
 Fredoka,/Expressive/Cute,15
+Fredoka,/Expressive/Vintage,52
 Fredoka,/Sans/Geometric,100
 Fredoka,/Sans/Rounded,100
 Freehand,/Expressive/Artistic,91
 Freehand,/Expressive/Rugged,75
+Freehand,/Expressive/Vintage,84.5
 Freehand,/Script/Handwritten,100
 Freehand,/Script/Informal,80
 Freehand,/Theme/Brush,30
 Freehand,/Theme/Distressed,80
-Freeman,/Expressive/Business,50
-Freeman,/Expressive/Business,50
-Freeman,/Expressive/Competent,60
 Freeman,/Sans/Grotesque,70
 Freeman,/Sans/Humanist,30
 Fresca,/Expressive/Awkward,11
@@ -2423,6 +2740,7 @@ Frijole,/Expressive/Excited,40
 Frijole,/Expressive/Innovative,93
 Frijole,/Expressive/Playful,60
 Frijole,/Expressive/Rugged,80
+Frijole,/Expressive/Vintage,13
 Frijole,/Sans/Humanist,80
 Frijole,/Theme/Distressed,40
 Frijole,/Theme/Wacky,90
@@ -2430,7 +2748,9 @@ Frijole,/Theme/Woodtype,40
 Fruktur,/Expressive/Artistic,63
 Fruktur,/Expressive/Awkward,34
 Fruktur,/Expressive/Childlike,31
+Fruktur,/Expressive/Loud,90
 Fruktur,/Expressive/Playful,30
+Fruktur,/Expressive/Vintage,67
 Fruktur,/Script/Informal,70
 Fruktur,/Script/Upright Script,100
 Fruktur,/Theme/Blackletter,90
@@ -2440,32 +2760,38 @@ Fugaz One,/Expressive/Calm,71
 Fugaz One,/Expressive/Childlike,20
 Fugaz One,/Expressive/Cute,3
 Fugaz One,/Expressive/Playful,31
+Fugaz One,/Expressive/Vintage,32
 Fugaz One,/Sans/Geometric,80
 Fugaz One,/Sans/Glyphic,10
 Fuggles,/Expressive/Artistic,80
 Fuggles,/Expressive/Excited,79
+Fuggles,/Expressive/Vintage,68.9
 Fuggles,/Script/Handwritten,50
 Fuggles,/Script/Informal,100
+Fustat,/Arabic/Kufi,90
 Fuzzy Bubbles,/Expressive/Artistic,3
 Fuzzy Bubbles,/Expressive/Awkward,62
 Fuzzy Bubbles,/Expressive/Childlike,77
 Fuzzy Bubbles,/Expressive/Cute,59
 Fuzzy Bubbles,/Expressive/Happy,61
 Fuzzy Bubbles,/Expressive/Playful,34
+Fuzzy Bubbles,/Expressive/Sincere,99
 Fuzzy Bubbles,/Script/Handwritten,100
 Fuzzy Bubbles,/Script/Informal,100
 Fuzzy Bubbles,/Theme/Brush,80
 Fuzzy Bubbles,/Theme/Wacky,20
-Gabarito,/Expressive/Business,57
+Gabarito,/Expressive/Business,57.3
 Gabarito,/Expressive/Calm,99
-Gabarito,/Expressive/Stiff,81
+Gabarito,/Expressive/Vintage,32.9
 Gabarito,/Sans/Geometric,100
+Gabarito,/Expressive/Stiff,81
 Gabriela,/Expressive/Calm,76
 Gabriela,/Expressive/Cute,15
 Gabriela,/Expressive/Happy,42
 Gabriela,/Expressive/Innovative,61
 Gabriela,/Expressive/Playful,61
 Gabriela,/Expressive/Sincere,17
+Gabriela,/Expressive/Vintage,47.3
 Gabriela,/Script/Upright Script,80
 Gabriela,/Serif/Old Style Garalde,80
 Gabriela,/Theme/Wacky,20
@@ -2485,23 +2811,26 @@ Gaegu,/Theme/Brush,80
 Gafata,/Expressive/Awkward,21
 Gafata,/Expressive/Business,53
 Gafata,/Expressive/Calm,93
-Gafata,/Expressive/Stiff,82
 Gafata,/Sans/Humanist,100
+Gafata,/Expressive/Stiff,82
 Gajraj One,/Expressive/Calm,80
 Gajraj One,/Expressive/Innovative,14
 Gajraj One,/Expressive/Rugged,100
-Gajraj One,/Expressive/Stiff,95
 Gajraj One,/Indic/Contemporary,90
 Gajraj One,/Indic/Sign Painting,80
+Gajraj One,/Expressive/Stiff,95
 Galada,/Expressive/Artistic,75
 Galada,/Expressive/Cute,35
 Galada,/Expressive/Fancy,92
 Galada,/Expressive/Happy,51
+Galada,/Expressive/Loud,73
 Galada,/Expressive/Playful,51
+Galada,/Expressive/Sincere,92
 Galada,/Script/Informal,100
 Galdeano,/Expressive/Calm,94
-Galdeano,/Expressive/Stiff,71
+Galdeano,/Expressive/Vintage,81
 Galdeano,/Sans/Glyphic,100
+Galdeano,/Expressive/Stiff,71
 Galindo,/Expressive/Awkward,92
 Galindo,/Expressive/Calm,48
 Galindo,/Expressive/Childlike,70
@@ -2518,106 +2847,117 @@ Gamja Flower,/Script/Informal,100
 Gamja Flower,/Script/Upright Script,100
 Gamja Flower,/Theme/Blobby,50
 Gamja Flower,/Theme/Brush,90
-Gantari,/Expressive/Business,57
+Gantari,/Expressive/Business,93.6
 Gantari,/Expressive/Calm,100
-Gantari,/Expressive/Stiff,71
 Gantari,/Sans/Geometric,20
 Gantari,/Sans/Neo Grotesque,100
+Gantari,/Expressive/Stiff,71
 Gasoek One,/Expressive/Business,38
 Gasoek One,/Expressive/Calm,100
+Gasoek One,/Expressive/Loud,100
 Gasoek One,/Expressive/Rugged,68
-Gasoek One,/Expressive/Stiff,76
 Gasoek One,/Sans/Neo Grotesque,80
 Gasoek One,/Theme/Woodtype,70
+Gasoek One,/Expressive/Stiff,76
 Gayathri,/Expressive/Calm,98
 Gayathri,/Expressive/Cute,14
 Gayathri,/Sans/Grotesque,90
 Gayathri,/Sans/Rounded,90
-Gelasio,/Expressive/Business,74
+Gelasio,/Expressive/Business,87.6
 Gelasio,/Expressive/Calm,97
-Gelasio,/Expressive/Sincere,100
+Gelasio,/Expressive/Vintage,82
 Gelasio,/Serif/Transitional,100
 Gemunu Libre,/Expressive/Calm,79
 Gemunu Libre,/Expressive/Futuristic,99
-Gemunu Libre,/Expressive/Stiff,99
 Gemunu Libre,/Sans/Geometric,50
 Gemunu Libre,/Theme/Techno,70
+Gemunu Libre,/Expressive/Stiff,99
 Genos,/Expressive/Calm,79
 Genos,/Expressive/Futuristic,97
 Genos,/Expressive/Innovative,41
-Genos,/Expressive/Stiff,97
 Genos,/Sans/Superellipse,100
 Genos,/Theme/Techno,100
-Gentium Book Plus,/Expressive/Business,20
+Genos,/Expressive/Stiff,97
+Gentium Book Plus,/Expressive/Business,73.3
 Gentium Book Plus,/Expressive/Calm,97
-Gentium Book Plus,/Expressive/Sincere,98
+Gentium Book Plus,/Expressive/Sincere,93
+Gentium Book Plus,/Expressive/Vintage,77.5
 Gentium Book Plus,/Serif/Humanist Venetian,30
 Gentium Book Plus,/Serif/Transitional,90
-Gentium Plus,/Expressive/Business,20
+Gentium Plus,/Expressive/Business,73.3
 Gentium Plus,/Expressive/Calm,97
-Gentium Plus,/Expressive/Sincere,97
+Gentium Plus,/Expressive/Sincere,93
+Gentium Plus,/Expressive/Vintage,77.5
 Gentium Plus,/Serif/Humanist Venetian,30
 Gentium Plus,/Serif/Transitional,90
 Geo,/Expressive/Calm,94
 Geo,/Expressive/Futuristic,100
+Geo,/Sans/Geometric,80
+Geo,/Theme/Techno,100
+Geo,/Theme/Woodtype,20
 Geo,/Expressive/Stiff,100
 Geologica,/Expressive/Business,47
 Geologica,/Expressive/Calm,99
-Geologica,/Expressive/Stiff,71
 Geologica,/Sans/Geometric,10
 Geologica,/Sans/Humanist,90
-Georama,/Expressive/Business,67
+Geologica,/Expressive/Stiff,71
+Georama,/Expressive/Business,67.1
 Georama,/Expressive/Calm,99
-Georama,/Expressive/Stiff,91
 Georama,/Sans/Humanist,100
 Georama,/Sans/Superellipse,50
-Geo,/Sans/Geometric,80
+Georama,/Expressive/Stiff,91
 Geostar,/Expressive/Futuristic,92
 Geostar,/Expressive/Innovative,91
 Geostar,/Expressive/Playful,32
-Geostar,/Expressive/Stiff,97
-Geostar Fill,/Expressive/Futuristic,95
-Geostar Fill,/Expressive/Innovative,61
-Geostar Fill,/Expressive/Stiff,97
 Geostar,/Theme/Inline,100
 Geostar,/Theme/Techno,10
 Geostar,/Theme/Woodtype,20
-Geo,/Theme/Techno,100
-Geo,/Theme/Woodtype,20
+Geostar,/Expressive/Stiff,97
+Geostar Fill,/Expressive/Futuristic,95
+Geostar Fill,/Expressive/Innovative,61
+Geostar Fill,/Expressive/Loud,39
+Geostar Fill,/Expressive/Stiff,97
 Germania One,/Expressive/Artistic,77
 Germania One,/Expressive/Calm,79
 Germania One,/Expressive/Innovative,15
 Germania One,/Expressive/Playful,11
+Germania One,/Expressive/Vintage,92
 Germania One,/Sans/Geometric,10
 Germania One,/Theme/Blackletter,100
-GFS Didot,/Expressive/Business,38
+GFS Didot,/Expressive/Business,64.2
 GFS Didot,/Expressive/Calm,98
-GFS Didot,/Expressive/Sincere,70
-GFS Didot,/Expressive/Stiff,10
+GFS Didot,/Expressive/Sincere,70.1
+GFS Didot,/Expressive/Vintage,79.3
 GFS Didot,/Serif/Didone,100
+GFS Didot,/Expressive/Stiff,10
 GFS Neohellenic,/Expressive/Business,27
 GFS Neohellenic,/Expressive/Calm,99
+GFS Neohellenic,/Expressive/Vintage,85.5
 GFS Neohellenic,/Sans/Humanist,100
 Gideon Roman,/Expressive/Business,13
 Gideon Roman,/Expressive/Calm,95
-Gideon Roman,/Expressive/Sincere,71
+Gideon Roman,/Expressive/Loud,22
+Gideon Roman,/Expressive/Sincere,70.5
+Gideon Roman,/Expressive/Vintage,84.5
 Gideon Roman,/Serif/Humanist Venetian,80
 Gideon Roman,/Serif/Transitional,30
 Gidugu,/Expressive/Business,42
 Gidugu,/Expressive/Calm,98
-Gidugu,/Expressive/Competent,5
-Gidugu,/Expressive/Stiff,91
+Gidugu,/Expressive/Vintage,67
 Gidugu,/Indic/Contemporary,100
 Gidugu,/Indic/Sign Painting,20
 Gidugu,/Sans/Grotesque,100
+Gidugu,/Expressive/Stiff,91
 Gilda Display,/Expressive/Business,29
 Gilda Display,/Expressive/Calm,94
-Gilda Display,/Expressive/Sincere,92
+Gilda Display,/Expressive/Sincere,98
+Gilda Display,/Expressive/Vintage,84.5
 Gilda Display,/Serif/Transitional,100
 Girassol,/Expressive/Artistic,41
 Girassol,/Expressive/Business,32
 Girassol,/Expressive/Calm,94
 Girassol,/Expressive/Sincere,72
+Girassol,/Expressive/Vintage,90.5
 Girassol,/Serif/Old Style Garalde,100
 Girassol,/Theme/Woodtype,20
 Give You Glory,/Expressive/Artistic,72
@@ -2631,17 +2971,20 @@ Give You Glory,/Script/Upright Script,80
 Glass Antiqua,/Expressive/Calm,74
 Glass Antiqua,/Expressive/Happy,57
 Glass Antiqua,/Expressive/Sincere,2
+Glass Antiqua,/Expressive/Vintage,58.9
 Glass Antiqua,/Theme/Art Nouveau,10
 Glass Antiqua,/Theme/Wacky,40
 Glass Antiqua,/Theme/Woodtype,10
 Glegoo,/Expressive/Business,23
 Glegoo,/Expressive/Calm,99
-Glegoo,/Expressive/Sincere,100
-Glegoo,/Expressive/Stiff,30
+Glegoo,/Expressive/Sincere,95
+Glegoo,/Expressive/Vintage,37.6
 Glegoo,/Indic/Low contrast,100
 Glegoo,/Slab/Humanist,20
-Gloock,/Expressive/Business,72
+Glegoo,/Expressive/Stiff,30
+Gloock,/Expressive/Business,85
 Gloock,/Expressive/Calm,97
+Gloock,/Expressive/Loud,69
 Gloock,/Expressive/Sincere,53
 Gloock,/Serif/Fat Face,60
 Gloock,/Serif/Transitional,100
@@ -2670,73 +3013,82 @@ Gluten,/Script/Informal,100
 Gluten,/Script/Upright Script,90
 Goblin One,/Expressive/Business,33
 Goblin One,/Expressive/Calm,98
-Goblin One,/Expressive/Sincere,70
+Goblin One,/Expressive/Loud,97
+Goblin One,/Expressive/Sincere,70.1
+Goblin One,/Expressive/Vintage,83
 Goblin One,/Theme/Woodtype,80
 Gochi Hand,/Expressive/Artistic,42
 Gochi Hand,/Expressive/Childlike,79
 Gochi Hand,/Expressive/Cute,40
 Gochi Hand,/Expressive/Happy,44
 Gochi Hand,/Expressive/Playful,15
+Gochi Hand,/Expressive/Sincere,98
 Gochi Hand,/Script/Handwritten,100
 Gochi Hand,/Script/Informal,100
 Gochi Hand,/Script/Upright Script,90
 Goldman,/Expressive/Business,34
 Goldman,/Expressive/Calm,82
 Goldman,/Expressive/Futuristic,98
-Goldman,/Expressive/Stiff,100
 Goldman,/Sans/Superellipse,80
 Goldman,/Theme/Techno,100
+Goldman,/Expressive/Stiff,100
+Golos Text,/Expressive/Business,95.4
 Golos Text,/Expressive/Calm,100
-Golos Text,/Expressive/Stiff,91
 Golos Text,/Sans/Neo Grotesque,100
+Golos Text,/Expressive/Stiff,91
 Gorditas,/Expressive/Awkward,74
 Gorditas,/Expressive/Childlike,91
 Gorditas,/Expressive/Excited,44
 Gorditas,/Expressive/Happy,28
 Gorditas,/Expressive/Innovative,31
+Gorditas,/Expressive/Loud,77
 Gorditas,/Expressive/Playful,47
 Gorditas,/Theme/Wacky,100
 Gothic A1,/Expressive/Calm,100
-Gothic A1,/Expressive/Stiff,11
 Gothic A1,/Sans/Humanist,80
 Gothic A1,/Sans/Neo Grotesque,20
+Gothic A1,/Expressive/Stiff,11
 Gotu,/Expressive/Business,31
 Gotu,/Expressive/Calm,96
-Gotu,/Expressive/Stiff,71
+Gotu,/Expressive/Loud,48
 Gotu,/Sans/Humanist,100
+Gotu,/Expressive/Stiff,71
 Goudy Bookletter 1911,/Expressive/Business,43
 Goudy Bookletter 1911,/Expressive/Calm,92
 Goudy Bookletter 1911,/Expressive/Sincere,71
+Goudy Bookletter 1911,/Expressive/Vintage,85.5
 Goudy Bookletter 1911,/Serif/Old Style Garalde,100
-Gowun Batang,/Expressive/Business,53
+Gowun Batang,/Expressive/Business,53.2
 Gowun Batang,/Expressive/Calm,97
-Gowun Batang,/Expressive/Sincere,96
-Gowun Batang,/Expressive/Stiff,30
 Gowun Batang,/Serif/Transitional,100
-Gowun Dodum,/Expressive/Business,74
+Gowun Batang,/Expressive/Stiff,30
+Gowun Dodum,/Expressive/Business,89.3
 Gowun Dodum,/Expressive/Calm,99
-Gowun Dodum,/Expressive/Stiff,61
 Gowun Dodum,/Sans/Humanist,90
 Gowun Dodum,/Sans/Neo Grotesque,20
-Graduate,/Expressive/Business,67
+Gowun Dodum,/Expressive/Stiff,61
+Graduate,/Expressive/Business,37
 Graduate,/Expressive/Calm,79
 Graduate,/Expressive/Futuristic,12
-Graduate,/Expressive/Sincere,23
-Graduate,/Expressive/Stiff,91
+Graduate,/Expressive/Sincere,22.5
+Graduate,/Expressive/Vintage,82.5
 Graduate,/Slab/Geometric,40
+Graduate,/Expressive/Stiff,91
 Grand Hotel,/Expressive/Artistic,94
 Grand Hotel,/Expressive/Cute,39
 Grand Hotel,/Expressive/Fancy,36
 Grand Hotel,/Expressive/Playful,22
+Grand Hotel,/Expressive/Sincere,96
+Grand Hotel,/Expressive/Vintage,89
 Grand Hotel,/Script/Informal,60
 Grand Hotel,/Script/Upright Script,100
 Grandiflora One,/Expressive/Artistic,31
 Grandiflora One,/Expressive/Calm,77
 Grandiflora One,/Expressive/Cute,11
 Grandiflora One,/Expressive/Sincere,50
-Grandiflora One,/Expressive/Stiff,30
 Grandiflora One,/Slab/Geometric,100
 Grandiflora One,/Theme/Art Nouveau,80
+Grandiflora One,/Expressive/Stiff,30
 Grandstander,/Expressive/Childlike,98
 Grandstander,/Expressive/Happy,56
 Grandstander,/Expressive/Playful,53
@@ -2745,16 +3097,21 @@ Grandstander,/Theme/Wacky,50
 Grape Nuts,/Expressive/Active,99
 Grape Nuts,/Expressive/Artistic,72
 Grape Nuts,/Expressive/Happy,44
+Grape Nuts,/Expressive/Sincere,98
 Grape Nuts,/Script/Handwritten,100
 Grape Nuts,/Script/Informal,100
-Gravitas One,/Expressive/Business,79
 Gravitas One,/Expressive/Calm,77
+Gravitas One,/Expressive/Competent,98.3
+Gravitas One,/Expressive/Loud,99
 Gravitas One,/Expressive/Rugged,59
 Gravitas One,/Expressive/Sincere,71
+Gravitas One,/Expressive/Vintage,84.5
 Gravitas One,/Serif/Fat Face,100
 Gravitas One,/Theme/Woodtype,100
 Great Vibes,/Expressive/Artistic,99
+Great Vibes,/Expressive/Sincere,91
 Great Vibes,/Expressive/Sophisticated,75
+Great Vibes,/Expressive/Vintage,93
 Great Vibes,/Script/Formal,80
 Grechen Fuemen,/Expressive/Active,77
 Grechen Fuemen,/Expressive/Artistic,20
@@ -2762,65 +3119,72 @@ Grechen Fuemen,/Expressive/Awkward,56
 Grechen Fuemen,/Expressive/Fancy,73
 Grechen Fuemen,/Expressive/Happy,44
 Grechen Fuemen,/Expressive/Playful,14
+Grechen Fuemen,/Expressive/Vintage,46.7
 Grechen Fuemen,/Script/Handwritten,40
 Grechen Fuemen,/Script/Informal,100
 Grenze,/Expressive/Artistic,36
 Grenze,/Expressive/Calm,96
 Grenze,/Expressive/Sincere,39
+Grenze,/Expressive/Vintage,89
+Grenze,/Theme/Blackletter,100
 Grenze Gotisch,/Expressive/Artistic,60
 Grenze Gotisch,/Expressive/Calm,96
 Grenze Gotisch,/Expressive/Sincere,39
+Grenze Gotisch,/Expressive/Vintage,98
 Grenze Gotisch,/Theme/Blackletter,100
 Grenze Gotisch,/Theme/Woodtype,10
-Grenze,/Theme/Blackletter,100
 Grey Qo,/Expressive/Artistic,80
 Grey Qo,/Expressive/Excited,26
 Grey Qo,/Expressive/Fancy,68
+Grey Qo,/Expressive/Vintage,63.4
 Grey Qo,/Script/Formal,80
 Griffy,/Expressive/Awkward,87
 Griffy,/Expressive/Innovative,74
+Griffy,/Expressive/Loud,73
 Griffy,/Expressive/Rugged,73
 Griffy,/Theme/Distressed,50
 Griffy,/Theme/Wacky,100
 Gruppo,/Expressive/Business,32
 Gruppo,/Expressive/Calm,98
-Gruppo,/Expressive/Competent,79
-Gruppo,/Expressive/Stiff,30
+Gruppo,/Expressive/Competent,95.8
 Gruppo,/Sans/Humanist,20
 Gruppo,/Sans/Neo Grotesque,70
 Gruppo,/Sans/Rounded,100
-Gudea,/Expressive/Business,58
+Gruppo,/Expressive/Stiff,30
+Gudea,/Expressive/Business,90.5
 Gudea,/Expressive/Calm,99
 Gudea,/Expressive/Competent,16
-Gudea,/Expressive/Stiff,54
 Gudea,/Sans/Humanist,100
+Gudea,/Expressive/Stiff,54
 Gugi,/Expressive/Calm,95
 Gugi,/Expressive/Futuristic,50
-Gugi,/Expressive/Stiff,98
 Gugi,/Sans/Rounded,100
 Gugi,/Sans/Superellipse,20
 Gugi,/Theme/Techno,100
+Gugi,/Expressive/Stiff,98
 Gulzar,/Expressive/Business,34
 Gulzar,/Expressive/Calm,97
-Gulzar,/Expressive/Sincere,99
+Gulzar,/Expressive/Vintage,71.8
 Gulzar,/Serif/Transitional,100
-Gupter,/Expressive/Business,37
+Gupter,/Expressive/Business,51.6
 Gupter,/Expressive/Calm,96
-Gupter,/Expressive/Sincere,95
+Gupter,/Expressive/Vintage,78.7
 Gupter,/Serif/Transitional,100
-Gurajada,/Expressive/Business,58
 Gurajada,/Expressive/Calm,98
-Gurajada,/Expressive/Stiff,54
 Gurajada,/Indic/Sign Painting,100
 Gurajada,/Indic/Traditional,100
 Gurajada,/Sans/Humanist,100
+Gurajada,/Expressive/Stiff,54
 Gwendolyn,/Expressive/Artistic,80
 Gwendolyn,/Expressive/Cute,51
 Gwendolyn,/Expressive/Fancy,63
+Gwendolyn,/Expressive/Sincere,94
+Gwendolyn,/Expressive/Vintage,67.8
 Gwendolyn,/Script/Formal,80
 Habibi,/Expressive/Business,48
 Habibi,/Expressive/Calm,98
 Habibi,/Expressive/Sincere,80
+Habibi,/Expressive/Vintage,77.3
 Habibi,/Serif/Old Style Garalde,100
 Hachi Maru Pop,/Expressive/Awkward,21
 Hachi Maru Pop,/Expressive/Childlike,73
@@ -2830,32 +3194,35 @@ Hachi Maru Pop,/Script/Handwritten,100
 Hachi Maru Pop,/Script/Upright Script,100
 Hachi Maru Pop,/Theme/Brush,100
 Hachi Maru Pop,/Theme/Wacky,20
-Hahmlet,/Expressive/Business,71
+Hahmlet,/Expressive/Business,84.1
 Hahmlet,/Expressive/Calm,99
-Hahmlet,/Expressive/Sincere,98
+Hahmlet,/Expressive/Vintage,53
 Hahmlet,/Serif/Transitional,100
-Halant,/Expressive/Business,75
+Halant,/Expressive/Business,74.9
 Halant,/Expressive/Calm,98
-Halant,/Expressive/Sincere,98
-Halant,/Expressive/Stiff,60
+Halant,/Expressive/Vintage,76.4
 Halant,/Serif/Transitional,100
+Halant,/Expressive/Stiff,60
 Hammersmith One,/Expressive/Business,22
 Hammersmith One,/Expressive/Calm,99
+Hammersmith One,/Expressive/Vintage,81
 Hammersmith One,/Sans/Humanist,100
 Hanalei,/Expressive/Innovative,98
 Hanalei,/Expressive/Playful,80
+Hanalei,/Expressive/Vintage,59
+Hanalei,/Sans/Glyphic,50
+Hanalei,/Theme/Wacky,20
 Hanalei Fill,/Expressive/Awkward,91
 Hanalei Fill,/Expressive/Innovative,55
 Hanalei Fill,/Expressive/Playful,95
 Hanalei Fill,/Expressive/Rugged,76
+Hanalei Fill,/Expressive/Vintage,59.3
 Hanalei Fill,/Sans/Glyphic,50
 Hanalei Fill,/Theme/Wacky,20
-Hanalei,/Sans/Glyphic,50
-Hanalei,/Theme/Wacky,20
 Handjet,/Expressive/Futuristic,77
 Handjet,/Expressive/Innovative,78
-Handjet,/Expressive/Stiff,73
 Handjet,/Theme/Techno,100
+Handjet,/Expressive/Stiff,73
 Handlee,/Expressive/Artistic,22
 Handlee,/Expressive/Awkward,62
 Handlee,/Expressive/Childlike,77
@@ -2863,11 +3230,11 @@ Handlee,/Expressive/Happy,52
 Handlee,/Script/Handwritten,100
 Handlee,/Script/Informal,50
 Handlee,/Theme/Brush,80
-Hanken Grotesk,/Expressive/Business,54
+Hanken Grotesk,/Expressive/Business,54.2
 Hanken Grotesk,/Expressive/Calm,100
-Hanken Grotesk,/Expressive/Stiff,60
 Hanken Grotesk,/Sans/Neo Grotesque,100
-Hanuman,/Expressive/Business,93
+Hanken Grotesk,/Expressive/Stiff,60
+Hanuman,/Expressive/Business,97.8
 Hanuman,/Expressive/Calm,100
 Hanuman,/Expressive/Sincere,79
 Hanuman,/Slab/Humanist,100
@@ -2882,28 +3249,31 @@ Harmattan,/Expressive/Calm,93
 Harmattan,/Sans/Grotesque,80
 Harmattan,/Sans/Neo Grotesque,40
 HeadlandOne,/Expressive/Sincere,75
+HeadlandOne,/Expressive/Vintage,72.4
 HeadlandOne,/Serif/Humanist Venetian,80
-Heebo,/Expressive/Business,91
 Heebo,/Expressive/Calm,100
 Heebo,/Sans/Grotesque,90
 Henny Penny,/Expressive/Cute,72
 Henny Penny,/Expressive/Excited,100
 Henny Penny,/Expressive/Happy,100
+Henny Penny,/Expressive/Loud,74
 Henny Penny,/Expressive/Playful,97
+Henny Penny,/Expressive/Vintage,67.6
 Henny Penny,/Theme/Wacky,60
-Hepta Slab,/Expressive/Business,55
+Hepta Slab,/Expressive/Business,56.9
 Hepta Slab,/Expressive/Calm,79
 Hepta Slab,/Expressive/Sincere,60
 Hepta Slab,/Slab/Geometric,90
-Hermeneus One,/Expressive/Business,26
+Hermeneus One,/Expressive/Business,54.7
 Hermeneus One,/Expressive/Calm,79
 Hermeneus One,/Expressive/Sincere,80
-Hermeneus One,/Expressive/Stiff,30
 Hermeneus One,/Serif/Transitional,80
+Hermeneus One,/Expressive/Stiff,30
 Herr Von Muellerhoff,/Expressive/Artistic,80
 Herr Von Muellerhoff,/Expressive/Fancy,58
-Herr Von Muellerhoff,/Expressive/Sincere,70
+Herr Von Muellerhoff,/Expressive/Sincere,70.1
 Herr Von Muellerhoff,/Expressive/Sophisticated,79
+Herr Von Muellerhoff,/Expressive/Vintage,94
 Herr Von Muellerhoff,/Script/Formal,100
 Hi Melody,/Expressive/Awkward,36
 Hi Melody,/Expressive/Calm,53
@@ -2917,49 +3287,57 @@ Hina Mincho,/Expressive/Calm,39
 Hina Mincho,/Expressive/Sincere,35
 Hina Mincho,/Serif/Scotch,60
 Hina Mincho,/Serif/Transitional,60
-Hind Colombo,/Expressive/Business,70
+Hind,/Expressive/Business,37
+Hind,/Expressive/Calm,100
+Hind,/Sans/Humanist,100
+Hind Colombo,/Expressive/Business,69.9
 Hind Colombo,/Expressive/Calm,100
 Hind Colombo,/Sans/Humanist,100
-Hind,/Expressive/Business,67
-Hind,/Expressive/Calm,100
-Hind Guntur,/Expressive/Business,70
+Hind Guntur,/Expressive/Business,69.9
 Hind Guntur,/Expressive/Calm,100
 Hind Guntur,/Sans/Humanist,100
-Hind Jalandhar,/Expressive/Business,70
+Hind Jalandhar,/Expressive/Business,69.9
 Hind Jalandhar,/Expressive/Calm,100
 Hind Jalandhar,/Sans/Humanist,100
-Hind Kochi,/Expressive/Business,70
+Hind Kochi,/Expressive/Business,69.9
 Hind Kochi,/Expressive/Calm,100
 Hind Kochi,/Sans/Humanist,100
-Hind Madurai,/Expressive/Business,70
+Hind Madurai,/Expressive/Business,69.9
 Hind Madurai,/Expressive/Calm,100
 Hind Madurai,/Sans/Humanist,100
-Hind Mysuru,/Expressive/Business,70
+Hind Mysuru,/Expressive/Business,69.9
 Hind Mysuru,/Expressive/Calm,100
 Hind Mysuru,/Sans/Humanist,100
-Hind,/Sans/Humanist,100
-Hind Siliguri,/Expressive/Business,70
+Hind Siliguri,/Expressive/Business,69.9
 Hind Siliguri,/Expressive/Calm,100
 Hind Siliguri,/Sans/Humanist,100
-Hind Vadodara,/Expressive/Business,70
+Hind Vadodara,/Expressive/Business,69.9
 Hind Vadodara,/Expressive/Calm,100
 Hind Vadodara,/Sans/Humanist,100
+Holtwood One SC,/Expressive/Business,61.6
 Holtwood One SC,/Expressive/Futuristic,36
-Holtwood One SC,/Expressive/Stiff,94
+Holtwood One SC,/Expressive/Loud,97
 Holtwood One SC,/Serif/Transitional,70
+Holtwood One SC,/Expressive/Stiff,94
 Homemade Apple,/Expressive/Active,66
 Homemade Apple,/Expressive/Artistic,72
 Homemade Apple,/Expressive/Cute,74
 Homemade Apple,/Expressive/Happy,52
 Homemade Apple,/Expressive/Playful,74
+Homemade Apple,/Expressive/Sincere,99
 Homemade Apple,/Script/Formal,20
 Homemade Apple,/Script/Handwritten,100
 Homemade Apple,/Script/Informal,80
 Homenaje,/Expressive/Calm,59
 Homenaje,/Expressive/Futuristic,78
-Homenaje,/Expressive/Stiff,100
 Homenaje,/Sans/Geometric,60
 Homenaje,/Sans/Superellipse,30
+Homenaje,/Expressive/Stiff,100
+Honk,/Expressive/Innovative,100
+Honk,/Expressive/Loud,85
+Honk,/Expressive/Playful,50
+Honk,/Sans/Geometric,10
+Honk,/Theme/Shaded,100
 Hubballi,/Expressive/Calm,95
 Hubballi,/Expressive/Childlike,70
 Hubballi,/Expressive/Cute,35
@@ -2969,30 +3347,37 @@ Hubballi,/Script/Handwritten,30
 Hurricane,/Expressive/Artistic,98
 Hurricane,/Expressive/Fancy,84
 Hurricane,/Expressive/Sophisticated,49
+Hurricane,/Expressive/Vintage,69.6
 Hurricane,/Script/Formal,90
 Hurricane,/Script/Informal,40
-Ibarra Real Nova,/Expressive/Business,34
+Ibarra Real Nova,/Expressive/Business,71.8
 Ibarra Real Nova,/Expressive/Sincere,94
+Ibarra Real Nova,/Expressive/Vintage,68.4
 Ibarra Real Nova,/Serif/Transitional,100
 IBM Plex Mono,/Expressive/Calm,92
-IBM Plex Mono,/Expressive/Competent,71
+IBM Plex Mono,/Expressive/Competent,99.4
 IBM Plex Mono,/Monospace/Monospace,100
 IBM Plex Mono,/Sans/Neo Grotesque,80
 IBM Plex Mono,/Slab/Geometric,20
+IBM Plex Sans,/Expressive/Business,96.2
+IBM Plex Sans,/Expressive/Calm,100
+IBM Plex Sans,/Expressive/Competent,99.4
+IBM Plex Sans,/Sans/Neo Grotesque,100
+IBM Plex Sans,/Sans/Superellipse,50
 IBM Plex Sans Arabic,/Expressive/Calm,100
 IBM Plex Sans Arabic,/Expressive/Competent,13
 IBM Plex Sans Arabic,/Sans/Neo Grotesque,100
 IBM Plex Sans Arabic,/Sans/Superellipse,50
+IBM Plex Sans Condensed,/Expressive/Business,95.7
 IBM Plex Sans Condensed,/Expressive/Calm,100
-IBM Plex Sans Condensed,/Expressive/Competent,95
+IBM Plex Sans Condensed,/Expressive/Competent,99.4
 IBM Plex Sans Condensed,/Sans/Neo Grotesque,100
 IBM Plex Sans Condensed,/Sans/Superellipse,100
+IBM Plex Sans Devanagari,/Expressive/Business,60.3
 IBM Plex Sans Devanagari,/Expressive/Calm,100
 IBM Plex Sans Devanagari,/Expressive/Competent,13
 IBM Plex Sans Devanagari,/Sans/Neo Grotesque,100
 IBM Plex Sans Devanagari,/Sans/Superellipse,50
-IBM Plex Sans,/Expressive/Calm,100
-IBM Plex Sans,/Expressive/Competent,13
 IBM Plex Sans Hebrew,/Expressive/Calm,100
 IBM Plex Sans Hebrew,/Expressive/Competent,13
 IBM Plex Sans Hebrew,/Sans/Neo Grotesque,100
@@ -3005,36 +3390,68 @@ IBM Plex Sans KR,/Expressive/Calm,100
 IBM Plex Sans KR,/Expressive/Competent,13
 IBM Plex Sans KR,/Sans/Neo Grotesque,100
 IBM Plex Sans KR,/Sans/Superellipse,50
-IBM Plex Sans,/Sans/Neo Grotesque,100
-IBM Plex Sans,/Sans/Superellipse,50
 IBM Plex Sans Thai,/Expressive/Calm,100
 IBM Plex Sans Thai,/Expressive/Competent,13
+IBM Plex Sans Thai,/Sans/Neo Grotesque,100
+IBM Plex Sans Thai,/Sans/Superellipse,50
 IBM Plex Sans Thai Looped,/Expressive/Calm,100
 IBM Plex Sans Thai Looped,/Expressive/Competent,13
 IBM Plex Sans Thai Looped,/Sans/Neo Grotesque,100
 IBM Plex Sans Thai Looped,/Sans/Superellipse,50
-IBM Plex Sans Thai,/Sans/Neo Grotesque,100
-IBM Plex Sans Thai,/Sans/Superellipse,50
 IBM Plex Serif,/Expressive/Business,99
-IBM Plex Serif,/Expressive/Sincere,99
+IBM Plex Serif,/Expressive/Competent,99.4
+IBM Plex Serif,/Expressive/Sincere,93
 IBM Plex Serif,/Serif/Scotch,100
 Iceberg,/Expressive/Futuristic,100
 Iceberg,/Expressive/Innovative,53
-Iceberg,/Expressive/Stiff,100
 Iceberg,/Theme/Blackletter,5
 Iceberg,/Theme/Techno,50
+Iceberg,/Expressive/Stiff,100
 Iceland,/Expressive/Futuristic,100
 Iceland,/Expressive/Innovative,53
-Iceland,/Expressive/Stiff,100
+Iceland,/Expressive/Vintage,37.4
 Iceland,/Theme/Techno,100
-Imbue,/Expressive/Sincere,91
+Iceland,/Expressive/Stiff,100
+IM FELL Double Pica,/Expressive/Business,28
+IM FELL Double Pica,/Expressive/Sincere,98
+IM FELL Double Pica,/Expressive/Vintage,89
+IM FELL Double Pica SC,/Expressive/Business,28
+IM FELL Double Pica SC,/Expressive/Sincere,98
+IM FELL Double Pica SC,/Expressive/Vintage,89
+IM FELL DW Pica,/Expressive/Business,28
+IM FELL DW Pica,/Expressive/Sincere,98
+IM FELL DW Pica,/Expressive/Vintage,89
+IM FELL DW Pica SC,/Expressive/Business,28
+IM FELL DW Pica SC,/Expressive/Sincere,98
+IM FELL DW Pica SC,/Expressive/Vintage,89
+IM FELL English,/Expressive/Business,28
+IM FELL English,/Expressive/Sincere,98
+IM FELL English,/Expressive/Vintage,89
+IM FELL English SC,/Expressive/Business,28
+IM FELL English SC,/Expressive/Sincere,98
+IM FELL English SC,/Expressive/Vintage,90
+IM FELL French Canon,/Expressive/Business,28
+IM FELL French Canon,/Expressive/Sincere,98
+IM FELL French Canon,/Expressive/Vintage,90.8
+IM FELL French Canon SC,/Expressive/Business,28
+IM FELL French Canon SC,/Expressive/Sincere,98
+IM FELL French Canon SC,/Expressive/Vintage,89
+IM FELL Great Primer,/Expressive/Business,28
+IM FELL Great Primer,/Expressive/Sincere,98
+IM FELL Great Primer,/Expressive/Vintage,89
+IM FELL Great Primer SC,/Expressive/Business,28
+IM FELL Great Primer SC,/Expressive/Sincere,98
+IM FELL Great Primer SC,/Expressive/Vintage,89
+Imbue,/Expressive/Competent,96.5
 Imbue,/Serif/Didone,100
 Imperial Script,/Expressive/Artistic,100
 Imperial Script,/Expressive/Fancy,100
 Imperial Script,/Expressive/Sophisticated,78
+Imperial Script,/Expressive/Vintage,73
 Imperial Script,/Script/Formal,100
 Imprima,/Expressive/Calm,97
 Imprima,/Sans/Humanist,100
+Inclusive Sans,/Expressive/Business,94.4
 Inclusive Sans,/Expressive/Calm,99
 Inclusive Sans,/Sans/Geometric,20
 Inclusive Sans,/Sans/Neo Grotesque,80
@@ -3057,28 +3474,30 @@ Ingrid Darling,/Expressive/Cute,72
 Ingrid Darling,/Expressive/Excited,59
 Ingrid Darling,/Expressive/Happy,72
 Ingrid Darling,/Expressive/Playful,94
+Ingrid Darling,/Expressive/Vintage,47.9
 Ingrid Darling,/Script/Handwritten,100
 Ingrid Darling,/Script/Informal,50
 Ingrid Darling,/Theme/Wacky,40
 Inika,/Expressive/Awkward,12
 Inika,/Expressive/Sincere,58
 Inika,/Serif/Old Style Garalde,10
-Inknut Antiqua,/Expressive/Business,78
+Inknut Antiqua,/Expressive/Business,80.1
 Inknut Antiqua,/Expressive/Calm,89
 Inknut Antiqua,/Expressive/Futuristic,63
 Inknut Antiqua,/Expressive/Innovative,12
-Inknut Antiqua,/Expressive/Sincere,45
-Inknut Antiqua,/Expressive/Stiff,81
+Inknut Antiqua,/Expressive/Loud,72
+Inknut Antiqua,/Expressive/Sincere,44.5
 Inknut Antiqua,/Script/Formal,20
 Inknut Antiqua,/Serif/Humanist Venetian,80
+Inknut Antiqua,/Expressive/Stiff,81
 Inria Sans,/Expressive/Business,92
 Inria Sans,/Expressive/Calm,96
 Inria Sans,/Expressive/Competent,12
-Inria Sans,/Expressive/Stiff,56
 Inria Sans,/Sans/Humanist,80
 Inria Sans,/Sans/Superellipse,20
-Inria Serif,/Expressive/Business,57
-Inria Serif,/Expressive/Sincere,98
+Inria Sans,/Expressive/Stiff,56
+Inria Serif,/Expressive/Business,56.5
+Inria Serif,/Expressive/Loud,38
 Inria Serif,/Serif/Modern,80
 Inria Serif,/Serif/Transitional,20
 Inspiration,/Expressive/Active,71
@@ -3086,21 +3505,24 @@ Inspiration,/Expressive/Awkward,56
 Inspiration,/Expressive/Excited,97
 Inspiration,/Expressive/Fancy,55
 Inspiration,/Expressive/Happy,98
+Inspiration,/Expressive/Vintage,33
 Inspiration,/Script/Handwritten,100
 Inspiration,/Script/Informal,100
 Inspiration,/Theme/Wacky,40
-Instrument Sans,/Expressive/Business,80
+Instrument Sans,/Expressive/Business,90.4
 Instrument Sans,/Expressive/Calm,100
 Instrument Sans,/Sans/Geometric,100
-Instrument Serif,/Expressive/Sincere,92
+Instrument Serif,/Expressive/Business,71.6
+Instrument Serif,/Expressive/Competent,98.7
+Instrument Serif,/Expressive/Sincere,99
+Instrument Serif,/Expressive/Vintage,75
 Instrument Serif,/Serif/Modern,100
 Instrument Serif,/Serif/Scotch,100
-Inter,/Expressive/Business,36
+Inter,/Expressive/Business,97.2
 Inter,/Expressive/Calm,100
 Inter,/Sans/Geometric,20
 Inter,/Sans/Humanist,10
 Inter,/Sans/Neo Grotesque,100
-Inter Tight,/Expressive/Business,36
 Inter Tight,/Expressive/Calm,100
 Inter Tight,/Sans/Geometric,20
 Inter Tight,/Sans/Humanist,10
@@ -3113,6 +3535,7 @@ Irish Grover,/Theme/Wacky,100
 Island Moments,/Expressive/Artistic,99
 Island Moments,/Expressive/Fancy,48
 Island Moments,/Expressive/Sophisticated,93
+Island Moments,/Expressive/Vintage,83.5
 Island Moments,/Script/Formal,100
 Island Moments,/Script/Handwritten,20
 Island Moments,/Theme/Brush,50
@@ -3120,11 +3543,13 @@ Istok Web,/Expressive/Business,15
 Istok Web,/Expressive/Calm,99
 Istok Web,/Sans/Humanist,60
 Istok Web,/Sans/Rounded,60
+Italiana,/Expressive/Loud,54
 Italiana,/Serif/Modern,100
 Italianno,/Expressive/Artistic,99
 Italianno,/Expressive/Fancy,18
 Italianno,/Expressive/Rugged,13
 Italianno,/Expressive/Sophisticated,98
+Italianno,/Expressive/Vintage,92
 Italianno,/Script/Formal,100
 Italianno,/Script/Handwritten,100
 Itim,/Expressive/Calm,18
@@ -3134,14 +3559,15 @@ Itim,/Expressive/Playful,76
 Itim,/Sans/Humanist,40
 Itim,/Script/Handwritten,50
 Itim,/Theme/Brush,100
-Jacquard 12 Charted,/Theme/Pixel,100
 Jacquard 12,/Theme/Pixel,100
-Jacquard 24 Charted,/Theme/Pixel,100
+Jacquard 12 Charted,/Theme/Pixel,100
 Jacquard 24,/Theme/Pixel,100
-Jacquarda Bastarda 9 Charted,/Theme/Pixel,100
+Jacquard 24 Charted,/Theme/Pixel,100
 Jacquarda Bastarda 9,/Theme/Pixel,100
+Jacquarda Bastarda 9 Charted,/Theme/Pixel,100
 Jacques Francois,/Expressive/Calm,70
 Jacques Francois,/Expressive/Sincere,88
+Jacques Francois,/Expressive/Vintage,77.5
 Jacques Francois,/Serif/Transitional,100
 Jacques Francois Shadow,/Expressive/Calm,47
 Jacques Francois Shadow,/Expressive/Innovative,92
@@ -3150,46 +3576,54 @@ Jacques Francois Shadow,/Theme/Shaded,100
 Jaldi,/Expressive/Calm,100
 Jaldi,/Indic/Low contrast,100
 Jaldi,/Sans/Superellipse,90
-Jersey 10 Charted,/Theme/Pixel,100
+Jaro,/Expressive/Loud,82
 Jersey 10,/Theme/Pixel,100
-Jersey 15 Charted,/Theme/Pixel,100
+Jersey 10 Charted,/Theme/Pixel,100
 Jersey 15,/Theme/Pixel,100
-Jersey 20 Charted,/Theme/Pixel,100
+Jersey 15 Charted,/Theme/Pixel,100
 Jersey 20,/Theme/Pixel,100
-Jersey 25 Charted,/Theme/Pixel,100
+Jersey 20 Charted,/Theme/Pixel,100
 Jersey 25,/Theme/Pixel,100
-JetBrains Mono,/Expressive/Business,73
+Jersey 25 Charted,/Theme/Pixel,100
+JetBrains Mono,/Expressive/Business,38
 JetBrains Mono,/Expressive/Calm,79
 JetBrains Mono,/Expressive/Futuristic,76
-JetBrains Mono,/Expressive/Stiff,74
+JetBrains Mono,/Expressive/Vintage,28.7
 JetBrains Mono,/Monospace/Monospace,100
 JetBrains Mono,/Sans/Geometric,70
+JetBrains Mono,/Expressive/Stiff,74
 Jim Nightshade,/Expressive/Artistic,89
 Jim Nightshade,/Expressive/Fancy,91
 Jim Nightshade,/Expressive/Rugged,79
 Jim Nightshade,/Expressive/Sophisticated,78
+Jim Nightshade,/Expressive/Vintage,96
 Jim Nightshade,/Script/Formal,80
 Jim Nightshade,/Script/Handwritten,50
+Joan,/Expressive/Business,64.3
 Joan,/Expressive/Calm,70
-Joan,/Expressive/Sincere,100
+Joan,/Expressive/Sincere,98
+Joan,/Expressive/Vintage,79.5
 Joan,/Serif/Humanist Venetian,100
 Jockey One,/Expressive/Futuristic,99
-Jockey One,/Expressive/Stiff,97
 Jockey One,/Sans/Superellipse,70
 Jockey One,/Theme/Techno,50
+Jockey One,/Expressive/Stiff,97
 Jolly Lodger,/Expressive/Awkward,95
 Jolly Lodger,/Expressive/Excited,98
 Jolly Lodger,/Expressive/Playful,98
+Jolly Lodger,/Expressive/Vintage,58.5
 Jolly Lodger,/Theme/Wacky,100
 Jomhuria,/Expressive/Futuristic,33
+Jomhuria,/Expressive/Loud,71
 Jomhuria,/Expressive/Playful,31
 Jomhuria,/Expressive/Rugged,96
 Jomhuria,/Sans/Superellipse,100
 Jomolhari,/Expressive/Calm,97
-Jomolhari,/Expressive/Sincere,99
+Jomolhari,/Expressive/Vintage,65
 Jomolhari,/Serif/Transitional,100
 Josefin Sans,/Expressive/Artistic,71
 Josefin Sans,/Expressive/Calm,94
+Josefin Sans,/Expressive/Vintage,79.4
 Josefin Sans,/Sans/Geometric,100
 Josefin Slab,/Expressive/Artistic,51
 Josefin Slab,/Expressive/Calm,92
@@ -3198,41 +3632,44 @@ Josefin Slab,/Expressive/Sincere,71
 Josefin Slab,/Slab/Geometric,100
 Jost,/Expressive/Artistic,51
 Jost,/Expressive/Calm,99
+Jost,/Expressive/Vintage,58
 Jost,/Sans/Geometric,100
 Jost,/Sans/Rounded,80
 Joti One,/Expressive/Awkward,98
 Joti One,/Expressive/Excited,95
+Joti One,/Expressive/Loud,82
 Joti One,/Expressive/Playful,94
 Joti One,/Expressive/Rugged,31
+Joti One,/Expressive/Vintage,77.5
 Joti One,/Theme/Wacky,100
 jsMath-cmbx10,/Expressive/Artistic,40
 jsMath-cmbx10,/Expressive/Calm,85
-jsMath-cmbx10,/Expressive/Sincere,98
+jsMath-cmbx10,/Expressive/Vintage,79
 jsMath-cmbx10,/Serif/Modern,100
 jsMath-cmbx10,/Slab/Clarendon,100
 jsMath-cmex10,/Expressive/Artistic,40
 jsMath-cmex10,/Expressive/Calm,85
-jsMath-cmex10,/Expressive/Sincere,98
+jsMath-cmex10,/Expressive/Vintage,79
 jsMath-cmex10,/Serif/Modern,100
 jsMath-cmex10,/Slab/Clarendon,100
 jsMath-cmmi10,/Expressive/Artistic,40
 jsMath-cmmi10,/Expressive/Calm,85
-jsMath-cmmi10,/Expressive/Sincere,98
+jsMath-cmmi10,/Expressive/Vintage,79
 jsMath-cmmi10,/Serif/Modern,100
 jsMath-cmmi10,/Slab/Clarendon,100
 jsMath-cmr10,/Expressive/Artistic,40
 jsMath-cmr10,/Expressive/Calm,85
-jsMath-cmr10,/Expressive/Sincere,98
+jsMath-cmr10,/Expressive/Vintage,79
 jsMath-cmr10,/Serif/Modern,100
 jsMath-cmr10,/Slab/Clarendon,100
 jsMath-cmsy10,/Expressive/Artistic,40
 jsMath-cmsy10,/Expressive/Calm,85
-jsMath-cmsy10,/Expressive/Sincere,98
+jsMath-cmsy10,/Expressive/Vintage,79
 jsMath-cmsy10,/Serif/Modern,100
 jsMath-cmsy10,/Slab/Clarendon,100
 jsMath-cmti10,/Expressive/Artistic,40
 jsMath-cmti10,/Expressive/Calm,85
-jsMath-cmti10,/Expressive/Sincere,98
+jsMath-cmti10,/Expressive/Vintage,79
 jsMath-cmti10,/Serif/Modern,100
 jsMath-cmti10,/Slab/Clarendon,100
 Jua,/Expressive/Calm,5
@@ -3248,30 +3685,35 @@ Judson,/Expressive/Sincere,77
 Judson,/Serif/Transitional,100
 Julee,/Expressive/Awkward,12
 Julee,/Expressive/Excited,25
+Julee,/Expressive/Loud,74
+Julee,/Expressive/Vintage,75
 Julee,/Script/Handwritten,100
 Julee,/Theme/Wacky,80
 Julius Sans One,/Expressive/Artistic,10
-Julius Sans One,/Expressive/Business,59
+Julius Sans One,/Expressive/Business,59.2
 Julius Sans One,/Expressive/Calm,98
-Julius Sans One,/Expressive/Stiff,58
+Julius Sans One,/Expressive/Vintage,81
 Julius Sans One,/Sans/Glyphic,100
+Julius Sans One,/Expressive/Stiff,58
 Junge,/Expressive/Business,13
 Junge,/Expressive/Calm,67
 Junge,/Expressive/Sincere,74
+Junge,/Expressive/Vintage,58.3
 Junge,/Serif/Humanist Venetian,30
 Junge,/Serif/Transitional,50
 Jura,/Expressive/Business,11
 Jura,/Expressive/Calm,91
 Jura,/Expressive/Futuristic,75
-Jura,/Expressive/Stiff,90
 Jura,/Sans/Rounded,100
 Jura,/Sans/Superellipse,100
+Jura,/Expressive/Stiff,90
 Just Another Hand,/Expressive/Artistic,61
 Just Another Hand,/Expressive/Childlike,79
 Just Another Hand,/Expressive/Excited,12
 Just Another Hand,/Expressive/Happy,33
 Just Another Hand,/Expressive/Playful,44
 Just Another Hand,/Expressive/Rugged,9
+Just Another Hand,/Expressive/Sincere,99
 Just Another Hand,/Script/Handwritten,100
 Just Another Hand,/Script/Informal,100
 Just Another Hand,/Script/Upright Script,100
@@ -3281,53 +3723,60 @@ Just Me Again Down Here,/Expressive/Excited,55
 Just Me Again Down Here,/Expressive/Happy,58
 Just Me Again Down Here,/Expressive/Playful,75
 Just Me Again Down Here,/Expressive/Rugged,35
+Just Me Again Down Here,/Expressive/Sincere,99
 Just Me Again Down Here,/Script/Handwritten,100
 Just Me Again Down Here,/Script/Informal,100
 Just Me Again Down Here,/Script/Upright Script,100
 K2D,/Expressive/Calm,92
-K2D,/Expressive/Stiff,30
 K2D,/Sans/Neo Grotesque,40
 K2D,/Sans/Superellipse,80
+K2D,/Expressive/Stiff,30
 Kablammo,/Expressive/Childlike,72
 Kablammo,/Expressive/Excited,100
 Kablammo,/Expressive/Happy,100
 Kablammo,/Expressive/Innovative,100
+Kablammo,/Expressive/Loud,80
 Kablammo,/Expressive/Playful,100
+Kablammo,/Expressive/Vintage,48.4
 Kablammo,/Theme/Blobby,100
 Kablammo,/Theme/Wacky,100
-Kadwa,/Expressive/Business,60
+Kadwa,/Expressive/Business,70
 Kadwa,/Expressive/Calm,97
-Kadwa,/Expressive/Sincere,99
 Kadwa,/Expressive/Stiff,20
 Kaisei Decol,/Expressive/Business,39
 Kaisei Decol,/Expressive/Calm,96
 Kaisei Decol,/Expressive/Sincere,87
-Kaisei Decol,/Expressive/Stiff,20
+Kaisei Decol,/Expressive/Vintage,65
 Kaisei Decol,/Serif/Modern,30
 Kaisei Decol,/Serif/Transitional,40
+Kaisei Decol,/Expressive/Stiff,20
 Kaisei HarunoUmi,/Expressive/Business,39
 Kaisei HarunoUmi,/Expressive/Calm,96
 Kaisei HarunoUmi,/Expressive/Sincere,87
-Kaisei HarunoUmi,/Expressive/Stiff,20
+Kaisei HarunoUmi,/Expressive/Vintage,66
 Kaisei HarunoUmi,/Serif/Modern,30
 Kaisei HarunoUmi,/Serif/Transitional,40
+Kaisei HarunoUmi,/Expressive/Stiff,20
 Kaisei Opti,/Expressive/Business,39
 Kaisei Opti,/Expressive/Calm,96
 Kaisei Opti,/Expressive/Sincere,87
-Kaisei Opti,/Expressive/Stiff,20
+Kaisei Opti,/Expressive/Vintage,34
 Kaisei Opti,/Serif/Modern,30
 Kaisei Opti,/Serif/Transitional,40
+Kaisei Opti,/Expressive/Stiff,20
 Kaisei Tokumin,/Expressive/Business,39
 Kaisei Tokumin,/Expressive/Calm,96
 Kaisei Tokumin,/Expressive/Sincere,87
-Kaisei Tokumin,/Expressive/Stiff,20
+Kaisei Tokumin,/Expressive/Vintage,68.9
 Kaisei Tokumin,/Serif/Modern,30
 Kaisei Tokumin,/Serif/Transitional,40
+Kaisei Tokumin,/Expressive/Stiff,20
 Kalam,/Expressive/Active,79
 Kalam,/Expressive/Artistic,42
 Kalam,/Expressive/Awkward,33
 Kalam,/Expressive/Childlike,70
 Kalam,/Expressive/Happy,15
+Kalam,/Expressive/Vintage,64
 Kalam,/Script/Handwritten,100
 Kalam,/Script/Informal,100
 Kalam,/Theme/Brush,100
@@ -3337,63 +3786,78 @@ Kalnia Glaze,/Theme/Inline,100
 Kameron,/Expressive/Business,46
 Kameron,/Expressive/Calm,99
 Kameron,/Expressive/Sincere,89
-Kameron,/Expressive/Stiff,10
+Kameron,/Expressive/Vintage,74.5
 Kameron,/Slab/Clarendon,60
 Kameron,/Slab/Geometric,30
+Kameron,/Expressive/Stiff,10
 Kanit,/Expressive/Business,15
 Kanit,/Expressive/Calm,88
 Kanit,/Expressive/Futuristic,28
-Kanit,/Expressive/Stiff,56
 Kanit,/Sans/Geometric,10
 Kanit,/Sans/Humanist,80
 Kanit,/Sans/Superellipse,100
 Kanit,/Theme/Techno,50
-Kantumruy Pro,/Expressive/Business,68
+Kanit,/Expressive/Stiff,56
+Kantumruy Pro,/Expressive/Business,99.2
 Kantumruy Pro,/Expressive/Calm,100
-Kantumruy Pro,/Expressive/Stiff,52
+Kantumruy Pro,/Expressive/Vintage,13
 Kantumruy Pro,/Sans/Grotesque,100
+Kantumruy Pro,/Expressive/Stiff,52
 Kapakana,/Expressive/Artistic,100
 Kapakana,/Expressive/Fancy,79
 Kapakana,/Expressive/Sophisticated,100
+Kapakana,/Expressive/Vintage,96
 Kapakana,/Script/Formal,100
 Karantina,/Expressive/Awkward,31
 Karantina,/Expressive/Calm,82
+Karantina,/Expressive/Competent,79.7
 Karantina,/Expressive/Futuristic,73
-Karantina,/Expressive/Stiff,85
+Karantina,/Expressive/Loud,96
 Karantina,/Sans/Geometric,50
 Karantina,/Sans/Superellipse,80
-Karla,/Expressive/Business,75
+Karantina,/Expressive/Stiff,85
+Karla,/Expressive/Business,91.3
 Karla,/Expressive/Calm,100
-Karla,/Expressive/Stiff,40
+Karla,/Expressive/Vintage,17
 Karla,/Sans/Grotesque,100
-Karla Tamil Inclined,/Expressive/Business,75
+Karla,/Expressive/Stiff,40
+Karla Tamil Inclined,/Expressive/Business,91.3
 Karla Tamil Inclined,/Expressive/Calm,100
-Karla Tamil Inclined,/Expressive/Stiff,40
+Karla Tamil Inclined,/Expressive/Vintage,48
 Karla Tamil Inclined,/Sans/Grotesque,100
-Karla Tamil Upright,/Expressive/Business,75
+Karla Tamil Inclined,/Expressive/Stiff,40
+Karla Tamil Upright,/Expressive/Business,91.3
 Karla Tamil Upright,/Expressive/Calm,100
-Karla Tamil Upright,/Expressive/Stiff,40
+Karla Tamil Upright,/Expressive/Vintage,48
 Karla Tamil Upright,/Sans/Grotesque,100
-Karma,/Expressive/Business,59
+Karla Tamil Upright,/Expressive/Stiff,40
+Karma,/Expressive/Business,59.5
 Karma,/Expressive/Calm,97
 Karma,/Expressive/Sincere,70
+Karma,/Expressive/Vintage,32.3
 Karma,/Indic/Contemporary,100
 Karma,/Serif/Transitional,10
 Katibeh,/Arabic/Naskh,100
 Katibeh,/Expressive/Calm,75
 Katibeh,/Expressive/Happy,1
+Katibeh,/Expressive/Loud,49
 Katibeh,/Expressive/Playful,11
 Katibeh,/Expressive/Sincere,62
+Katibeh,/Expressive/Vintage,81.5
 Katibeh,/Serif/Fat Face,10
 Kaushan Script,/Expressive/Active,36
 Kaushan Script,/Expressive/Artistic,97
 Kaushan Script,/Expressive/Childlike,20
+Kaushan Script,/Expressive/Loud,47
+Kaushan Script,/Expressive/Sincere,92
+Kaushan Script,/Expressive/Vintage,37.3
 Kaushan Script,/Script/Informal,50
 Kavivanar,/Expressive/Calm,47
 Kavivanar,/Expressive/Childlike,76
 Kavivanar,/Expressive/Cute,2
 Kavivanar,/Expressive/Excited,33
 Kavivanar,/Expressive/Happy,34
+Kavivanar,/Expressive/Loud,22
 Kavivanar,/Indic/Sign Painting,100
 Kavivanar,/Indic/Traditional,100
 Kavivanar,/Sans/Humanist,100
@@ -3405,49 +3869,55 @@ Kavoon,/Expressive/Childlike,13
 Kavoon,/Expressive/Cute,26
 Kavoon,/Expressive/Excited,14
 Kavoon,/Expressive/Happy,37
-Kavoon,/Expressive/Sincere,30
+Kavoon,/Expressive/Loud,92
+Kavoon,/Expressive/Sincere,30.1
 Kavoon,/Script/Upright Script,100
 Kavoon,/Theme/Wacky,10
-Kdam Thmor Pro,/Expressive/Business,64
+Kdam Thmor Pro,/Expressive/Business,50.5
 Kdam Thmor Pro,/Expressive/Calm,87
+Kdam Thmor Pro,/Expressive/Competent,77.6
 Kdam Thmor Pro,/Expressive/Futuristic,99
-Kdam Thmor Pro,/Expressive/Stiff,97
+Kdam Thmor Pro,/Expressive/Vintage,58.9
 Kdam Thmor Pro,/Sans/Geometric,10
 Kdam Thmor Pro,/Sans/Superellipse,30
 Kdam Thmor Pro,/Theme/Techno,50
 Kdam Thmor Pro,/Theme/Woodtype,50
+Kdam Thmor Pro,/Expressive/Stiff,97
 Keania One,/Expressive/Calm,45
 Keania One,/Expressive/Futuristic,79
 Keania One,/Expressive/Innovative,77
-Keania One,/Expressive/Stiff,92
 Keania One,/Sans/Superellipse,70
 Keania One,/Theme/Stencil,100
 Keania One,/Theme/Techno,10
 Keania One,/Theme/Woodtype,50
+Keania One,/Expressive/Stiff,92
 Kelly Slab,/Expressive/Futuristic,89
 Kelly Slab,/Expressive/Happy,34
 Kelly Slab,/Expressive/Sincere,44
-Kelly Slab,/Expressive/Stiff,58
 Kelly Slab,/Slab/Humanist,30
 Kelly Slab,/Theme/Woodtype,30
+Kelly Slab,/Expressive/Stiff,58
 Kenia,/Expressive/Artistic,91
 Kenia,/Expressive/Happy,74
 Kenia,/Expressive/Innovative,96
+Kenia,/Expressive/Loud,91
 Kenia,/Expressive/Playful,62
 Kenia,/Theme/Blackletter,20
 Kenia,/Theme/Stencil,100
-Khand,/Expressive/Business,79
+Khand,/Expressive/Business,82
+Khand,/Expressive/Competent,94.6
 Khand,/Expressive/Futuristic,66
 Khand,/Expressive/Rugged,76
-Khand,/Expressive/Stiff,96
 Khand,/Indic/Low contrast,100
 Khand,/Sans/Humanist,80
+Khand,/Expressive/Stiff,96
 Khula,/Expressive/Calm,98
 Khula,/Indic/Low contrast,100
 Khula,/Sans/Humanist,100
 Kings,/Expressive/Artistic,96
 Kings,/Expressive/Fancy,71
 Kings,/Expressive/Sophisticated,79
+Kings,/Expressive/Vintage,98.5
 Kings,/Script/Formal,80
 Kings,/Script/Handwritten,60
 Kings,/Theme/Medieval,80
@@ -3456,6 +3926,7 @@ Kirang Haerang,/Expressive/Awkward,99
 Kirang Haerang,/Expressive/Childlike,71
 Kirang Haerang,/Expressive/Excited,96
 Kirang Haerang,/Expressive/Happy,78
+Kirang Haerang,/Expressive/Loud,52
 Kirang Haerang,/Expressive/Playful,100
 Kirang Haerang,/Theme/Blobby,60
 Kirang Haerang,/Theme/Wacky,100
@@ -3481,8 +3952,10 @@ Knewave,/Expressive/Awkward,91
 Knewave,/Expressive/Cute,59
 Knewave,/Expressive/Excited,95
 Knewave,/Expressive/Happy,53
+Knewave,/Expressive/Loud,86
 Knewave,/Expressive/Playful,94
 Knewave,/Expressive/Rugged,84
+Knewave,/Expressive/Vintage,63.4
 Knewave,/Script/Handwritten,100
 Knewave,/Script/Informal,100
 Knewave,/Theme/Blobby,80
@@ -3492,6 +3965,10 @@ Kodchasan,/Expressive/Playful,32
 Kodchasan,/Sans/Geometric,100
 Kodchasan,/Sans/Rounded,100
 Kodchasan,"/South East Asian (Thai, Khmer, Lao)/Looped",100
+Koh Santepheap,/Expressive/Business,98.9
+Koh Santepheap,/Expressive/Vintage,58.7
+Koh Santepheap,/Serif/Modern,100
+Koh Santepheap,/Serif/Scotch,100
 KoHo,/Expressive/Calm,78
 KoHo,/Expressive/Competent,52
 KoHo,/Expressive/Happy,11
@@ -3499,41 +3976,39 @@ KoHo,/Sans/Geometric,60
 KoHo,/Sans/Humanist,60
 KoHo,/Sans/Neo Grotesque,40
 KoHo,"/South East Asian (Thai, Khmer, Lao)/Looped",100
-Koh Santepheap,/Expressive/Business,80
-Koh Santepheap,/Expressive/Sincere,95
-Koh Santepheap,/Serif/Modern,100
-Koh Santepheap,/Serif/Scotch,100
 Kolker Brush,/Expressive/Active,96
 Kolker Brush,/Expressive/Excited,79
 Kolker Brush,/Expressive/Fancy,41
 Kolker Brush,/Expressive/Innovative,62
 Kolker Brush,/Expressive/Rugged,19
+Kolker Brush,/Expressive/Vintage,57.8
 Kolker Brush,/Script/Informal,100
 Kolker Brush,/Theme/Brush,100
-Konkhmer Sleokchher,/Expressive/Business,92
 Konkhmer Sleokchher,/Expressive/Calm,100
-Konkhmer Sleokchher,/Expressive/Stiff,71
+Konkhmer Sleokchher,/Expressive/Vintage,35.8
 Konkhmer Sleokchher,/Sans/Neo Grotesque,100
+Konkhmer Sleokchher,/Expressive/Stiff,71
 Kosugi,/Expressive/Calm,82
 Kosugi,/Expressive/Competent,19
+Kosugi,/Sans/Grotesque,60
 Kosugi Maru,/Expressive/Calm,82
 Kosugi Maru,/Expressive/Competent,19
 Kosugi Maru,/Sans/Grotesque,60
 Kosugi Maru,/Sans/Rounded,100
-Kosugi,/Sans/Grotesque,60
-Kotta One,/Expressive/Sincere,47
+Kotta One,/Expressive/Sincere,46.5
+Kotta One,/Expressive/Vintage,79.8
 Kotta One,/Serif/Humanist Venetian,10
 Koulen,/Expressive/Calm,86
-Koulen,/Expressive/Competent,96
 Koulen,/Expressive/Rugged,94
-Koulen,/Expressive/Stiff,91
 Koulen,/Sans/Superellipse,100
+Koulen,/Expressive/Stiff,91
 Kranky,/Expressive/Awkward,79
 Kranky,/Expressive/Childlike,44
 Kranky,/Expressive/Happy,98
 Kranky,/Expressive/Playful,90
 Kranky,/Expressive/Rugged,98
-Kranky,/Expressive/Sincere,11
+Kranky,/Expressive/Sincere,10.5
+Kranky,/Expressive/Vintage,77.6
 Kranky,/Script/Handwritten,20
 Kranky,/Theme/Brush,20
 Kranky,/Theme/Distressed,50
@@ -3545,8 +4020,8 @@ Kristi,/Expressive/Active,92
 Kristi,/Expressive/Childlike,90
 Kristi,/Expressive/Excited,15
 Kristi,/Expressive/Happy,80
+Kristi,/Expressive/Sincere,94
 Krona One,/Expressive/Calm,76
-Krona One,/Expressive/Competent,92
 Krona One,/Sans/Geometric,100
 Krub,/Expressive/Calm,97
 Krub,/Expressive/Competent,72
@@ -3554,29 +4029,31 @@ Krub,/Sans/Humanist,100
 Kufam,/Expressive/Calm,78
 Kufam,/Expressive/Competent,52
 Kufam,/Expressive/Futuristic,18
-Kufam,/Expressive/Stiff,92
 Kufam,/Sans/Geometric,20
 Kufam,/Sans/Humanist,40
+Kufam,/Expressive/Stiff,92
 Kulim Park,/Expressive/Calm,98
 Kulim Park,/Expressive/Rugged,2
-Kulim Park,/Expressive/Stiff,52
 Kulim Park,/Sans/Geometric,30
 Kulim Park,/Sans/Humanist,30
+Kulim Park,/Expressive/Stiff,52
 Kumar One,/Expressive/Futuristic,92
+Kumar One,/Expressive/Loud,95
 Kumar One,/Expressive/Rugged,99
+Kumar One,/Expressive/Vintage,56.7
+Kumar One,/Sans/Geometric,10
+Kumar One,/Serif/Fat Face,30
+Kumar One,/Serif/Modern,100
+Kumar One,/Slab/Geometric,10
 Kumar One,/Expressive/Stiff,93
 Kumar One Inline,/Expressive/Futuristic,91
 Kumar One Inline,/Expressive/Innovative,92
-Kumar One Inline,/Expressive/Stiff,97
 Kumar One Inline,/Sans/Geometric,10
 Kumar One Inline,/Serif/Fat Face,30
 Kumar One Inline,/Serif/Modern,100
 Kumar One Inline,/Slab/Geometric,10
 Kumar One Inline,/Theme/Inline,50
-Kumar One,/Sans/Geometric,10
-Kumar One,/Serif/Fat Face,30
-Kumar One,/Serif/Modern,100
-Kumar One,/Slab/Geometric,10
+Kumar One Inline,/Expressive/Stiff,97
 Kumbh Sans,/Expressive/Calm,99
 Kumbh Sans,/Sans/Geometric,100
 Kurale,/Expressive/Calm,73
@@ -3585,6 +4062,7 @@ Kurale,/Expressive/Happy,11
 Kurale,/Expressive/Innovative,61
 Kurale,/Expressive/Playful,61
 Kurale,/Expressive/Sincere,19
+Kurale,/Expressive/Vintage,78.8
 Kurale,/Script/Upright Script,80
 Kurale,/Serif/Old Style Garalde,80
 Kurale,/Theme/Wacky,20
@@ -3593,7 +4071,7 @@ La Belle Aurore,/Expressive/Awkward,12
 La Belle Aurore,/Expressive/Happy,34
 La Belle Aurore,/Script/Informal,100
 Labrada,/Expressive/Business,10
-Labrada,/Expressive/Sincere,91
+Labrada,/Expressive/Vintage,63.4
 Labrada,/Serif/Humanist Venetian,40
 Lacquer,/Expressive/Awkward,97
 Lacquer,/Expressive/Childlike,97
@@ -3604,48 +4082,54 @@ Lacquer,/Expressive/Rugged,98
 Lacquer,/Script/Handwritten,100
 Lacquer,/Theme/Brush,100
 Laila,/Expressive/Calm,77
-Laila,/Expressive/Sincere,10
+Laila,/Expressive/Sincere,10.1
 Laila,/Sans/Humanist,60
 Laila,/Serif/Humanist Venetian,40
 Lakki Reddy,/Expressive/Awkward,98
 Lakki Reddy,/Expressive/Excited,94
+Lakki Reddy,/Expressive/Loud,79
+Lakki Reddy,/Expressive/Vintage,53.4
 Lakki Reddy,/Sans/Glyphic,50
 Lakki Reddy,/Serif/Transitional,10
 Lalezar,/Expressive/Calm,73
 Lalezar,/Expressive/Competent,36
 Lalezar,/Expressive/Rugged,24
-Lalezar,/Expressive/Stiff,96
 Lalezar,/Sans/Humanist,100
-Lancelot,/Expressive/Business,92
+Lalezar,/Expressive/Stiff,96
+Lancelot,/Expressive/Business,50.1
 Lancelot,/Expressive/Calm,92
-Lancelot,/Expressive/Sincere,91
+Lancelot,/Expressive/Sincere,97
+Lancelot,/Expressive/Vintage,81
 Lancelot,/Serif/Old Style Garalde,100
 Langar,/Expressive/Cute,13
 Langar,/Script/Upright Script,20
 Langar,/Serif/Humanist Venetian,30
 Lateef,/Expressive/Business,60
-Lateef,/Expressive/Sincere,95
 Lateef,/Serif/Old Style Garalde,30
 Lateef,/Serif/Transitional,70
+Lato,/Expressive/Business,91.5
 Lato,/Expressive/Calm,100
 Lato,/Sans/Humanist,100
 Lavishly Yours,/Expressive/Artistic,100
 Lavishly Yours,/Expressive/Fancy,100
+Lavishly Yours,/Expressive/Vintage,57.8
 Lavishly Yours,/Script/Formal,60
 Lavishly Yours,/Script/Handwritten,100
 Lavishly Yours,/Script/Informal,20
-League Gothic,/Expressive/Business,94
 League Gothic,/Expressive/Calm,78
-League Gothic,/Expressive/Competent,98
+League Gothic,/Expressive/Competent,99.7
 League Gothic,/Expressive/Rugged,92
-League Gothic,/Expressive/Stiff,94
+League Gothic,/Expressive/Vintage,64.5
 League Gothic,/Sans/Grotesque,100
 League Gothic,/Sans/Superellipse,100
+League Gothic,/Expressive/Stiff,94
 League Script,/Expressive/Artistic,97
 League Script,/Expressive/Fancy,96
+League Script,/Expressive/Vintage,69.4
 League Script,/Script/Formal,40
 League Script,/Script/Handwritten,40
 League Script,/Script/Informal,40
+League Spartan,/Expressive/Business,62
 League Spartan,/Expressive/Calm,100
 League Spartan,/Sans/Geometric,100
 Leckerli One,/Expressive/Active,26
@@ -3654,120 +4138,142 @@ Leckerli One,/Expressive/Playful,54
 Leckerli One,/Script/Handwritten,100
 Leckerli One,/Script/Informal,100
 Leckerli One,/Theme/Brush,100
-Ledger,/Expressive/Business,56
-Ledger,/Expressive/Sincere,94
+Ledger,/Expressive/Business,56.8
+Ledger,/Expressive/Sincere,93
 Ledger,/Serif/Modern,100
 Lekton,/Expressive/Calm,74
-Lekton,/Expressive/Competent,97
+Lekton,/Expressive/Competent,97.2
 Lekton,/Expressive/Futuristic,97
-Lekton,/Expressive/Stiff,91
 Lekton,/Sans/Humanist,70
 Lekton,/Slab/Humanist,30
-Lemonada,/Expressive/Calm,55
-Lemonada,/Expressive/Playful,12
-Lemonada,/Theme/Brush,100
+Lekton,/Expressive/Stiff,91
 Lemon,/Expressive/Calm,48
 Lemon,/Expressive/Playful,12
 Lemon,/Theme/Brush,100
+Lemonada,/Expressive/Calm,55
+Lemonada,/Expressive/Playful,12
+Lemonada,/Theme/Brush,100
+Lexend,/Expressive/Calm,100
+Lexend,/Sans/Geometric,100
 Lexend Deca,/Expressive/Calm,100
 Lexend Deca,/Sans/Geometric,100
 Lexend Exa,/Expressive/Calm,100
-Lexend Exa,/Expressive/Competent,49
+Lexend Exa,/Expressive/Competent,95.9
 Lexend Exa,/Sans/Geometric,100
-Lexend,/Expressive/Calm,100
 Lexend Giga,/Expressive/Calm,100
-Lexend Giga,/Expressive/Competent,59
+Lexend Giga,/Expressive/Competent,95.9
 Lexend Giga,/Sans/Geometric,100
 Lexend Mega,/Expressive/Calm,100
-Lexend Mega,/Expressive/Competent,69
+Lexend Mega,/Expressive/Competent,95.9
 Lexend Mega,/Sans/Geometric,100
 Lexend Peta,/Expressive/Calm,100
-Lexend Peta,/Expressive/Competent,78
+Lexend Peta,/Expressive/Competent,95.9
 Lexend Peta,/Sans/Geometric,100
-Lexend,/Sans/Geometric,100
 Lexend Tera,/Expressive/Calm,100
-Lexend Tera,/Expressive/Competent,86
+Lexend Tera,/Expressive/Competent,95.9
 Lexend Tera,/Sans/Geometric,100
 Lexend Zetta,/Expressive/Calm,100
-Lexend Zetta,/Expressive/Competent,95
+Lexend Zetta,/Expressive/Competent,95.9
 Lexend Zetta,/Sans/Geometric,100
+Libre Barcode 128,/Expressive/Vintage,73.4
 Libre Barcode 128,/Not text/Symbols,100
+Libre Barcode 128 Text,/Expressive/Vintage,73.4
 Libre Barcode 128 Text,/Not text/Symbols,100
-Libre Barcode 39 Extended,/Not text/Symbols,100
-Libre Barcode 39 Extended Text,/Not text/Symbols,100
+Libre Barcode 39,/Expressive/Vintage,73.4
 Libre Barcode 39,/Not text/Symbols,100
+Libre Barcode 39 Extended,/Expressive/Vintage,73.4
+Libre Barcode 39 Extended,/Not text/Symbols,100
+Libre Barcode 39 Extended Text,/Expressive/Vintage,73.4
+Libre Barcode 39 Extended Text,/Not text/Symbols,100
+Libre Barcode 39 Text,/Expressive/Vintage,73.4
 Libre Barcode 39 Text,/Not text/Symbols,100
+Libre Barcode EAN13 Text,/Expressive/Vintage,73.4
 Libre Barcode EAN13 Text,/Not text/Symbols,100
-Libre Baskerville,/Expressive/Business,79
+Libre Baskerville,/Expressive/Business,87.9
 Libre Baskerville,/Expressive/Calm,98
 Libre Baskerville,/Expressive/Sincere,99
-Libre Baskerville,/Expressive/Stiff,60
+Libre Baskerville,/Expressive/Vintage,84.5
 Libre Baskerville,/Serif/Transitional,100
-Libre Bodoni,/Expressive/Business,76
+Libre Baskerville,/Expressive/Stiff,60
+Libre Bodoni,/Expressive/Business,91
 Libre Bodoni,/Expressive/Calm,98
-Libre Bodoni,/Expressive/Sincere,99
+Libre Bodoni,/Expressive/Sincere,98
+Libre Bodoni,/Expressive/Vintage,82
 Libre Bodoni,/Serif/Didone,100
-Libre Caslon Display,/Expressive/Business,79
+Libre Caslon Display,/Expressive/Business,87.9
 Libre Caslon Display,/Expressive/Calm,98
+Libre Caslon Display,/Expressive/Loud,56
 Libre Caslon Display,/Expressive/Sincere,99
-Libre Caslon Display,/Expressive/Stiff,50
+Libre Caslon Display,/Expressive/Vintage,81
 Libre Caslon Display,/Serif/Old Style Garalde,100
-Libre Caslon Text,/Expressive/Business,80
+Libre Caslon Display,/Expressive/Stiff,50
+Libre Caslon Text,/Expressive/Business,84.7
 Libre Caslon Text,/Expressive/Calm,98
-Libre Caslon Text,/Expressive/Sincere,99
-Libre Caslon Text,/Expressive/Stiff,60
+Libre Caslon Text,/Expressive/Sincere,98
+Libre Caslon Text,/Expressive/Vintage,70.8
 Libre Caslon Text,/Serif/Old Style Garalde,100
-Libre Franklin,/Expressive/Business,77
+Libre Caslon Text,/Expressive/Stiff,60
+Libre Franklin,/Expressive/Business,89.5
 Libre Franklin,/Expressive/Calm,99
-Libre Franklin,/Expressive/Stiff,81
+Libre Franklin,/Expressive/Vintage,84.5
 Libre Franklin,/Sans/Grotesque,100
+Libre Franklin,/Expressive/Stiff,81
 Licorice,/Expressive/Artistic,80
 Licorice,/Expressive/Cute,37
 Licorice,/Expressive/Fancy,45
 Licorice,/Expressive/Happy,67
 Licorice,/Expressive/Playful,33
+Licorice,/Expressive/Vintage,35.4
 Licorice,/Script/Informal,50
 Life Savers,/Expressive/Awkward,11
 Life Savers,/Expressive/Childlike,72
 Life Savers,/Expressive/Excited,46
 Life Savers,/Expressive/Happy,25
 Life Savers,/Expressive/Playful,14
-Life Savers,/Expressive/Sincere,50
+Life Savers,/Expressive/Sincere,50.1
+Life Savers,/Expressive/Vintage,37.6
 Life Savers,/Theme/Wacky,50
 Lilita One,/Expressive/Calm,96
+Lilita One,/Expressive/Competent,54
 Lilita One,/Expressive/Happy,5
 Lilita One,/Expressive/Playful,33
-Lilita One,/Expressive/Stiff,51
 Lilita One,/Sans/Humanist,100
 Lilita One,/Theme/Blobby,30
 Lilita One,/Theme/Wacky,10
 Lilita One,/Theme/Woodtype,20
+Lilita One,/Expressive/Stiff,51
 Lily Script One,/Expressive/Artistic,54
 Lily Script One,/Expressive/Cute,52
 Lily Script One,/Expressive/Happy,22
+Lily Script One,/Expressive/Loud,74
 Lily Script One,/Expressive/Playful,53
 Lily Script One,/Script/Informal,100
 Limelight,/Expressive/Artistic,100
 Limelight,/Expressive/Awkward,66
 Limelight,/Expressive/Calm,80
+Limelight,/Expressive/Loud,93
 Limelight,/Expressive/Rugged,88
+Limelight,/Expressive/Vintage,92
 Limelight,/Theme/Art Deco,100
 Linden Hill,/Expressive/Business,40
 Linden Hill,/Expressive/Calm,93
-Linden Hill,/Expressive/Sincere,92
-Linden Hill,/Expressive/Stiff,50
+Linden Hill,/Expressive/Sincere,98
+Linden Hill,/Expressive/Vintage,74.8
 Linden Hill,/Serif/Old Style Garalde,100
+Linden Hill,/Expressive/Stiff,50
 Linefont,/Not text/Symbols,100
-Lisu Bosa,/Expressive/Business,59
+Lisu Bosa,/Expressive/Business,59.9
 Lisu Bosa,/Expressive/Calm,97
-Lisu Bosa,/Expressive/Sincere,98
-Lisu Bosa,/Expressive/Stiff,50
+Lisu Bosa,/Expressive/Vintage,45
 Lisu Bosa,/Serif/Transitional,100
-Literata,/Expressive/Business,70
+Lisu Bosa,/Expressive/Stiff,50
+Literata,/Expressive/Business,69.8
 Literata,/Expressive/Calm,99
-Literata,/Expressive/Sincere,100
-Literata,/Expressive/Stiff,60
+Literata,/Expressive/Competent,96.4
+Literata,/Expressive/Sincere,96
+Literata,/Expressive/Vintage,69.8
 Literata,/Serif/Transitional,100
+Literata,/Expressive/Stiff,60
 Liu Jian Mao Cao,/Expressive/Artistic,71
 Liu Jian Mao Cao,/Expressive/Awkward,64
 Liu Jian Mao Cao,/Expressive/Childlike,58
@@ -3781,16 +4287,22 @@ Liu Jian Mao Cao,/Script/Informal,100
 Liu Jian Mao Cao,/Script/Upright Script,100
 Livvic,/Expressive/Business,22
 Livvic,/Expressive/Calm,94
-Livvic,/Expressive/Stiff,71
 Livvic,/Sans/Geometric,10
 Livvic,/Sans/Humanist,100
+Livvic,/Expressive/Stiff,71
 Lobster,/Expressive/Artistic,75
 Lobster,/Expressive/Cute,35
 Lobster,/Expressive/Fancy,92
 Lobster,/Expressive/Happy,21
+Lobster,/Expressive/Loud,73
+Lobster,/Expressive/Sincere,92
+Lobster,/Expressive/Vintage,48
 Lobster,/Script/Informal,40
 Lobster Two,/Expressive/Artistic,75
 Lobster Two,/Expressive/Childlike,20
+Lobster Two,/Expressive/Loud,73
+Lobster Two,/Expressive/Sincere,91
+Lobster Two,/Expressive/Vintage,48
 Lobster Two,/Script/Informal,40
 Londrina Outline,/Expressive/Awkward,61
 Londrina Outline,/Expressive/Calm,25
@@ -3799,10 +4311,11 @@ Londrina Outline,/Expressive/Happy,89
 Londrina Outline,/Expressive/Innovative,79
 Londrina Outline,/Expressive/Playful,54
 Londrina Outline,/Expressive/Rugged,99
-Londrina Outline,/Expressive/Stiff,60
+Londrina Outline,/Expressive/Vintage,25.4
 Londrina Outline,/Sans/Grotesque,100
 Londrina Outline,/Theme/Distressed,100
 Londrina Outline,/Theme/Wacky,10
+Londrina Outline,/Expressive/Stiff,60
 Londrina Shadow,/Expressive/Awkward,61
 Londrina Shadow,/Expressive/Calm,25
 Londrina Shadow,/Expressive/Excited,24
@@ -3810,11 +4323,12 @@ Londrina Shadow,/Expressive/Happy,89
 Londrina Shadow,/Expressive/Innovative,79
 Londrina Shadow,/Expressive/Playful,54
 Londrina Shadow,/Expressive/Rugged,99
-Londrina Shadow,/Expressive/Stiff,60
+Londrina Shadow,/Expressive/Vintage,25.4
 Londrina Shadow,/Sans/Grotesque,100
 Londrina Shadow,/Theme/Distressed,100
 Londrina Shadow,/Theme/Shaded,100
 Londrina Shadow,/Theme/Wacky,10
+Londrina Shadow,/Expressive/Stiff,60
 Londrina Sketch,/Expressive/Awkward,61
 Londrina Sketch,/Expressive/Calm,25
 Londrina Sketch,/Expressive/Excited,24
@@ -3822,10 +4336,11 @@ Londrina Sketch,/Expressive/Happy,89
 Londrina Sketch,/Expressive/Innovative,79
 Londrina Sketch,/Expressive/Playful,54
 Londrina Sketch,/Expressive/Rugged,99
-Londrina Sketch,/Expressive/Stiff,60
+Londrina Sketch,/Expressive/Vintage,25.4
 Londrina Sketch,/Sans/Grotesque,100
 Londrina Sketch,/Theme/Distressed,100
 Londrina Sketch,/Theme/Wacky,10
+Londrina Sketch,/Expressive/Stiff,60
 Londrina Solid,/Expressive/Awkward,64
 Londrina Solid,/Expressive/Calm,61
 Londrina Solid,/Expressive/Excited,23
@@ -3833,10 +4348,10 @@ Londrina Solid,/Expressive/Happy,89
 Londrina Solid,/Expressive/Innovative,72
 Londrina Solid,/Expressive/Playful,54
 Londrina Solid,/Expressive/Rugged,38
-Londrina Solid,/Expressive/Stiff,63
 Londrina Solid,/Sans/Grotesque,100
 Londrina Solid,/Theme/Distressed,100
 Londrina Solid,/Theme/Wacky,10
+Londrina Solid,/Expressive/Stiff,63
 Long Cang,/Expressive/Active,12
 Long Cang,/Expressive/Artistic,43
 Long Cang,/Expressive/Childlike,49
@@ -3845,32 +4360,19 @@ Long Cang,/Expressive/Playful,17
 Long Cang,/Expressive/Rugged,22
 Long Cang,/Script/Handwritten,100
 Long Cang,/Script/Informal,100
-Lora,/Expressive/Business,59
+Lora,/Expressive/Business,59.7
 Lora,/Expressive/Calm,98
-Lora,/Expressive/Sincere,99
-Lora,/Expressive/Stiff,50
+Lora,/Expressive/Vintage,55.4
 Lora,/Serif/Transitional,60
-Loved by the King,/Expressive/Artistic,51
-Loved by the King,/Expressive/Childlike,77
-Loved by the King,/Expressive/Excited,66
-Loved by the King,/Expressive/Happy,55
-Loved by the King,/Expressive/Playful,34
-Loved by the King,/Expressive/Rugged,15
-Loved by the King,/Script/Handwritten,100
-Loved by the King,/Script/Informal,100
-Loved by the King,/Script/Upright Script,100
+Lora,/Expressive/Stiff,50
 Love Light,/Expressive/Artistic,99
 Love Light,/Expressive/Excited,79
 Love Light,/Expressive/Fancy,78
 Love Light,/Expressive/Happy,32
 Love Light,/Expressive/Playful,55
 Love Light,/Expressive/Sophisticated,15
+Love Light,/Expressive/Vintage,61.2
 Love Light,/Script/Formal,60
-Lovers Quarrel,/Expressive/Artistic,100
-Lovers Quarrel,/Expressive/Fancy,65
-Lovers Quarrel,/Expressive/Playful,11
-Lovers Quarrel,/Expressive/Sophisticated,73
-Lovers Quarrel,/Script/Formal,80
 Love Ya Like A Sister,/Expressive/Awkward,87
 Love Ya Like A Sister,/Expressive/Childlike,46
 Love Ya Like A Sister,/Expressive/Excited,34
@@ -3881,70 +4383,122 @@ Love Ya Like A Sister,/Expressive/Rugged,78
 Love Ya Like A Sister,/Theme/Distressed,90
 Love Ya Like A Sister,/Theme/Wacky,60
 Love Ya Like A Sister,/Theme/Woodtype,20
+Loved by the King,/Expressive/Artistic,51
+Loved by the King,/Expressive/Childlike,77
+Loved by the King,/Expressive/Excited,66
+Loved by the King,/Expressive/Happy,55
+Loved by the King,/Expressive/Playful,34
+Loved by the King,/Expressive/Rugged,15
+Loved by the King,/Expressive/Sincere,97
+Loved by the King,/Script/Handwritten,100
+Loved by the King,/Script/Informal,100
+Loved by the King,/Script/Upright Script,100
+Lovers Quarrel,/Expressive/Artistic,100
+Lovers Quarrel,/Expressive/Fancy,65
+Lovers Quarrel,/Expressive/Playful,11
+Lovers Quarrel,/Expressive/Sophisticated,73
+Lovers Quarrel,/Expressive/Vintage,68.7
+Lovers Quarrel,/Script/Formal,80
 Luckiest Guy,/Expressive/Awkward,12
 Luckiest Guy,/Expressive/Calm,71
 Luckiest Guy,/Expressive/Childlike,81
 Luckiest Guy,/Expressive/Excited,25
 Luckiest Guy,/Expressive/Happy,64
+Luckiest Guy,/Expressive/Loud,100
 Luckiest Guy,/Expressive/Playful,58
 Luckiest Guy,/Theme/Wacky,40
 Luckiest Guy,/Theme/Woodtype,30
 Lugrasimo,/Expressive/Active,64
 Lugrasimo,/Expressive/Artistic,79
+Lugrasimo,/Expressive/Vintage,97
 Lugrasimo,/Script/Formal,100
 Lugrasimo,/Script/Handwritten,100
 Lumanosimo,/Expressive/Active,62
 Lumanosimo,/Expressive/Artistic,20
 Lumanosimo,/Expressive/Cute,16
 Lumanosimo,/Expressive/Happy,25
+Lumanosimo,/Expressive/Vintage,77.6
 Lumanosimo,/Script/Informal,50
+Lunasima,/Expressive/Business,91.8
 Lunasima,/Expressive/Calm,100
-Lunasima,/Expressive/Stiff,64
 Lunasima,/Sans/Humanist,100
-Lusitana,/Expressive/Business,58
+Lunasima,/Expressive/Stiff,64
+Lusitana,/Expressive/Business,58.4
 Lusitana,/Expressive/Calm,97
-Lusitana,/Expressive/Sincere,100
+Lusitana,/Expressive/Sincere,97
+Lusitana,/Expressive/Vintage,55.4
 Lusitana,/Serif/Transitional,100
 Lustria,/Expressive/Business,28
 Lustria,/Expressive/Calm,97
 Lustria,/Expressive/Sincere,85
-Lustria,/Expressive/Stiff,10
+Lustria,/Expressive/Vintage,63.4
 Lustria,/Serif/Transitional,60
+Lustria,/Expressive/Stiff,10
 Luxurious Roman,/Expressive/Active,3
 Luxurious Roman,/Expressive/Artistic,34
 Luxurious Roman,/Expressive/Happy,11
 Luxurious Roman,/Expressive/Playful,11
-Luxurious Roman,/Expressive/Sincere,21
+Luxurious Roman,/Expressive/Sincere,20.5
+Luxurious Roman,/Expressive/Vintage,87.5
 Luxurious Roman,/Serif/Humanist Venetian,50
 Luxurious Roman,/Serif/Transitional,50
 Luxurious Script,/Expressive/Artistic,99
 Luxurious Script,/Expressive/Fancy,77
 Luxurious Script,/Expressive/Sophisticated,99
+Luxurious Script,/Expressive/Vintage,92
 Luxurious Script,/Script/Formal,100
+M PLUS 1,/Expressive/Calm,99
+M PLUS 1,/Sans/Geometric,50
+M PLUS 1,/Sans/Humanist,50
+M PLUS 1 Code,/Expressive/Calm,68
+M PLUS 1 Code,/Expressive/Futuristic,54
+M PLUS 1 Code,/Monospace/Monospace,100
+M PLUS 1 Code,/Sans/Humanist,60
+M PLUS 1 Code,/Sans/Superellipse,30
+M PLUS 1 Code,/Slab/Geometric,10
+M PLUS 1 Code,/Expressive/Stiff,10
+M PLUS 1p,/Expressive/Calm,99
+M PLUS 1p,/Sans/Geometric,50
+M PLUS 1p,/Sans/Humanist,50
+M PLUS 2,/Expressive/Calm,99
+M PLUS 2,/Sans/Geometric,50
+M PLUS 2,/Sans/Humanist,50
+M PLUS Code Latin,/Expressive/Calm,68
+M PLUS Code Latin,/Expressive/Futuristic,58
+Ma Shan Zheng,/Expressive/Active,19
+Ma Shan Zheng,/Expressive/Childlike,47
+Ma Shan Zheng,/Expressive/Excited,39
+Ma Shan Zheng,/Script/Handwritten,100
+Ma Shan Zheng,/Script/Informal,50
+Ma Shan Zheng,/Theme/Brush,100
 Macondo,/Expressive/Awkward,11
 Macondo,/Expressive/Childlike,41
 Macondo,/Expressive/Cute,36
+Macondo,/Expressive/Loud,46
 Macondo,/Expressive/Playful,25
+Macondo,/Expressive/Vintage,99
+Macondo,/Theme/Blobby,10
+Macondo,/Theme/Medieval,80
 Macondo Swash Caps,/Expressive/Artistic,44
 Macondo Swash Caps,/Expressive/Awkward,11
 Macondo Swash Caps,/Expressive/Childlike,41
 Macondo Swash Caps,/Expressive/Cute,36
+Macondo Swash Caps,/Expressive/Loud,46
 Macondo Swash Caps,/Expressive/Playful,25
+Macondo Swash Caps,/Expressive/Vintage,99
 Macondo Swash Caps,/Theme/Blobby,10
 Macondo Swash Caps,/Theme/Medieval,80
-Macondo,/Theme/Blobby,10
-Macondo,/Theme/Medieval,80
 Mada,/Arabic/Kufi,100
-Mada,/Expressive/Business,57
+Mada,/Expressive/Business,95.6
 Mada,/Expressive/Calm,99
-Mada,/Expressive/Stiff,40
 Mada,/Sans/Humanist,80
 Mada,/Sans/Neo Grotesque,20
+Mada,/Expressive/Stiff,40
 Magra,/Expressive/Business,34
 Magra,/Expressive/Calm,99
-Magra,/Expressive/Competent,64
-Magra,/Expressive/Stiff,63
+Magra,/Expressive/Competent,95.1
 Magra,/Sans/Humanist,100
+Magra,/Expressive/Stiff,63
 Maiden Orange,/Expressive/Calm,78
 Maiden Orange,/Expressive/Excited,33
 Maiden Orange,/Expressive/Innovative,41
@@ -3955,21 +4509,21 @@ Maiden Orange,/Slab/Clarendon,20
 Maiden Orange,/Theme/Distressed,10
 Maiden Orange,/Theme/Wacky,40
 Maiden Orange,/Theme/Woodtype,70
-Maitree,/Expressive/Business,36
+Maitree,/Expressive/Business,62.9
 Maitree,/Expressive/Calm,98
 Maitree,/Expressive/Sincere,86
-Maitree,/Expressive/Stiff,60
 Maitree,/Serif/Transitional,50
+Maitree,/Expressive/Stiff,60
 Major Mono Display,/Expressive/Calm,92
 Major Mono Display,/Expressive/Futuristic,78
 Major Mono Display,/Expressive/Innovative,61
 Major Mono Display,/Expressive/Playful,16
-Major Mono Display,/Expressive/Stiff,72
 Major Mono Display,/Monospace/Monospace,100
 Major Mono Display,/Sans/Glyphic,100
 Major Mono Display,/Theme/Art Deco,80
 Major Mono Display,/Theme/Techno,80
-Mako,/Expressive/Business,69
+Major Mono Display,/Expressive/Stiff,72
+Mako,/Expressive/Business,96.6
 Mako,/Expressive/Calm,98
 Mako,/Expressive/Stiff,76
 Mali,/Expressive/Awkward,41
@@ -3983,18 +4537,18 @@ Mallanna,/Expressive/Business,6
 Mallanna,/Expressive/Calm,96
 Mallanna,/Expressive/Cute,2
 Mallanna,/Expressive/Playful,11
-Mallanna,/Expressive/Stiff,40
 Mallanna,/Sans/Geometric,60
 Mallanna,/Sans/Neo Grotesque,20
 Mallanna,/Sans/Rounded,100
+Mallanna,/Expressive/Stiff,40
 Mandali,/Expressive/Business,6
 Mandali,/Expressive/Calm,96
 Mandali,/Expressive/Cute,2
 Mandali,/Expressive/Playful,11
-Mandali,/Expressive/Stiff,40
 Mandali,/Sans/Geometric,60
 Mandali,/Sans/Neo Grotesque,20
 Mandali,/Sans/Rounded,100
+Mandali,/Expressive/Stiff,40
 Manjari,/Expressive/Awkward,41
 Manjari,/Expressive/Business,37
 Manjari,/Expressive/Calm,98
@@ -4005,8 +4559,8 @@ Manjari,/Sans/Geometric,100
 Manjari,/Sans/Rounded,100
 Manrope,/Expressive/Business,46
 Manrope,/Expressive/Calm,99
-Manrope,/Expressive/Stiff,71
 Manrope,/Sans/Neo Grotesque,100
+Manrope,/Expressive/Stiff,71
 Mansalva,/Expressive/Awkward,88
 Mansalva,/Expressive/Childlike,99
 Mansalva,/Expressive/Cute,25
@@ -4017,17 +4571,18 @@ Mansalva,/Expressive/Rugged,24
 Mansalva,/Script/Handwritten,100
 Mansalva,/Script/Informal,100
 Mansalva,/Script/Upright Script,30
-Manuale,/Expressive/Business,74
+Manuale,/Expressive/Business,74.2
 Manuale,/Expressive/Calm,96
-Manuale,/Expressive/Sincere,97
-Manuale,/Expressive/Stiff,71
 Manuale,/Serif/Transitional,20
+Manuale,/Expressive/Stiff,71
 Marcellus,/Expressive/Business,33
 Marcellus,/Expressive/Calm,79
+Marcellus,/Expressive/Loud,52
 Marcellus,/Expressive/Sincere,10
 Marcellus,/Expressive/Stiff,20
 Marcellus SC,/Expressive/Business,32
 Marcellus SC,/Expressive/Calm,79
+Marcellus SC,/Expressive/Loud,52
 Marcellus SC,/Expressive/Sincere,10
 Marcellus SC,/Expressive/Stiff,20
 Marck Script,/Expressive/Active,88
@@ -4035,7 +4590,9 @@ Marck Script,/Expressive/Artistic,74
 Marck Script,/Expressive/Cute,47
 Marck Script,/Expressive/Fancy,26
 Marck Script,/Expressive/Happy,16
+Marck Script,/Expressive/Sincere,96
 Marck Script,/Expressive/Sophisticated,33
+Marck Script,/Expressive/Vintage,66.8
 Marck Script,/Script/Handwritten,50
 Marck Script,/Script/Informal,100
 Marck Script,/Theme/Brush,80
@@ -4043,6 +4600,7 @@ Margarine,/Expressive/Childlike,100
 Margarine,/Expressive/Excited,15
 Margarine,/Expressive/Innovative,91
 Margarine,/Expressive/Rugged,96
+Margarine,/Expressive/Vintage,35.6
 Margarine,/Theme/Brush,100
 Margarine,/Theme/Distressed,100
 Marhey,/Expressive/Childlike,38
@@ -4050,53 +4608,52 @@ Marhey,/Expressive/Playful,45
 Marhey,/Sans/Humanist,40
 Marhey,/Script/Upright Script,30
 Marhey,/Theme/Brush,50
-Markazi Text,/Expressive/Business,99
+Markazi Text,/Expressive/Business,99.7
 Markazi Text,/Expressive/Calm,96
-Markazi Text,/Expressive/Sincere,98
-Markazi Text,/Expressive/Stiff,50
+Markazi Text,/Expressive/Vintage,58.7
 Markazi Text,/Serif/Old Style Garalde,30
 Markazi Text,/Serif/Transitional,30
+Markazi Text,/Expressive/Stiff,50
+Marko One,/Expressive/Loud,71
 Marko One,/Expressive/Playful,22
 Marko One,/Script/Upright Script,20
 Marko One,/Theme/Brush,30
 Marmelad,/Expressive/Calm,77
+Marmelad,/Expressive/Loud,47
 Marmelad,/Sans/Humanist,60
 Marmelad,/Sans/Neo Grotesque,20
 Marmelad,/Sans/Rounded,80
-Martel,/Expressive/Business,96
-Martel,/Expressive/Sincere,99
-Martel Sans,/Expressive/Calm,95
-Martel Sans,/Sans/Humanist,100
+Martel,/Expressive/Business,98.4
+Martel,/Expressive/Sincere,95
 Martel,/Serif/Humanist Venetian,20
 Martel,/Serif/Old Style Garalde,20
+Martel Sans,/Expressive/Business,90.6
+Martel Sans,/Expressive/Calm,95
+Martel Sans,/Sans/Humanist,100
 Martian Mono,/Expressive/Business,11
 Martian Mono,/Expressive/Calm,64
 Martian Mono,/Expressive/Competent,44
 Martian Mono,/Expressive/Futuristic,96
 Martian Mono,/Expressive/Happy,42
-Martian Mono,/Expressive/Stiff,71
 Martian Mono,/Sans/Grotesque,100
 Martian Mono,/Slab/Geometric,30
+Martian Mono,/Expressive/Stiff,71
 Marvel,/Expressive/Calm,93
-Marvel,/Expressive/Competent,79
+Marvel,/Expressive/Competent,89.7
 Marvel,/Sans/Humanist,70
 Marvel,/Sans/Superellipse,100
-Ma Shan Zheng,/Expressive/Active,19
-Ma Shan Zheng,/Expressive/Childlike,47
-Ma Shan Zheng,/Expressive/Excited,39
-Ma Shan Zheng,/Script/Handwritten,100
-Ma Shan Zheng,/Script/Informal,50
-Ma Shan Zheng,/Theme/Brush,100
 Mate,/Expressive/Business,31
-Mate,/Expressive/Sincere,95
-Mate SC,/Expressive/Business,31
-Mate SC,/Expressive/Sincere,95
-Mate SC,/Serif/Humanist Venetian,50
+Mate,/Expressive/Sincere,92
+Mate,/Expressive/Vintage,83.5
 Mate,/Serif/Humanist Venetian,50
+Mate SC,/Expressive/Business,31
+Mate SC,/Expressive/Sincere,92
+Mate SC,/Expressive/Vintage,83.5
+Mate SC,/Serif/Humanist Venetian,50
 Maven Pro,/Expressive/Calm,75
 Maven Pro,/Expressive/Futuristic,72
-Maven Pro,/Expressive/Stiff,91
 Maven Pro,/Sans/Humanist,50
+Maven Pro,/Expressive/Stiff,91
 McLaren,/Expressive/Awkward,41
 McLaren,/Expressive/Calm,29
 McLaren,/Expressive/Excited,32
@@ -4105,46 +4662,53 @@ McLaren,/Sans/Geometric,20
 Mea Culpa,/Expressive/Artistic,100
 Mea Culpa,/Expressive/Fancy,100
 Mea Culpa,/Expressive/Sophisticated,89
+Mea Culpa,/Expressive/Vintage,92
 Mea Culpa,/Script/Formal,100
 Meddon,/Expressive/Active,78
 Meddon,/Expressive/Artistic,97
 Meddon,/Expressive/Fancy,98
+Meddon,/Expressive/Sincere,97
+Meddon,/Expressive/Vintage,91
 Meddon,/Script/Formal,50
 Meddon,/Script/Handwritten,100
 MedievalSharp,/Expressive/Artistic,49
+MedievalSharp,/Expressive/Vintage,34
 MedievalSharp,/Sans/Glyphic,100
 MedievalSharp,/Theme/Blackletter,20
 MedievalSharp,/Theme/Medieval,60
 Medula One,/Expressive/Calm,75
-Medula One,/Expressive/Competent,99
-Medula One,/Expressive/Stiff,54
 Medula One,/Sans/Rounded,40
 Medula One,/Theme/Blackletter,50
+Medula One,/Expressive/Stiff,54
 Meera Inimai,/Expressive/Calm,97
 Meera Inimai,/Sans/Geometric,40
 Meera Inimai,/Sans/Neo Grotesque,40
 Megrim,/Expressive/Calm,52
 Megrim,/Expressive/Futuristic,97
 Megrim,/Expressive/Innovative,93
-Megrim,/Expressive/Stiff,91
 Megrim,/Theme/Art Deco,10
+Megrim,/Expressive/Stiff,91
 Meie Script,/Expressive/Artistic,40
 Meie Script,/Expressive/Fancy,75
 Meie Script,/Expressive/Sophisticated,99
+Meie Script,/Expressive/Vintage,92
 Meie Script,/Script/Formal,100
 Meow Script,/Expressive/Artistic,36
 Meow Script,/Expressive/Cute,100
 Meow Script,/Expressive/Fancy,38
 Meow Script,/Expressive/Happy,33
+Meow Script,/Expressive/Sincere,98
+Meow Script,/Expressive/Vintage,66.4
 Meow Script,/Script/Handwritten,20
 Meow Script,/Script/Informal,100
 Meow Script,/Theme/Brush,100
 Merge One,/Expressive/Calm,92
 Merge One,/Expressive/Competent,52
 Merge One,/Expressive/Cute,14
-Merge One,/Expressive/Stiff,60
+Merge One,/Expressive/Vintage,16.5
 Merge One,/Sans/Humanist,100
 Merge One,/Sans/Rounded,50
+Merge One,/Expressive/Stiff,60
 Merienda,/Expressive/Active,22
 Merienda,/Expressive/Childlike,30
 Merienda,/Expressive/Excited,10
@@ -4152,77 +4716,91 @@ Merienda,/Expressive/Rugged,16
 Merienda,/Script/Handwritten,100
 Merienda,/Script/Informal,40
 Merienda,/Theme/Brush,100
-Merriweather,/Expressive/Business,97
-Merriweather,/Expressive/Sincere,97
-Merriweather,/Expressive/Stiff,30
-Merriweather Sans,/Expressive/Business,20
-Merriweather Sans,/Expressive/Calm,98
-Merriweather Sans,/Sans/Humanist,100
+Merriweather,/Expressive/Business,99.3
+Merriweather,/Expressive/Competent,98.6
+Merriweather,/Expressive/Sincere,98
 Merriweather,/Serif/Humanist Venetian,20
 Merriweather,/Serif/Old Style Garalde,40
 Merriweather,/Serif/Transitional,20
+Merriweather,/Expressive/Stiff,30
+Merriweather Sans,/Expressive/Business,96.8
+Merriweather Sans,/Expressive/Calm,98
+Merriweather Sans,/Expressive/Competent,98.5
+Merriweather Sans,/Expressive/Sincere,94
+Merriweather Sans,/Sans/Humanist,100
 Mervale Script,/Expressive/Active,25
 Mervale Script,/Expressive/Artistic,57
 Mervale Script,/Expressive/Cute,32
 Mervale Script,/Expressive/Sophisticated,73
+Mervale Script,/Expressive/Vintage,49.6
 Mervale Script,/Script/Formal,30
 Metal,/Expressive/Business,39
-Metal,/Expressive/Sincere,97
+Metal,/Expressive/Vintage,79.2
+Metal,/Serif/Old Style Garalde,100
 Metal Mania,/Expressive/Awkward,13
 Metal Mania,/Expressive/Excited,72
 Metal Mania,/Expressive/Innovative,94
+Metal Mania,/Expressive/Loud,72
 Metal Mania,/Expressive/Rugged,96
-Metal Mania,/Expressive/Sincere,11
-Metal Mania,/Expressive/Stiff,91
+Metal Mania,/Expressive/Sincere,10.5
+Metal Mania,/Expressive/Vintage,74
 Metal Mania,/Theme/Distressed,100
 Metal Mania,/Theme/Wacky,10
-Metal,/Serif/Old Style Garalde,100
+Metal Mania,/Expressive/Stiff,91
 Metamorphous,/Expressive/Artistic,93
 Metamorphous,/Expressive/Sincere,23
 Metamorphous,/Theme/Medieval,100
 Metrophobic,/Expressive/Calm,77
-Metrophobic,/Expressive/Competent,71
+Metrophobic,/Expressive/Competent,78.4
 Metrophobic,/Expressive/Futuristic,74
-Metrophobic,/Expressive/Stiff,79
 Metrophobic,/Sans/Superellipse,100
+Metrophobic,/Expressive/Stiff,79
 Miama,/Expressive/Artistic,60
+Miama,/Expressive/Loud,22
 Miama,/Expressive/Sophisticated,24
+Miama,/Expressive/Vintage,78.7
 Miama,/Script/Formal,50
 Michroma,/Expressive/Calm,85
-Michroma,/Expressive/Competent,94
+Michroma,/Expressive/Competent,95.8
 Michroma,/Expressive/Futuristic,100
-Michroma,/Expressive/Stiff,98
+Michroma,/Expressive/Vintage,57.8
 Michroma,/Sans/Superellipse,100
 Michroma,/Theme/Techno,60
+Michroma,/Expressive/Stiff,98
+Micro 5,/Theme/Pixel,100
 Micro 5 Charted,/Theme/Pixel,100
 Milonga,/Expressive/Artistic,12
 Milonga,/Expressive/Awkward,71
 Milonga,/Expressive/Innovative,11
 Milonga,/Expressive/Playful,11
-Milonga,/Expressive/Sincere,40
+Milonga,/Expressive/Sincere,40.1
+Milonga,/Expressive/Vintage,63.5
 Milonga,/Serif/Transitional,100
 Miltonian,/Expressive/Artistic,8
 Miltonian,/Expressive/Childlike,15
 Miltonian,/Expressive/Happy,77
 Miltonian,/Expressive/Innovative,53
-Miltonian,/Expressive/Sincere,10
+Miltonian,/Expressive/Sincere,10.1
 Miltonian,/Serif/Modern,40
-Miltonian Tattoo,/Expressive/Artistic,8
-Miltonian Tattoo,/Serif/Modern,40
-Miltonian Tattoo,/Theme/Brush,10
 Miltonian,/Theme/Brush,10
 Miltonian,/Theme/Inline,100
+Miltonian Tattoo,/Expressive/Artistic,8
+Miltonian Tattoo,/Expressive/Loud,74
+Miltonian Tattoo,/Serif/Modern,40
+Miltonian Tattoo,/Theme/Brush,10
 Mina,/Expressive/Calm,82
-Mina,/Expressive/Competent,71
+Mina,/Expressive/Competent,79.3
 Mina,/Expressive/Futuristic,96
-Mina,/Expressive/Stiff,96
+Mina,/Expressive/Vintage,54
 Mina,/Sans/Humanist,20
 Mina,/Sans/Superellipse,100
-Mingzat,/Expressive/Business,54
+Mina,/Expressive/Stiff,96
+Mingzat,/Expressive/Business,54.8
 Mingzat,/Expressive/Calm,99
-Mingzat,/Expressive/Stiff,51
+Mingzat,/Expressive/Vintage,67
 Mingzat,/Sans/Grotesque,20
 Mingzat,/Sans/Neo Grotesque,80
+Mingzat,/Expressive/Stiff,51
 Miniver,/Expressive/Active,54
 Miniver,/Expressive/Cute,78
 Miniver,/Expressive/Excited,15
@@ -4244,10 +4822,12 @@ Miss Fajardose,/Expressive/Artistic,80
 Miss Fajardose,/Expressive/Cute,72
 Miss Fajardose,/Expressive/Fancy,80
 Miss Fajardose,/Expressive/Sophisticated,47
+Miss Fajardose,/Expressive/Vintage,69
 Miss Fajardose,/Script/Formal,40
 Mitr,/Expressive/Calm,85
-Mitr,/Expressive/Competent,14
+Mitr,/Expressive/Competent,71.2
 Mitr,/Expressive/Cute,11
+Mitr,/Expressive/Loud,78
 Mitr,/Expressive/Playful,32
 Mitr,/Sans/Humanist,100
 Mochiy Pop One,/Expressive/Awkward,12
@@ -4261,15 +4841,16 @@ Mochiy Pop P One,/Expressive/Happy,11
 Mochiy Pop P One,/Expressive/Playful,13
 Mochiy Pop P One,/Sans/Humanist,50
 Modak,/Expressive/Calm,30
-Modak,/Expressive/Competent,32
 Modak,/Expressive/Cute,36
 Modak,/Expressive/Excited,78
 Modak,/Expressive/Innovative,60
+Modak,/Expressive/Loud,100
 Modak,/Expressive/Playful,100
 Modak,/Sans/Humanist,100
 Modak,/Serif/Humanist Venetian,50
 Modak,/Theme/Blobby,95
-Modern Antiqua,/Expressive/Sincere,30
+Modern Antiqua,/Expressive/Sincere,30.1
+Modern Antiqua,/Expressive/Vintage,91.5
 Modern Antiqua,/Theme/Medieval,70
 Mogra,/Expressive/Active,13
 Mogra,/Expressive/Cute,27
@@ -4279,10 +4860,9 @@ Mogra,/Expressive/Playful,91
 Mogra,/Script/Informal,50
 Mogra,/Theme/Brush,100
 Mohave,/Expressive/Calm,98
-Mohave,/Expressive/Competent,98
 Mohave,/Expressive/Futuristic,76
-Mohave,/Expressive/Stiff,79
 Mohave,/Sans/Superellipse,100
+Mohave,/Expressive/Stiff,79
 Moirai One,/Expressive/Cute,17
 Moirai One,/Expressive/Playful,100
 Molengo,/Expressive/Calm,99
@@ -4291,32 +4871,34 @@ Molle,/Expressive/Artistic,73
 Molle,/Expressive/Cute,57
 Molle,/Expressive/Fancy,12
 Molle,/Expressive/Innovative,20
+Molle,/Expressive/Sincere,93
+Molle,/Expressive/Vintage,90.5
 Molle,/Script/Informal,50
 Molle,/Theme/Art Nouveau,30
 Molle,/Theme/Blobby,50
 Molle,/Theme/Brush,50
 Monda,/Expressive/Business,34
 Monda,/Expressive/Calm,97
-Monda,/Expressive/Competent,85
+Monda,/Expressive/Competent,89.6
 Monda,/Expressive/Futuristic,83
-Monda,/Expressive/Stiff,87
+Monda,/Expressive/Vintage,38.2
 Monda,/Sans/Humanist,40
 Monda,/Sans/Superellipse,100
-Monofett,/Expressive/Competent,69
+Monda,/Expressive/Stiff,87
 Monofett,/Expressive/Futuristic,48
 Monofett,/Expressive/Innovative,98
-Monofett,/Expressive/Stiff,91
 Monofett,/Monospace/Monospace,100
 Monofett,/Sans/Geometric,10
 Monofett,/Sans/Superellipse,50
 Monofett,/Theme/Shaded,100
+Monofett,/Expressive/Stiff,91
 Monomaniac One,/Expressive/Calm,79
-Monomaniac One,/Expressive/Competent,65
+Monomaniac One,/Expressive/Competent,88.4
 Monomaniac One,/Expressive/Futuristic,76
 Monomaniac One,/Expressive/Playful,41
-Monomaniac One,/Expressive/Stiff,69
 Monomaniac One,/Sans/Rounded,100
 Monomaniac One,/Sans/Superellipse,100
+Monomaniac One,/Expressive/Stiff,69
 Monoton,/Expressive/Artistic,93
 Monoton,/Expressive/Excited,91
 Monoton,/Expressive/Futuristic,15
@@ -4329,29 +4911,35 @@ Monoton,/Theme/Techno,20
 Monsieur La Doulaise,/Expressive/Artistic,100
 Monsieur La Doulaise,/Expressive/Fancy,100
 Monsieur La Doulaise,/Expressive/Sophisticated,100
+Monsieur La Doulaise,/Expressive/Vintage,92
 Monsieur La Doulaise,/Script/Formal,100
-Montaga,/Expressive/Sincere,92
+Montaga,/Expressive/Business,52.2
+Montaga,/Expressive/Sincere,98
 Montaga,/Serif/Humanist Venetian,80
 Montaga,/Serif/Old Style Garalde,20
-Montagu Slab,/Expressive/Business,17
+Montagu Slab,/Expressive/Business,63.9
+Montagu Slab,/Expressive/Competent,99.2
 Montagu Slab,/Expressive/Rugged,53
-Montagu Slab,/Expressive/Sincere,92
+Montagu Slab,/Expressive/Vintage,84
 Montagu Slab,/Slab/Clarendon,100
 MonteCarlo,/Expressive/Artistic,40
 MonteCarlo,/Expressive/Fancy,56
+MonteCarlo,/Expressive/Sincere,92
 MonteCarlo,/Expressive/Sophisticated,97
+MonteCarlo,/Expressive/Vintage,45.4
 MonteCarlo,/Script/Formal,100
 Montez,/Expressive/Cute,32
 Montez,/Expressive/Excited,34
 Montez,/Expressive/Playful,12
+Montez,/Expressive/Vintage,63.4
 Montez,/Script/Handwritten,100
 Montez,/Script/Upright Script,100
+Montserrat,/Expressive/Business,56.6
+Montserrat,/Expressive/Calm,100
+Montserrat,/Sans/Geometric,100
 Montserrat Alternates,/Expressive/Calm,100
 Montserrat Alternates,/Expressive/Playful,11
 Montserrat Alternates,/Sans/Geometric,100
-Montserrat,/Expressive/Business,56
-Montserrat,/Expressive/Calm,100
-Montserrat,/Sans/Geometric,100
 Montserrat Subrayada,/Expressive/Calm,71
 Montserrat Subrayada,/Sans/Geometric,100
 Moo Lah Lah,/Expressive/Awkward,78
@@ -4367,24 +4955,28 @@ Mooli,/Expressive/Competent,16
 Mooli,/Sans/Humanist,100
 Moon Dance,/Expressive/Artistic,40
 Moon Dance,/Expressive/Innovative,11
+Moon Dance,/Expressive/Sincere,93
 Moon Dance,/Expressive/Sophisticated,52
+Moon Dance,/Expressive/Vintage,22
 Moon Dance,/Script/Formal,100
 Moon Dance,/Script/Handwritten,100
-Moul,/Expressive/Business,53
+Moul,/Expressive/Business,59.1
 Moul,/Expressive/Rugged,55
-Moul,/Expressive/Sincere,90
+Moul,/Expressive/Vintage,81
+Moul,/Slab/Clarendon,100
 Moulpali,/Expressive/Calm,85
-Moulpali,/Expressive/Competent,76
-Moulpali,/Expressive/Stiff,30
+Moulpali,/Expressive/Competent,87.9
+Moulpali,/Expressive/Vintage,68.7
 Moulpali,/Sans/Humanist,50
 Moulpali,/Sans/Superellipse,50
-Moul,/Slab/Clarendon,100
+Moulpali,/Expressive/Stiff,30
 Mountains of Christmas,/Expressive/Awkward,96
 Mountains of Christmas,/Expressive/Excited,97
 Mountains of Christmas,/Expressive/Happy,100
 Mountains of Christmas,/Expressive/Innovative,78
 Mountains of Christmas,/Expressive/Playful,78
 Mountains of Christmas,/Expressive/Rugged,76
+Mountains of Christmas,/Expressive/Vintage,76.5
 Mountains of Christmas,/Serif/Modern,20
 Mountains of Christmas,/Serif/Transitional,20
 Mountains of Christmas,/Theme/Distressed,40
@@ -4393,33 +4985,16 @@ Mouse Memoirs,/Expressive/Awkward,91
 Mouse Memoirs,/Expressive/Calm,17
 Mouse Memoirs,/Expressive/Cute,11
 Mouse Memoirs,/Expressive/Excited,72
+Mouse Memoirs,/Expressive/Loud,74
 Mouse Memoirs,/Expressive/Playful,77
 Mouse Memoirs,/Sans/Glyphic,100
 Mouse Memoirs,/Sans/Grotesque,20
 Mouse Memoirs,/Theme/Wacky,100
-M PLUS 1 Code,/Expressive/Calm,68
-M PLUS 1 Code,/Expressive/Competent,78
-M PLUS 1 Code,/Expressive/Futuristic,54
-M PLUS 1 Code,/Expressive/Stiff,10
-M PLUS 1 Code,/Monospace/Monospace,100
-M PLUS 1 Code,/Sans/Humanist,60
-M PLUS 1 Code,/Sans/Superellipse,30
-M PLUS 1 Code,/Slab/Geometric,10
-M PLUS 1,/Expressive/Calm,99
-M PLUS 1p,/Expressive/Calm,99
-M PLUS 1p,/Sans/Geometric,50
-M PLUS 1p,/Sans/Humanist,50
-M PLUS 1,/Sans/Geometric,50
-M PLUS 1,/Sans/Humanist,50
-M PLUS 2,/Expressive/Calm,99
-M PLUS 2,/Sans/Geometric,50
-M PLUS 2,/Sans/Humanist,50
-M PLUS Code Latin,/Expressive/Calm,68
-M PLUS Code Latin,/Expressive/Competent,78
-M PLUS Code Latin,/Expressive/Futuristic,58
 Mr Bedfort,/Expressive/Cute,13
 Mr Bedfort,/Expressive/Fancy,34
+Mr Bedfort,/Expressive/Loud,46
 Mr Bedfort,/Expressive/Sophisticated,54
+Mr Bedfort,/Expressive/Vintage,89
 Mr Bedfort,/Script/Formal,50
 Mr Bedfort,/Script/Handwritten,100
 Mr Bedfort,/Script/Informal,50
@@ -4427,7 +5002,9 @@ Mr Bedfort,/Theme/Brush,20
 Mr Dafoe,/Expressive/Cute,43
 Mr Dafoe,/Expressive/Excited,46
 Mr Dafoe,/Expressive/Fancy,26
+Mr Dafoe,/Expressive/Sincere,93
 Mr Dafoe,/Expressive/Sophisticated,18
+Mr Dafoe,/Expressive/Vintage,78.7
 Mr Dafoe,/Script/Handwritten,100
 Mr Dafoe,/Script/Informal,100
 Mr Dafoe,/Theme/Brush,100
@@ -4435,6 +5012,7 @@ Mr De Haviland,/Expressive/Artistic,40
 Mr De Haviland,/Expressive/Fancy,75
 Mr De Haviland,/Expressive/Happy,32
 Mr De Haviland,/Expressive/Sophisticated,59
+Mr De Haviland,/Expressive/Vintage,63
 Mr De Haviland,/Script/Formal,60
 Mr De Haviland,/Script/Handwritten,100
 Mr De Haviland,/Script/Informal,40
@@ -4442,6 +5020,7 @@ Mr De Haviland,/Theme/Brush,10
 Mrs Saint Delafield,/Expressive/Artistic,20
 Mrs Saint Delafield,/Expressive/Fancy,97
 Mrs Saint Delafield,/Expressive/Sophisticated,98
+Mrs Saint Delafield,/Expressive/Vintage,64.7
 Mrs Saint Delafield,/Script/Formal,80
 Mrs Saint Delafield,/Script/Handwritten,100
 Mrs Saint Delafield,/Script/Informal,20
@@ -4451,7 +5030,10 @@ Mrs Sheppards,/Expressive/Cute,54
 Mrs Sheppards,/Expressive/Excited,20
 Mrs Sheppards,/Expressive/Fancy,26
 Mrs Sheppards,/Expressive/Happy,14
+Mrs Sheppards,/Expressive/Loud,88
 Mrs Sheppards,/Expressive/Playful,54
+Mrs Sheppards,/Expressive/Sincere,92
+Mrs Sheppards,/Expressive/Vintage,78.9
 Mrs Sheppards,/Script/Handwritten,100
 Mrs Sheppards,/Script/Informal,100
 Mrs Sheppards,/Theme/Brush,100
@@ -4460,15 +5042,18 @@ Ms Madi,/Expressive/Cute,79
 Ms Madi,/Expressive/Fancy,73
 Ms Madi,/Expressive/Happy,31
 Ms Madi,/Expressive/Playful,12
+Ms Madi,/Expressive/Sincere,94
+Ms Madi,/Expressive/Vintage,56.4
 Ms Madi,/Script/Handwritten,100
 Ms Madi,/Script/Informal,100
 Ms Madi,/Theme/Brush,60
+Mukta,/Expressive/Business,96.4
 Mukta,/Expressive/Calm,100
+Mukta,/Sans/Humanist,100
 Mukta Mahee,/Expressive/Calm,100
 Mukta Mahee,/Sans/Humanist,100
 Mukta Malar,/Expressive/Calm,100
 Mukta Malar,/Sans/Humanist,100
-Mukta,/Sans/Humanist,100
 Mukta Vaani,/Expressive/Calm,100
 Mukta Vaani,/Sans/Humanist,100
 Mulish,/Expressive/Calm,100
@@ -4478,7 +5063,16 @@ Murecho,/Expressive/Calm,99
 Murecho,/Sans/Humanist,100
 MuseoModerno,/Expressive/Calm,93
 MuseoModerno,/Expressive/Competent,34
+MuseoModerno,/Expressive/Vintage,34.8
 MuseoModerno,/Sans/Geometric,100
+My Soul,/Expressive/Active,53
+My Soul,/Expressive/Artistic,80
+My Soul,/Expressive/Excited,20
+My Soul,/Expressive/Fancy,59
+My Soul,/Expressive/Sophisticated,73
+My Soul,/Expressive/Vintage,38.9
+My Soul,/Script/Formal,80
+My Soul,/Script/Handwritten,100
 Mynerve,/Expressive/Awkward,51
 Mynerve,/Expressive/Childlike,99
 Mynerve,/Expressive/Cute,68
@@ -4487,29 +5081,23 @@ Mynerve,/Expressive/Innovative,22
 Mynerve,/Expressive/Rugged,42
 Mynerve,/Script/Handwritten,100
 Mynerve,/Script/Informal,100
-My Soul,/Expressive/Active,53
-My Soul,/Expressive/Artistic,80
-My Soul,/Expressive/Excited,20
-My Soul,/Expressive/Fancy,59
-My Soul,/Expressive/Sophisticated,73
-My Soul,/Script/Formal,80
-My Soul,/Script/Handwritten,100
 Mystery Quest,/Expressive/Artistic,40
 Mystery Quest,/Expressive/Awkward,95
 Mystery Quest,/Expressive/Happy,99
-Mystery Quest,/Expressive/Sincere,50
+Mystery Quest,/Expressive/Sincere,50.1
+Mystery Quest,/Expressive/Vintage,73
 Mystery Quest,/Theme/Wacky,100
 Nabla,/Expressive/Futuristic,98
 Nabla,/Expressive/Innovative,100
 Nabla,/Expressive/Rugged,91
-Nabla,/Expressive/Stiff,91
 Nabla,/Theme/Shaded,100
 Nabla,/Theme/Techno,40
+Nabla,/Expressive/Stiff,91
 Namdhinggo,/Expressive/Business,95
 Namdhinggo,/Expressive/Calm,94
-Namdhinggo,/Expressive/Sincere,98
-Namdhinggo,/Expressive/Stiff,60
+Namdhinggo,/Expressive/Vintage,57.3
 Namdhinggo,/Serif/Humanist Venetian,100
+Namdhinggo,/Expressive/Stiff,60
 Nanum Brush Script,/Expressive/Awkward,36
 Nanum Brush Script,/Expressive/Childlike,38
 Nanum Brush Script,/Expressive/Excited,59
@@ -4517,22 +5105,6 @@ Nanum Brush Script,/Expressive/Innovative,12
 Nanum Brush Script,/Expressive/Playful,35
 Nanum Brush Script,/Expressive/Rugged,14
 Nanum Brush Script,/Script/Handwritten,100
-NanumGothicCoding,/Expressive/Calm,78
-NanumGothicCoding,/Expressive/Competent,72
-NanumGothicCoding,/Expressive/Futuristic,32
-NanumGothicCoding,/Expressive/Stiff,10
-NanumGothicCoding,/Sans/Geometric,40
-NanumGothicCoding,/Sans/Grotesque,20
-NanumGothicCoding,/Sans/Humanist,20
-NanumGothicCoding,/Slab/Geometric,20
-NanumGothic,/Expressive/Calm,99
-NanumGothic,/Sans/Grotesque,70
-NanumGothic,/Sans/Humanist,30
-NanumMyeongjo,/Expressive/Business,99
-NanumMyeongjo,/Expressive/Calm,98
-NanumMyeongjo,/Expressive/Sincere,99
-NanumMyeongjo,/Expressive/Stiff,40
-NanumMyeongjo,/Serif/Old Style Garalde,100
 Nanum Pen,/Expressive/Artistic,12
 Nanum Pen,/Expressive/Awkward,21
 Nanum Pen,/Expressive/Childlike,79
@@ -4541,12 +5113,28 @@ Nanum Pen,/Expressive/Happy,47
 Nanum Pen,/Script/Handwritten,100
 Nanum Pen,/Script/Informal,100
 Nanum Pen,/Theme/Brush,100
+NanumGothic,/Expressive/Calm,99
+NanumGothic,/Sans/Grotesque,70
+NanumGothic,/Sans/Humanist,30
+NanumGothicCoding,/Expressive/Calm,78
+NanumGothicCoding,/Expressive/Competent,78.1
+NanumGothicCoding,/Expressive/Futuristic,32
+NanumGothicCoding,/Sans/Geometric,40
+NanumGothicCoding,/Sans/Grotesque,20
+NanumGothicCoding,/Sans/Humanist,20
+NanumGothicCoding,/Slab/Geometric,20
+NanumGothicCoding,/Expressive/Stiff,10
+NanumMyeongjo,/Expressive/Business,98.7
+NanumMyeongjo,/Expressive/Calm,98
+NanumMyeongjo,/Expressive/Vintage,81
+NanumMyeongjo,/Serif/Old Style Garalde,100
+NanumMyeongjo,/Expressive/Stiff,40
 Narnoor,/Expressive/Calm,99
 Narnoor,/Sans/Humanist,100
-NATS,/Expressive/Business,83
+NATS,/Expressive/Business,80.2
 NATS,/Expressive/Calm,99
-NATS,/Expressive/Stiff,51
 NATS,/Sans/Geometric,100
+NATS,/Expressive/Stiff,51
 Neonderthaw,/Expressive/Active,78
 Neonderthaw,/Expressive/Artistic,74
 Neonderthaw,/Expressive/Cute,36
@@ -4566,40 +5154,49 @@ Neucha,/Expressive/Childlike,38
 Neucha,/Expressive/Playful,52
 Neucha,/Expressive/Rugged,15
 Neucha,/Sans/Humanist,20
-Neuton,/Expressive/Business,72
-Neuton,/Expressive/Sincere,98
+Neuton,/Expressive/Business,89
+Neuton,/Expressive/Sincere,96
+Neuton,/Expressive/Vintage,78.3
 Neuton,/Serif/Humanist Venetian,100
 New Rocker,/Expressive/Artistic,58
+New Rocker,/Expressive/Loud,88
 New Rocker,/Expressive/Rugged,98
-New Rocker,/Expressive/Stiff,91
+New Rocker,/Expressive/Vintage,95
 New Rocker,/Theme/Blackletter,100
-News Cycle,/Expressive/Business,32
-News Cycle,/Expressive/Calm,86
-News Cycle,/Expressive/Competent,79
-News Cycle,/Sans/Grotesque,20
-News Cycle,/Sans/Humanist,80
-Newsreader,/Expressive/Business,78
-Newsreader,/Expressive/Sincere,99
-Newsreader,/Serif/Transitional,100
+New Rocker,/Expressive/Stiff,91
 New Tegomin,/Expressive/Excited,15
 New Tegomin,/Expressive/Innovative,12
 New Tegomin,/Expressive/Playful,20
 New Tegomin,/Expressive/Rugged,72
 New Tegomin,/Expressive/Sincere,51
+New Tegomin,/Expressive/Vintage,84.5
 New Tegomin,/Serif/Transitional,50
 New Tegomin,/Slab/Humanist,50
+News Cycle,/Expressive/Business,32
+News Cycle,/Expressive/Calm,86
+News Cycle,/Expressive/Competent,89.2
+News Cycle,/Sans/Grotesque,20
+News Cycle,/Sans/Humanist,80
+Newsreader,/Expressive/Business,99.5
+Newsreader,/Expressive/Competent,97.1
+Newsreader,/Expressive/Loud,20
+Newsreader,/Expressive/Sincere,97
+Newsreader,/Expressive/Vintage,81.5
+Newsreader,/Serif/Transitional,100
 Niconne,/Expressive/Active,66
 Niconne,/Expressive/Fancy,57
-Niconne,/Expressive/Sincere,40
+Niconne,/Expressive/Loud,37
+Niconne,/Expressive/Sincere,40.1
+Niconne,/Expressive/Vintage,77
 Niconne,/Serif/Modern,100
-Niramit,/Expressive/Business,81
+Niramit,/Expressive/Business,67.3
 Niramit,/Expressive/Calm,97
 Niramit,/Expressive/Happy,11
-Niramit,/Expressive/Stiff,53
+Niramit,/Expressive/Vintage,64.7
 Niramit,/Sans/Geometric,90
 Niramit,/Sans/Humanist,10
+Niramit,/Expressive/Stiff,53
 Nixie One,/Expressive/Awkward,11
-Nixie One,/Expressive/Sincere,93
 Nixie One,/Slab/Humanist,100
 Nobile,/Expressive/Business,20
 Nobile,/Expressive/Calm,98
@@ -4609,58 +5206,62 @@ Nokora,/Expressive/Calm,99
 Nokora,/Sans/Neo Grotesque,100
 Norican,/Expressive/Cute,14
 Norican,/Expressive/Fancy,18
+Norican,/Expressive/Loud,25
+Norican,/Expressive/Sincere,92
 Norican,/Expressive/Sophisticated,24
+Norican,/Expressive/Vintage,59
 Norican,/Script/Formal,50
-Nosifer Caps,/Expressive/Excited,34
-Nosifer Caps,/Expressive/Innovative,76
-Nosifer Caps,/Expressive/Rugged,92
-Nosifer Caps,/Expressive/Stiff,55
-Nosifer Caps,/Theme/Wacky,100
 Nosifer,/Expressive/Excited,34
 Nosifer,/Expressive/Innovative,76
+Nosifer,/Expressive/Loud,99
 Nosifer,/Expressive/Rugged,92
-Nosifer,/Expressive/Stiff,55
 Nosifer,/Theme/Wacky,100
+Nosifer,/Expressive/Stiff,55
+Nosifer Caps,/Expressive/Excited,34
+Nosifer Caps,/Expressive/Innovative,76
+Nosifer Caps,/Expressive/Loud,99
+Nosifer Caps,/Expressive/Rugged,92
+Nosifer Caps,/Theme/Wacky,100
+Nosifer Caps,/Expressive/Stiff,55
 Notable,/Expressive/Artistic,97
+Notable,/Expressive/Loud,98
 Notable,/Expressive/Rugged,76
-Notable,/Expressive/Stiff,71
 Notable,/Theme/Art Deco,100
+Notable,/Expressive/Stiff,71
 Nothing You Could Do,/Expressive/Active,76
 Nothing You Could Do,/Expressive/Childlike,90
 Nothing You Could Do,/Expressive/Excited,23
 Nothing You Could Do,/Expressive/Playful,22
 Nothing You Could Do,/Expressive/Rugged,16
+Nothing You Could Do,/Expressive/Sincere,97
 Nothing You Could Do,/Script/Handwritten,100
 Nothing You Could Do,/Script/Informal,100
-Noticia Text,/Expressive/Business,80
-Noticia Text,/Expressive/Sincere,100
+Noticia Text,/Expressive/Business,79
+Noticia Text,/Expressive/Sincere,97
 Noticia Text,/Slab/Humanist,100
-Noto Color Emoji Compat Test,/Not text/Symbols,100
 Noto Color Emoji,/Expressive/Childlike,90
 Noto Color Emoji,/Expressive/Cute,95
 Noto Color Emoji,/Expressive/Excited,100
 Noto Color Emoji,/Expressive/Innovative,100
 Noto Color Emoji,/Expressive/Playful,100
+Noto Color Emoji Compat Test,/Not text/Symbols,100
 Noto Emoji,/Expressive/Cute,80
 Noto Emoji,/Expressive/Innovative,99
 Noto Emoji,/Expressive/Playful,80
 Noto Kufi Arabic,/Arabic/Kufi,100
+Noto Music,/Expressive/Business,58
 Noto Music,/Not text/Symbols,100
 Noto Naskh Arabic,/Arabic/Naskh,100
-Noto Naskh Arabic,/Expressive/Business,99
-Noto Naskh Arabic,/Expressive/Sincere,99
 Noto Naskh Arabic,/Serif/Transitional,100
 Noto Naskh Arabic UI,/Arabic/Naskh,100
-Noto Naskh Arabic UI,/Expressive/Business,99
-Noto Naskh Arabic UI,/Expressive/Sincere,99
 Noto Nastaliq Urdu,/Arabic/Nastaliq,100
-Noto Nastaliq Urdu,/Expressive/Business,99
-Noto Nastaliq Urdu,/Expressive/Sincere,99
+Noto Nastaliq Urdu,/Expressive/Vintage,53.4
 Noto Nastaliq Urdu,/Serif/Transitional,100
-Noto Rashi Hebrew,/Expressive/Business,99
-Noto Rashi Hebrew,/Expressive/Sincere,99
 Noto Rashi Hebrew,/Hebrew/Rashi,100
 Noto Rashi Hebrew,/Serif/Transitional,100
+Noto Sans,/Expressive/Business,98.3
+Noto Sans,/Expressive/Calm,99
+Noto Sans,/Sans/Humanist,100
 Noto Sans Adlam,/Expressive/Business,58
 Noto Sans Adlam,/Expressive/Calm,99
 Noto Sans Adlam,/Sans/Humanist,100
@@ -4768,8 +5369,6 @@ Noto Sans Elymaic,/Sans/Humanist,100
 Noto Sans Ethiopic,/Expressive/Business,58
 Noto Sans Ethiopic,/Expressive/Calm,99
 Noto Sans Ethiopic,/Sans/Humanist,100
-Noto Sans,/Expressive/Business,58
-Noto Sans,/Expressive/Calm,99
 Noto Sans Georgian,/Expressive/Business,58
 Noto Sans Georgian,/Expressive/Calm,99
 Noto Sans Georgian,/Sans/Humanist,100
@@ -4862,10 +5461,10 @@ Noto Sans KR,/Expressive/Calm,99
 Noto Sans KR,/Sans/Humanist,100
 Noto Sans Lao,/Expressive/Business,58
 Noto Sans Lao,/Expressive/Calm,99
+Noto Sans Lao,/Sans/Humanist,100
 Noto Sans Lao Looped,/Expressive/Business,58
 Noto Sans Lao Looped,/Expressive/Calm,99
 Noto Sans Lao Looped,/Sans/Humanist,100
-Noto Sans Lao,/Sans/Humanist,100
 Noto Sans Lao UI,/Sans/Humanist,100
 Noto Sans Lepcha,/Expressive/Business,58
 Noto Sans Lepcha,/Expressive/Calm,99
@@ -4952,12 +5551,13 @@ Noto Sans Nag Mundari,/Sans/Humanist,100
 Noto Sans Nandinagari,/Expressive/Business,58
 Noto Sans Nandinagari,/Expressive/Calm,99
 Noto Sans Nandinagari,/Sans/Humanist,100
-Noto Sans Newa,/Expressive/Business,58
-Noto Sans Newa,/Expressive/Calm,99
-Noto Sans Newa,/Sans/Humanist,100
 Noto Sans New Tai Lue,/Expressive/Business,58
 Noto Sans New Tai Lue,/Expressive/Calm,99
 Noto Sans New Tai Lue,/Sans/Humanist,100
+Noto Sans Newa,/Expressive/Business,58
+Noto Sans Newa,/Expressive/Calm,99
+Noto Sans Newa,/Sans/Humanist,100
+Noto Sans NKo,/Expressive/Business,58
 Noto Sans NKo,/Expressive/Business,58
 Noto Sans NKo,/Expressive/Calm,99
 Noto Sans NKo,/Sans/Humanist,100
@@ -5034,7 +5634,6 @@ Noto Sans Runic,/Sans/Humanist,100
 Noto Sans Samaritan,/Expressive/Business,58
 Noto Sans Samaritan,/Expressive/Calm,99
 Noto Sans Samaritan,/Sans/Humanist,100
-Noto Sans,/Sans/Humanist,100
 Noto Sans Saurashtra,/Expressive/Business,58
 Noto Sans Saurashtra,/Expressive/Calm,99
 Noto Sans Saurashtra,/Sans/Humanist,100
@@ -5072,16 +5671,17 @@ Noto Sans Sundanese,/Sans/Humanist,100
 Noto Sans Syloti Nagri,/Expressive/Business,58
 Noto Sans Syloti Nagri,/Expressive/Calm,99
 Noto Sans Syloti Nagri,/Sans/Humanist,100
-Noto Sans Symbols 2,/Not text/Symbols,100
 Noto Sans Symbols,/Expressive/Business,58
 Noto Sans Symbols,/Expressive/Calm,99
 Noto Sans Symbols,/Sans/Humanist,100
-Noto Sans Syriac Eastern,/Expressive/Business,58
-Noto Sans Syriac Eastern,/Expressive/Calm,99
-Noto Sans Syriac Eastern,/Sans/Humanist,100
+Noto Sans Symbols 2,/Expressive/Business,58
+Noto Sans Symbols 2,/Not text/Symbols,100
 Noto Sans Syriac,/Expressive/Business,58
 Noto Sans Syriac,/Expressive/Calm,99
 Noto Sans Syriac,/Sans/Humanist,100
+Noto Sans Syriac Eastern,/Expressive/Business,58
+Noto Sans Syriac Eastern,/Expressive/Calm,99
+Noto Sans Syriac Eastern,/Sans/Humanist,100
 Noto Sans Tagalog,/Expressive/Business,58
 Noto Sans Tagalog,/Expressive/Calm,99
 Noto Sans Tagalog,/Sans/Humanist,100
@@ -5122,10 +5722,10 @@ Noto Sans Thaana,/Expressive/Calm,99
 Noto Sans Thaana,/Sans/Humanist,100
 Noto Sans Thai,/Expressive/Business,58
 Noto Sans Thai,/Expressive/Calm,99
+Noto Sans Thai,/Sans/Humanist,100
 Noto Sans Thai Looped,/Expressive/Business,58
 Noto Sans Thai Looped,/Expressive/Calm,99
 Noto Sans Thai Looped,/Sans/Humanist,100
-Noto Sans Thai,/Sans/Humanist,100
 Noto Sans Thai UI,/Sans/Humanist,100
 Noto Sans Tifinagh,/Expressive/Business,58
 Noto Sans Tifinagh,/Expressive/Calm,99
@@ -5154,156 +5754,84 @@ Noto Sans Yi,/Sans/Humanist,100
 Noto Sans Zanabazar Square,/Expressive/Business,58
 Noto Sans Zanabazar Square,/Expressive/Calm,99
 Noto Sans Zanabazar Square,/Sans/Humanist,100
-Noto Serif Ahom,/Expressive/Business,99
-Noto Serif Ahom,/Expressive/Sincere,99
-Noto Serif Ahom,/Serif/Transitional,100
-Noto Serif Armenian,/Expressive/Business,99
-Noto Serif Armenian,/Expressive/Sincere,99
-Noto Serif Armenian,/Serif/Transitional,100
-Noto Serif Balinese,/Expressive/Business,99
-Noto Serif Balinese,/Expressive/Sincere,99
-Noto Serif Balinese,/Serif/Transitional,100
-Noto Serif Bengali,/Expressive/Business,99
-Noto Serif Bengali,/Expressive/Sincere,99
-Noto Serif Bengali,/Serif/Transitional,100
-Noto Serif Devanagari,/Expressive/Business,99
-Noto Serif Devanagari,/Expressive/Sincere,99
-Noto Serif Devanagari,/Serif/Transitional,100
-Noto Serif Display,/Expressive/Business,99
-Noto Serif Display,/Expressive/Sincere,99
-Noto Serif Display,/Serif/Transitional,100
-Noto Serif Dogra,/Expressive/Business,99
-Noto Serif Dogra,/Expressive/Sincere,99
-Noto Serif Dogra,/Serif/Transitional,100
-Noto Serif Ethiopic,/Expressive/Business,99
-Noto Serif Ethiopic,/Expressive/Sincere,99
-Noto Serif Ethiopic,/Serif/Transitional,100
-Noto Serif,/Expressive/Business,99
-Noto Serif,/Expressive/Sincere,99
-Noto Serif Georgian,/Expressive/Business,99
-Noto Serif Georgian,/Expressive/Sincere,99
-Noto Serif Georgian,/Serif/Transitional,100
-Noto Serif Grantha,/Expressive/Business,99
-Noto Serif Grantha,/Expressive/Sincere,99
-Noto Serif Grantha,/Serif/Transitional,100
-Noto Serif Gujarati,/Expressive/Business,99
-Noto Serif Gujarati,/Expressive/Sincere,99
-Noto Serif Gujarati,/Serif/Transitional,100
-Noto Serif Gurmukhi,/Expressive/Business,99
-Noto Serif Gurmukhi,/Expressive/Sincere,99
-Noto Serif Gurmukhi,/Serif/Transitional,100
-Noto Serif Hebrew,/Expressive/Business,99
-Noto Serif Hebrew,/Expressive/Sincere,99
-Noto Serif Hebrew,/Serif/Transitional,100
-Noto Serif HK,/Expressive/Business,99
-Noto Serif HK,/Expressive/Sincere,99
-Noto Serif HK,/Serif/Transitional,100
-Noto Serif JP,/Expressive/Business,99
-Noto Serif JP,/Expressive/Sincere,99
-Noto Serif JP,/Serif/Transitional,100
-Noto Serif Kannada,/Expressive/Business,99
-Noto Serif Kannada,/Expressive/Sincere,99
-Noto Serif Kannada,/Serif/Transitional,100
-Noto Serif Khitan Small Script,/Expressive/Business,99
-Noto Serif Khitan Small Script,/Expressive/Sincere,99
-Noto Serif Khitan Small Script,/Serif/Transitional,100
-Noto Serif Khmer,/Expressive/Business,99
-Noto Serif Khmer,/Expressive/Sincere,99
-Noto Serif Khmer,/Serif/Transitional,100
-Noto Serif Khojki,/Expressive/Business,99
-Noto Serif Khojki,/Expressive/Sincere,99
-Noto Serif Khojki,/Serif/Transitional,100
-Noto Serif KR,/Expressive/Business,99
-Noto Serif KR,/Expressive/Sincere,99
-Noto Serif KR,/Serif/Transitional,100
-Noto Serif Lao,/Expressive/Business,99
-Noto Serif Lao,/Expressive/Sincere,99
-Noto Serif Lao,/Serif/Transitional,100
-Noto Serif Makasar,/Expressive/Business,99
-Noto Serif Makasar,/Expressive/Sincere,99
-Noto Serif Makasar,/Serif/Transitional,100
-Noto Serif Malayalam,/Expressive/Business,99
-Noto Serif Malayalam,/Expressive/Sincere,99
-Noto Serif Malayalam,/Serif/Transitional,100
-Noto Serif Myanmar,/Expressive/Business,99
-Noto Serif Myanmar,/Expressive/Sincere,99
-Noto Serif Myanmar,/Serif/Transitional,100
-Noto Serif NP Hmong,/Expressive/Business,99
-Noto Serif NP Hmong,/Expressive/Sincere,99
-Noto Serif NP Hmong,/Serif/Transitional,100
-Noto Serif Nyiakeng Puachue Hmong,/Expressive/Business,99
-Noto Serif Nyiakeng Puachue Hmong,/Expressive/Sincere,99
-Noto Serif Nyiakeng Puachue Hmong,/Serif/Transitional,100
-Noto Serif Oriya,/Expressive/Business,99
-Noto Serif Oriya,/Expressive/Sincere,99
-Noto Serif Oriya,/Serif/Transitional,100
-Noto Serif Ottoman Siyaq,/Expressive/Business,99
-Noto Serif Ottoman Siyaq,/Expressive/Sincere,99
-Noto Serif Ottoman Siyaq,/Serif/Transitional,100
-Noto Serif SC,/Expressive/Business,99
-Noto Serif SC,/Expressive/Sincere,99
-Noto Serif SC,/Serif/Transitional,100
+Noto Serif,/Expressive/Business,98.9
+Noto Serif,/Expressive/Competent,98.9
+Noto Serif,/Expressive/Sincere,91
 Noto Serif,/Serif/Transitional,100
-Noto Serif Sinhala,/Expressive/Business,99
-Noto Serif Sinhala,/Expressive/Sincere,99
+Noto Serif Ahom,/Serif/Transitional,100
+Noto Serif Armenian,/Serif/Transitional,100
+Noto Serif Balinese,/Serif/Transitional,100
+Noto Serif Bengali,/Serif/Transitional,100
+Noto Serif Devanagari,/Serif/Transitional,100
+Noto Serif Display,/Serif/Transitional,100
+Noto Serif Dogra,/Serif/Transitional,100
+Noto Serif Ethiopic,/Serif/Transitional,100
+Noto Serif Georgian,/Serif/Transitional,100
+Noto Serif Grantha,/Serif/Transitional,100
+Noto Serif Gujarati,/Serif/Transitional,100
+Noto Serif Gurmukhi,/Serif/Transitional,100
+Noto Serif Hebrew,/Serif/Transitional,100
+Noto Serif HK,/Expressive/Loud,25
+Noto Serif HK,/Serif/Transitional,100
+Noto Serif JP,/Expressive/Loud,25
+Noto Serif JP,/Serif/Transitional,100
+Noto Serif Kannada,/Serif/Transitional,100
+Noto Serif Khitan Small Script,/Serif/Transitional,100
+Noto Serif Khmer,/Serif/Transitional,100
+Noto Serif Khojki,/Serif/Transitional,100
+Noto Serif KR,/Expressive/Loud,25
+Noto Serif KR,/Serif/Transitional,100
+Noto Serif Lao,/Serif/Transitional,100
+Noto Serif Makasar,/Serif/Transitional,100
+Noto Serif Malayalam,/Serif/Transitional,100
+Noto Serif Myanmar,/Serif/Transitional,100
+Noto Serif NP Hmong,/Serif/Transitional,100
+Noto Serif Nyiakeng Puachue Hmong,/Serif/Transitional,100
+Noto Serif Oriya,/Serif/Transitional,100
+Noto Serif Ottoman Siyaq,/Serif/Transitional,100
+Noto Serif SC,/Expressive/Loud,25
+Noto Serif SC,/Serif/Transitional,100
 Noto Serif Sinhala,/Serif/Transitional,100
-Noto Serif Tamil,/Expressive/Business,99
-Noto Serif Tamil,/Expressive/Sincere,99
 Noto Serif Tamil,/Serif/Transitional,100
-Noto Serif Tangut,/Expressive/Business,99
-Noto Serif Tangut,/Expressive/Sincere,99
+Noto Serif Tangut,/Expressive/Loud,25
 Noto Serif Tangut,/Serif/Transitional,100
-Noto Serif TC,/Expressive/Business,99
-Noto Serif TC,/Expressive/Sincere,99
+Noto Serif TC,/Expressive/Loud,25
 Noto Serif TC,/Serif/Transitional,100
-Noto Serif Telugu,/Expressive/Business,99
-Noto Serif Telugu,/Expressive/Sincere,99
 Noto Serif Telugu,/Serif/Transitional,100
-Noto Serif Thai,/Expressive/Business,99
-Noto Serif Thai,/Expressive/Sincere,99
 Noto Serif Thai,/Serif/Transitional,100
-Noto Serif Tibetan,/Expressive/Business,99
-Noto Serif Tibetan,/Expressive/Sincere,99
 Noto Serif Tibetan,/Serif/Transitional,100
-Noto Serif Toto,/Expressive/Business,99
-Noto Serif Toto,/Expressive/Sincere,99
 Noto Serif Toto,/Serif/Transitional,100
-Noto Serif Vithkuqi,/Expressive/Business,99
-Noto Serif Vithkuqi,/Expressive/Sincere,99
 Noto Serif Vithkuqi,/Serif/Transitional,100
-Noto Serif Yezidi,/Expressive/Business,99
-Noto Serif Yezidi,/Expressive/Sincere,99
 Noto Serif Yezidi,/Serif/Transitional,100
 Noto Traditional Nushu,/Expressive/Business,58
 Noto Traditional Nushu,/Expressive/Calm,99
 Noto Traditional Nushu,/Sans/Humanist,100
 Nova Cut,/Expressive/Futuristic,78
-Nova Cut,/Expressive/Stiff,96
+Nova Cut,/Expressive/Loud,28
 Nova Cut,/Theme/Blackletter,20
-Nova Flat,/Expressive/Competent,14
+Nova Cut,/Expressive/Stiff,96
+Nova Flat,/Expressive/Competent,77.9
 Nova Flat,/Expressive/Futuristic,38
-Nova Flat,/Expressive/Stiff,96
 Nova Flat,/Theme/Blackletter,20
 Nova Flat,/Theme/Techno,30
+Nova Flat,/Expressive/Stiff,96
 Nova Mono,/Expressive/Futuristic,38
 Nova Mono,/Expressive/Playful,14
-Nova Mono,/Expressive/Stiff,30
 Nova Mono,/Monospace/Monospace,100
 Nova Mono,/Sans/Superellipse,60
 Nova Mono,/Theme/Blackletter,10
 Nova Mono,/Theme/Techno,50
+Nova Mono,/Expressive/Stiff,30
 Nova Oval,/Expressive/Calm,73
-Nova Oval,/Expressive/Competent,32
 Nova Oval,/Expressive/Playful,14
 Nova Oval,/Sans/Superellipse,40
 Nova Oval,/Theme/Blackletter,10
 Nova Oval,/Theme/Medieval,50
 Nova Round,/Expressive/Calm,38
-Nova Round,/Expressive/Competent,53
-Nova Round,/Expressive/Stiff,30
 Nova Round,/Sans/Superellipse,60
 Nova Round,/Theme/Blackletter,10
 Nova Round,/Theme/Techno,20
+Nova Round,/Expressive/Stiff,30
 Nova Script,/Expressive/Active,37
 Nova Script,/Sans/Superellipse,40
 Nova Script,/Theme/Medieval,50
@@ -5311,16 +5839,19 @@ Nova Script,/Theme/Techno,10
 Nova Slim,/Expressive/Artistic,17
 Nova Slim,/Expressive/Calm,78
 Nova Slim,/Expressive/Competent,32
-Nova Slim,/Expressive/Stiff,10
+Nova Slim,/Expressive/Loud,33
 Nova Slim,/Sans/Superellipse,60
+Nova Slim,/Expressive/Stiff,10
 Nova Square,/Expressive/Calm,55
 Nova Square,/Expressive/Futuristic,99
-Nova Square,/Expressive/Stiff,96
+Nova Square,/Expressive/Vintage,58
 Nova Square,/Theme/Techno,100
+Nova Square,/Expressive/Stiff,96
 NTR,/Expressive/Calm,68
 NTR,/Expressive/Childlike,30
 NTR,/Expressive/Cute,32
 NTR,/Expressive/Playful,31
+NTR,/Expressive/Vintage,74.3
 NTR,/Sans/Geometric,60
 NTR,/Sans/Rounded,100
 Numans,/Expressive/Business,16
@@ -5331,196 +5862,224 @@ Numans,/Sans/Humanist,30
 Nunito,/Expressive/Calm,99
 Nunito,/Expressive/Cute,21
 Nunito,/Expressive/Playful,1
-Nunito Sans,/Expressive/Business,96
-Nunito Sans,/Expressive/Calm,100
-Nunito Sans,/Expressive/Competent,91
 Nunito,/Sans/Humanist,20
 Nunito,/Sans/Neo Grotesque,80
 Nunito,/Sans/Rounded,100
+Nunito Sans,/Expressive/Business,98.1
+Nunito Sans,/Expressive/Calm,100
+Nunito Sans,/Expressive/Competent,82
 Nunito Sans,/Sans/Humanist,20
 Nunito Sans,/Sans/Neo Grotesque,80
 Nunito Sans,/Sans/Rounded,100
-Nuosu SIL,/Expressive/Business,100
-Nuosu SIL,/Expressive/Sincere,97
+Nuosu SIL,/Expressive/Business,98
 Nuosu SIL,/Serif/Old Style Garalde,50
 Nuosu SIL,/Serif/Transitional,50
-Odibee Sans,/Expressive/Competent,55
 Odibee Sans,/Expressive/Futuristic,80
 Odibee Sans,/Expressive/Rugged,73
-Odibee Sans,/Expressive/Stiff,97
 Odibee Sans,/Theme/Blackletter,20
 Odibee Sans,/Theme/Wacky,50
-Odor Mean Chey,/Expressive/Business,61
+Odibee Sans,/Expressive/Stiff,97
+Odor Mean Chey,/Expressive/Business,60.2
 Odor Mean Chey,/Expressive/Sincere,54
+Odor Mean Chey,/Expressive/Vintage,81
 Odor Mean Chey,/Expressive/Stiff,30
-Offside,/Expressive/Competent,64
+Offside,/Expressive/Competent,89.7
 Offside,/Expressive/Futuristic,98
 Offside,/Expressive/Innovative,21
-Offside,/Expressive/Stiff,94
 Offside,/Sans/Superellipse,100
 Offside,/Theme/Medieval,10
 Offside,/Theme/Stencil,10
 Offside,/Theme/Techno,100
-OFL Sorts Mill Goudy TT,/Expressive/Business,67
+Offside,/Expressive/Stiff,94
+OFL Sorts Mill Goudy TT,/Expressive/Business,67.9
 OFL Sorts Mill Goudy TT,/Expressive/Calm,97
 OFL Sorts Mill Goudy TT,/Expressive/Sincere,99
+OFL Sorts Mill Goudy TT,/Expressive/Vintage,72.5
 OFL Sorts Mill Goudy TT,/Serif/Old Style Garalde,100
 Oi,/Expressive/Innovative,98
+Oi,/Expressive/Loud,100
 Oi,/Expressive/Rugged,98
-Oi,/Expressive/Sincere,10
+Oi,/Expressive/Sincere,10.1
 Oi,/Slab/Clarendon,80
+Ojuju,/Expressive/Awkward,60
+Ojuju,/Expressive/Cute,20
+Old Standard TT,/Expressive/Business,68.8
+Old Standard TT,/Expressive/Competent,99.8
+Old Standard TT,/Expressive/Loud,57
+Old Standard TT,/Expressive/Vintage,78.7
+Old Standard TT,/Serif/Modern,100
 Oldenburg,/Expressive/Childlike,10
 Oldenburg,/Expressive/Cute,52
 Oldenburg,/Expressive/Playful,31
 Oldenburg,/Serif/Humanist Venetian,10
 Oldenburg,/Slab/Humanist,100
 Oldenburg,/Theme/Medieval,30
-Old Standard TT,/Expressive/Business,68
-Old Standard TT,/Serif/Modern,100
 Ole,/Expressive/Artistic,96
 Ole,/Expressive/Awkward,47
 Ole,/Expressive/Childlike,76
 Ole,/Expressive/Excited,98
 Ole,/Expressive/Fancy,44
 Ole,/Expressive/Playful,18
+Ole,/Expressive/Vintage,27.4
+Ole,/Theme/Wacky,100
 Oleo Script,/Expressive/Active,15
-Oleo Script,/Expressive/Stiff,20
+Oleo Script,/Expressive/Loud,89
+Oleo Script,/Expressive/Sincere,92
 Oleo Script,/Script/Formal,30
+Oleo Script,/Expressive/Stiff,20
 Oleo Script Swash Caps,/Expressive/Active,15
 Oleo Script Swash Caps,/Expressive/Fancy,27
-Oleo Script Swash Caps,/Expressive/Stiff,20
+Oleo Script Swash Caps,/Expressive/Loud,83
+Oleo Script Swash Caps,/Expressive/Sincere,92
 Oleo Script Swash Caps,/Script/Formal,30
-Ole,/Theme/Wacky,100
+Oleo Script Swash Caps,/Expressive/Stiff,20
 Onest,/Expressive/Business,47
 Onest,/Expressive/Calm,99
 Onest,/Sans/Humanist,10
 Onest,/Sans/Neo Grotesque,90
 Oooh Baby,/Expressive/Active,99
 Oooh Baby,/Expressive/Childlike,10
+Oooh Baby,/Expressive/Sincere,94
+Oooh Baby,/Expressive/Vintage,33.4
 Oooh Baby,/Script/Handwritten,100
 Oooh Baby,/Script/Informal,100
-Open Sans,/Expressive/Business,96
+Open Sans,/Expressive/Business,98.5
 Open Sans,/Expressive/Calm,99
 Open Sans,/Sans/Humanist,80
 Open Sans,/Sans/Neo Grotesque,20
 Oranienbaum,/Expressive/Business,14
 Oranienbaum,/Expressive/Sincere,78
-Oranienbaum,/Expressive/Stiff,30
 Oranienbaum,/Serif/Modern,100
 Oranienbaum,/Serif/Scotch,40
+Oranienbaum,/Expressive/Stiff,30
 Orbit,/Expressive/Calm,59
-Orbit,/Expressive/Competent,71
+Orbit,/Expressive/Competent,31
 Orbit,/Expressive/Excited,41
 Orbit,/Expressive/Futuristic,99
 Orbit,/Expressive/Happy,80
+Orbit,/Expressive/Vintage,54
+Orbit,/Sans/Geometric,100
 Orbit,/Expressive/Stiff,80
 Orbitron,/Expressive/Futuristic,100
-Orbitron,/Expressive/Stiff,100
+Orbitron,/Expressive/Vintage,68.3
 Orbitron,/Theme/Techno,100
-Orbit,/Sans/Geometric,100
+Orbitron,/Expressive/Stiff,100
 Oregano,/Expressive/Active,100
 Oregano,/Expressive/Excited,71
 Oregano,/Expressive/Rugged,34
+Oregano,/Expressive/Sincere,94
+Oregano,/Expressive/Vintage,57.5
 Oregano,/Script/Handwritten,100
 Oregano,/Script/Informal,100
 Oregano,/Theme/Brush,100
+Orelega One,/Expressive/Competent,97.3
+Orelega One,/Expressive/Loud,48
 Orelega One,/Expressive/Rugged,28
 Orelega One,/Slab/Clarendon,100
+Orienta,/Expressive/Business,73.7
 Orienta,/Expressive/Calm,97
 Orienta,/Sans/Humanist,100
 Original Surfer,/Expressive/Awkward,96
+Original Surfer,/Expressive/Loud,55
 Original Surfer,/Expressive/Playful,77
+Original Surfer,/Expressive/Vintage,71.7
 Original Surfer,/Sans/Glyphic,80
 Original Surfer,/Theme/Wacky,100
-Oswald,/Expressive/Business,98
-Oswald,/Expressive/Competent,96
+Oswald,/Expressive/Business,94.1
+Oswald,/Expressive/Competent,99.9
 Oswald,/Expressive/Rugged,92
-Oswald,/Expressive/Stiff,91
+Oswald,/Expressive/Vintage,41.2
 Oswald,/Sans/Grotesque,100
+Oswald,/Expressive/Stiff,91
 Otomanopee One,/Expressive/Business,45
 Otomanopee One,/Expressive/Calm,19
 Otomanopee One,/Expressive/Excited,54
 Otomanopee One,/Expressive/Happy,21
+Otomanopee One,/Expressive/Loud,55
 Otomanopee One,/Sans/Humanist,80
 Otomanopee One,/Theme/Wacky,60
-Outfit,/Expressive/Business,73
+Outfit,/Expressive/Business,61.2
 Outfit,/Expressive/Calm,99
 Outfit,/Sans/Geometric,100
+Over the Rainbow,/Expressive/Awkward,53
+Over the Rainbow,/Expressive/Childlike,69
+Over the Rainbow,/Expressive/Happy,56
+Over the Rainbow,/Expressive/Sincere,97
+Over the Rainbow,/Expressive/Vintage,19
+Over the Rainbow,/Script/Handwritten,100
+Over the Rainbow,/Script/Informal,100
 Overlock,/Expressive/Calm,73
 Overlock,/Expressive/Cute,33
 Overlock,/Expressive/Playful,11
 Overlock,/Sans/Humanist,100
+Overlock,/Theme/Brush,20
 Overlock SC,/Expressive/Calm,73
 Overlock SC,/Expressive/Cute,33
 Overlock SC,/Expressive/Playful,11
 Overlock SC,/Sans/Humanist,100
 Overlock SC,/Theme/Brush,20
-Overlock,/Theme/Brush,20
 Overpass,/Expressive/Calm,77
 Overpass,/Expressive/Competent,17
+Overpass,/Sans/Grotesque,90
+Overpass,/Sans/Humanist,10
 Overpass Mono,/Expressive/Calm,58
 Overpass Mono,/Expressive/Competent,45
 Overpass Mono,/Expressive/Futuristic,97
-Overpass Mono,/Expressive/Stiff,78
 Overpass Mono,/Monospace/Monospace,100
 Overpass Mono,/Sans/Grotesque,80
 Overpass Mono,/Sans/Humanist,10
 Overpass Mono,/Slab/Humanist,10
-Overpass,/Sans/Grotesque,90
-Overpass,/Sans/Humanist,10
-Over the Rainbow,/Expressive/Awkward,53
-Over the Rainbow,/Expressive/Childlike,69
-Over the Rainbow,/Expressive/Happy,56
-Over the Rainbow,/Script/Handwritten,100
-Over the Rainbow,/Script/Informal,100
+Overpass Mono,/Expressive/Stiff,78
 Ovo,/Expressive/Business,46
-Ovo,/Expressive/Sincere,99
 Ovo,/Serif/Humanist Venetian,100
 Oxanium,/Expressive/Calm,87
 Oxanium,/Expressive/Futuristic,99
-Oxanium,/Expressive/Stiff,98
 Oxanium,/Sans/Superellipse,100
 Oxanium,/Theme/Techno,100
+Oxanium,/Expressive/Stiff,98
 Oxygen,/Expressive/Business,96
 Oxygen,/Expressive/Calm,97
+Oxygen,/Sans/Grotesque,40
+Oxygen,/Sans/Humanist,60
 Oxygen,/Expressive/Stiff,52
 Oxygen Mono,/Expressive/Calm,59
 Oxygen Mono,/Expressive/Futuristic,54
-Oxygen Mono,/Expressive/Stiff,78
+Oxygen Mono,/Expressive/Vintage,33
 Oxygen Mono,/Monospace/Monospace,100
 Oxygen Mono,/Sans/Grotesque,40
 Oxygen Mono,/Sans/Humanist,60
-Oxygen,/Sans/Grotesque,40
-Oxygen,/Sans/Humanist,60
+Oxygen Mono,/Expressive/Stiff,78
 Pacifico,/Expressive/Artistic,61
 Pacifico,/Expressive/Cute,100
 Pacifico,/Expressive/Playful,18
+Pacifico,/Expressive/Sincere,95
+Pacifico,/Expressive/Vintage,58.9
 Pacifico,/Script/Handwritten,50
 Pacifico,/Script/Informal,80
 Padauk,/Expressive/Business,46
 Padauk,/Expressive/Calm,98
-Padauk,/Expressive/Stiff,20
+Padauk,/Expressive/Vintage,78
 Padauk,/Sans/Geometric,20
 Padauk,/Sans/Grotesque,90
+Padauk,/Expressive/Stiff,20
 Padyakke Expanded One,/Expressive/Calm,96
-Padyakke Expanded One,/Expressive/Competent,80
 Padyakke Expanded One,/Expressive/Happy,24
-Padyakke Expanded One,/Expressive/Stiff,20
 Padyakke Expanded One,/Indic/Low contrast,100
 Padyakke Expanded One,/Serif/Humanist Venetian,30
 Padyakke Expanded One,/Serif/Transitional,50
 Padyakke Expanded One,/Slab/Humanist,60
+Padyakke Expanded One,/Expressive/Stiff,20
+Palanquin,/Expressive/Business,55.4
+Palanquin,/Expressive/Calm,99
+Palanquin,/Indic/Low contrast,100
+Palanquin,/Sans/Humanist,100
+Palanquin,/Expressive/Stiff,40
 Palanquin Dark,/Expressive/Business,11
 Palanquin Dark,/Expressive/Calm,98
 Palanquin Dark,/Expressive/Happy,17
-Palanquin Dark,/Expressive/Stiff,40
 Palanquin Dark,/Indic/Low contrast,100
 Palanquin Dark,/Sans/Humanist,100
-Palanquin,/Expressive/Business,55
-Palanquin,/Expressive/Calm,99
-Palanquin,/Expressive/Stiff,40
-Palanquin,/Indic/Low contrast,100
-Palanquin,/Sans/Humanist,100
+Palanquin Dark,/Expressive/Stiff,40
 Palette Mosaic,/Expressive/Innovative,98
 Palette Mosaic,/Expressive/Playful,70
 Palette Mosaic,/Expressive/Rugged,99
@@ -5545,75 +6104,83 @@ Paprika,/Serif/Humanist Venetian,90
 Parisienne,/Expressive/Artistic,99
 Parisienne,/Expressive/Fancy,73
 Parisienne,/Expressive/Sophisticated,83
+Parisienne,/Expressive/Vintage,58.4
 Parisienne,/Script/Formal,100
 Passero One,/Expressive/Awkward,97
 Passero One,/Expressive/Calm,81
 Passero One,/Expressive/Futuristic,95
 Passero One,/Expressive/Innovative,65
-Passero One,/Expressive/Stiff,91
 Passero One,/Theme/Techno,50
 Passero One,/Theme/Wacky,10
 Passero One,/Theme/Woodtype,20
-Passion One,/Expressive/Business,38
+Passero One,/Expressive/Stiff,91
+Passion One,/Expressive/Business,65.9
 Passion One,/Expressive/Calm,93
 Passion One,/Expressive/Competent,66
-Passion One,/Expressive/Stiff,76
+Passion One,/Expressive/Loud,88
 Passion One,/Sans/Humanist,100
 Passion One,/Theme/Woodtype,50
+Passion One,/Expressive/Stiff,76
 Passions Conflict,/Expressive/Artistic,100
 Passions Conflict,/Expressive/Fancy,88
+Passions Conflict,/Expressive/Vintage,68.7
 Passions Conflict,/Script/Formal,100
 Pathway Extreme,/Expressive/Business,35
 Pathway Extreme,/Expressive/Calm,80
 Pathway Extreme,/Expressive/Futuristic,49
-Pathway Extreme,/Expressive/Stiff,77
 Pathway Extreme,/Sans/Grotesque,50
 Pathway Extreme,/Sans/Neo Grotesque,50
 Pathway Extreme,/Sans/Superellipse,80
+Pathway Extreme,/Expressive/Stiff,77
 Pathway Gothic One,/Expressive/Business,49
 Pathway Gothic One,/Expressive/Calm,98
-Pathway Gothic One,/Expressive/Competent,79
+Pathway Gothic One,/Expressive/Competent,95.2
+Pathway Gothic One,/Expressive/Vintage,58.5
 Pathway Gothic One,/Sans/Grotesque,100
 Patrick Hand,/Expressive/Awkward,74
 Patrick Hand,/Expressive/Childlike,78
 Patrick Hand,/Expressive/Cute,35
 Patrick Hand,/Expressive/Innovative,12
 Patrick Hand,/Expressive/Playful,43
+Patrick Hand,/Expressive/Sincere,96
+Patrick Hand,/Script/Handwritten,100
+Patrick Hand,/Script/Informal,100
+Patrick Hand,/Script/Upright Script,100
+Patrick Hand,/Theme/Distressed,20
 Patrick Hand SC,/Expressive/Awkward,73
 Patrick Hand SC,/Expressive/Childlike,78
 Patrick Hand SC,/Expressive/Cute,35
 Patrick Hand SC,/Expressive/Innovative,12
 Patrick Hand SC,/Expressive/Playful,43
-Patrick Hand,/Script/Handwritten,100
-Patrick Hand,/Script/Informal,100
-Patrick Hand,/Script/Upright Script,100
+Patrick Hand SC,/Expressive/Sincere,95
 Patrick Hand SC,/Script/Handwritten,100
 Patrick Hand SC,/Script/Informal,100
 Patrick Hand SC,/Script/Upright Script,100
 Patrick Hand SC,/Theme/Distressed,20
-Patrick Hand,/Theme/Distressed,20
 Pattaya,/Expressive/Artistic,75
 Pattaya,/Expressive/Cute,35
 Pattaya,/Expressive/Fancy,92
 Pattaya,/Expressive/Happy,21
+Pattaya,/Expressive/Loud,73
+Pattaya,/Expressive/Vintage,48
 Pattaya,/Script/Informal,40
-Patua One,/Expressive/Business,80
 Patua One,/Expressive/Calm,97
 Patua One,/Expressive/Sincere,81
+Patua One,/Expressive/Vintage,73.6
 Patua One,/Serif/Transitional,100
 Patua One,/Slab/Humanist,20
 Pavanam,/Expressive/Business,44
 Pavanam,/Expressive/Calm,99
 Pavanam,/Expressive/Competent,19
-Pavanam,/Expressive/Stiff,51
 Pavanam,/Indic/Low contrast,100
 Pavanam,/Sans/Neo Grotesque,80
+Pavanam,/Expressive/Stiff,51
 Paytone One,/Expressive/Business,42
 Paytone One,/Expressive/Calm,95
+Paytone One,/Expressive/Vintage,68.2
 Paytone One,/Sans/Geometric,80
-Peddana,/Expressive/Business,80
 Peddana,/Expressive/Calm,98
-Peddana,/Expressive/Sincere,98
+Peddana,/Expressive/Vintage,79.4
 Peddana,/Indic/Traditional,100
 Peddana,/Serif/Transitional,100
 Peralta,/Expressive/Awkward,77
@@ -5621,6 +6188,7 @@ Peralta,/Expressive/Calm,43
 Peralta,/Expressive/Childlike,24
 Peralta,/Expressive/Excited,37
 Peralta,/Expressive/Innovative,15
+Peralta,/Expressive/Loud,71
 Peralta,/Expressive/Playful,20
 Peralta,/Theme/Wacky,80
 Permanent Marker,/Expressive/Active,73
@@ -5630,37 +6198,44 @@ Permanent Marker,/Expressive/Excited,36
 Permanent Marker,/Expressive/Happy,12
 Permanent Marker,/Expressive/Innovative,32
 Permanent Marker,/Expressive/Rugged,85
+Permanent Marker,/Expressive/Sincere,97
+Permanent Marker,/Expressive/Vintage,63
 Permanent Marker,/Script/Handwritten,100
 Permanent Marker,/Script/Informal,100
 Permanent Marker,/Theme/Brush,100
 Permanent Marker,/Theme/Distressed,30
 Petemoss,/Expressive/Artistic,99
 Petemoss,/Expressive/Fancy,53
+Petemoss,/Expressive/Vintage,58.7
 Petemoss,/Script/Formal,80
 Petit Formal Script,/Expressive/Artistic,79
 Petit Formal Script,/Expressive/Fancy,35
+Petit Formal Script,/Expressive/Loud,62
 Petit Formal Script,/Expressive/Sophisticated,86
+Petit Formal Script,/Expressive/Vintage,84.5
 Petit Formal Script,/Script/Formal,90
-Petrona,/Expressive/Business,59
+Petrona,/Expressive/Business,59.4
 Petrona,/Expressive/Calm,99
 Petrona,/Expressive/Sincere,80
-Petrona,/Expressive/Stiff,30
+Petrona,/Expressive/Vintage,63.2
 Petrona,/Serif/Old Style Garalde,50
 Petrona,/Serif/Transitional,10
+Petrona,/Expressive/Stiff,30
 Philosopher,/Expressive/Business,31
 Philosopher,/Expressive/Calm,66
 Philosopher,/Expressive/Happy,1
+Philosopher,/Expressive/Loud,58
 Philosopher,/Sans/Glyphic,30
 Philosopher,/Sans/Humanist,20
 Phudu,/Expressive/Business,12
 Phudu,/Expressive/Calm,87
 Phudu,/Expressive/Happy,2
-Phudu,/Expressive/Stiff,30
 Phudu,/Sans/Humanist,40
+Phudu,/Expressive/Stiff,30
 Piazzolla,/Expressive/Awkward,31
-Piazzolla,/Expressive/Business,57
+Piazzolla,/Expressive/Business,57.5
 Piazzolla,/Expressive/Calm,98
-Piazzolla,/Expressive/Sincere,73
+Piazzolla,/Expressive/Sincere,72.5
 Piedra,/Expressive/Calm,59
 Piedra,/Expressive/Futuristic,21
 Piedra,/Expressive/Innovative,92
@@ -5669,50 +6244,67 @@ Piedra,/Theme/Distressed,60
 Piedra,/Theme/Wacky,30
 Pinyon Script,/Expressive/Artistic,100
 Pinyon Script,/Expressive/Fancy,59
+Pinyon Script,/Expressive/Loud,54
 Pinyon Script,/Expressive/Sophisticated,94
+Pinyon Script,/Expressive/Vintage,94
 Pinyon Script,/Script/Formal,100
 Pirata One,/Expressive/Artistic,80
 Pirata One,/Expressive/Calm,71
-Pirata One,/Expressive/Stiff,61
+Pirata One,/Expressive/Loud,78
+Pirata One,/Expressive/Vintage,99
 Pirata One,/Theme/Blackletter,100
+Pirata One,/Expressive/Stiff,61
 Pixelify Sans,/Expressive/Awkward,93
 Pixelify Sans,/Expressive/Futuristic,96
 Pixelify Sans,/Expressive/Innovative,47
-Pixelify Sans,/Expressive/Stiff,76
+Pixelify Sans,/Expressive/Loud,59
+Pixelify Sans,/Expressive/Vintage,84.5
 Pixelify Sans,/Theme/Techno,100
+Pixelify Sans,/Expressive/Stiff,76
 Plaster,/Expressive/Artistic,91
+Plaster,/Expressive/Loud,99
 Plaster,/Expressive/Rugged,100
-Plaster,/Expressive/Stiff,93
+Plaster,/Expressive/Vintage,93
 Plaster,/Theme/Art Deco,10
 Plaster,/Theme/Stencil,100
 Plaster,/Theme/Woodtype,80
-Playball,/Expressive/Artistic,65
-Playball,/Expressive/Sophisticated,74
-Playball,/Script/Formal,80
+Plaster,/Expressive/Stiff,93
 Play,/Expressive/Business,11
 Play,/Expressive/Calm,73
 Play,/Expressive/Futuristic,98
+Play,/Sans/Geometric,30
+Play,/Sans/Superellipse,90
 Play,/Expressive/Stiff,97
-Playfair Display,/Expressive/Business,76
-Playfair Display,/Expressive/Calm,99
-Playfair Display,/Expressive/Sincere,98
-Playfair Display SC,/Expressive/Business,78
-Playfair Display SC,/Expressive/Calm,99
-Playfair Display SC,/Expressive/Sincere,98
-Playfair Display SC,/Serif/Didone,100
-Playfair Display,/Serif/Didone,100
-Playfair,/Expressive/Business,79
+Playball,/Expressive/Artistic,65
+Playball,/Expressive/Loud,74
+Playball,/Expressive/Sophisticated,74
+Playball,/Expressive/Vintage,69
+Playball,/Script/Formal,80
+Playfair,/Expressive/Business,66.6
 Playfair,/Expressive/Calm,95
-Playfair,/Expressive/Sincere,98
+Playfair,/Expressive/Competent,98.8
+Playfair,/Expressive/Sincere,99
+Playfair,/Expressive/Vintage,83
 Playfair,/Serif/Didone,100
+Playfair Display,/Expressive/Business,82.8
+Playfair Display,/Expressive/Calm,99
+Playfair Display,/Expressive/Loud,70
+Playfair Display,/Expressive/Sincere,96
+Playfair Display,/Expressive/Vintage,84.5
+Playfair Display,/Serif/Didone,100
+Playfair Display SC,/Expressive/Business,82.8
+Playfair Display SC,/Expressive/Calm,99
+Playfair Display SC,/Expressive/Loud,72
+Playfair Display SC,/Expressive/Sincere,96
+Playfair Display SC,/Expressive/Vintage,84.5
+Playfair Display SC,/Serif/Didone,100
 Playpen Sans,/Expressive/Awkward,41
 Playpen Sans,/Expressive/Childlike,99
 Playpen Sans,/Expressive/Cute,43
 Playpen Sans,/Expressive/Playful,22
+Playpen Sans,/Expressive/Sincere,99
 Playpen Sans,/Script/Handwritten,100
 Playpen Sans,/Script/Informal,100
-Play,/Sans/Geometric,30
-Play,/Sans/Superellipse,90
 Playwrite AR,/Expressive/Active,100
 Playwrite AR,/Expressive/Calm,50
 Playwrite AR,/Expressive/Cute,50
@@ -6041,10 +6633,10 @@ Playwrite ZA,/Expressive/Cute,50
 Playwrite ZA,/Expressive/Sophisticated,50
 Playwrite ZA,/Script/Handwritten,100
 Playwrite ZA,/Script/Informal,80
-Plus Jakarta Sans,/Expressive/Business,55
+Plus Jakarta Sans,/Expressive/Business,55.2
 Plus Jakarta Sans,/Expressive/Calm,99
-Plus Jakarta Sans,/Expressive/Stiff,71
 Plus Jakarta Sans,/Sans/Geometric,100
+Plus Jakarta Sans,/Expressive/Stiff,71
 Podkova,/Expressive/Calm,93
 Podkova,/Expressive/Happy,32
 Podkova,/Expressive/Sincere,9
@@ -6052,44 +6644,49 @@ Podkova,/Slab/Humanist,30
 PoetsenOne,/Expressive/Calm,27
 PoetsenOne,/Expressive/Childlike,70
 PoetsenOne,/Expressive/Cute,33
+PoetsenOne,/Expressive/Loud,71
 PoetsenOne,/Expressive/Playful,51
 PoetsenOne,/Sans/Humanist,50
 PoetsenOne,/Sans/Neo Grotesque,30
 PoetsenOne,/Sans/Rounded,60
 Poiret One,/Expressive/Business,41
 Poiret One,/Expressive/Calm,93
-Poiret One,/Expressive/Stiff,62
 Poiret One,/Sans/Geometric,100
+Poiret One,/Expressive/Stiff,62
 Poller One,/Expressive/Business,41
 Poller One,/Expressive/Calm,99
-Poller One,/Expressive/Stiff,40
+Poller One,/Expressive/Loud,98
+Poller One,/Expressive/Vintage,91.5
 Poller One,/Sans/Humanist,100
+Poller One,/Expressive/Stiff,40
 Poltawski Nowy,/Expressive/Business,29
 Poltawski Nowy,/Expressive/Calm,95
 Poltawski Nowy,/Expressive/Innovative,11
 Poltawski Nowy,/Expressive/Sincere,63
+Poltawski Nowy,/Expressive/Vintage,77.8
 Poltawski Nowy,/Serif/Didone,30
 Poltawski Nowy,/Serif/Modern,30
-Poly,/Expressive/Business,80
+Poly,/Expressive/Business,79.8
 Poly,/Expressive/Calm,98
 Poly,/Expressive/Sincere,81
+Poly,/Expressive/Vintage,78.7
 Poly,/Serif/Transitional,60
 Pompiere,/Expressive/Awkward,41
 Pompiere,/Expressive/Calm,92
 Pompiere,/Expressive/Childlike,26
-Pompiere,/Expressive/Competent,34
 Pompiere,/Expressive/Happy,15
 Pompiere,/Expressive/Innovative,11
 Pompiere,/Expressive/Playful,51
-Pompiere,/Expressive/Stiff,40
 Pompiere,/Theme/Blobby,1
 Pompiere,/Theme/Brush,20
+Pompiere,/Expressive/Stiff,40
 Ponnala,/Indic/Sign Painting,100
 Ponnala,/Indic/Traditional,100
+Pontano Sans,/Expressive/Business,91.1
 Pontano Sans,/Expressive/Calm,98
 Pontano Sans,/Expressive/Competent,38
-Pontano Sans,/Expressive/Stiff,72
 Pontano Sans,/Sans/Neo Grotesque,100
+Pontano Sans,/Expressive/Stiff,72
 Poor Story,/Expressive/Awkward,95
 Poor Story,/Expressive/Calm,61
 Poor Story,/Expressive/Childlike,53
@@ -6098,18 +6695,12 @@ Poor Story,/Expressive/Innovative,11
 Poor Story,/Expressive/Playful,28
 Poor Story,/Theme/Distressed,10
 Poor Story,/Theme/Wacky,80
-Poppins,/Expressive/Business,54
+Poppins,/Expressive/Business,54.9
 Poppins,/Expressive/Calm,100
-Poppins,/Expressive/Stiff,71
+Poppins,/Expressive/Vintage,57.5
 Poppins,/Indic/Low contrast,100
 Poppins,/Sans/Geometric,100
-Porter Sans Block,/Expressive/Business,49
-Porter Sans Block,/Expressive/Calm,37
-Porter Sans Block,/Expressive/Innovative,93
-Porter Sans Block,/Expressive/Stiff,91
-Porter Sans Block,/Theme/Inline,100
-Porter Sans Block,/Theme/Shaded,100
-Porter Sans Block,/Theme/Woodtype,100
+Poppins,/Expressive/Stiff,71
 Port Lligat Sans,/Expressive/Awkward,21
 Port Lligat Sans,/Expressive/Calm,77
 Port Lligat Sans,/Expressive/Happy,14
@@ -6123,6 +6714,15 @@ Port Lligat Slab,/Expressive/Playful,12
 Port Lligat Slab,/Expressive/Sincere,9
 Port Lligat Slab,/Serif/Humanist Venetian,50
 Port Lligat Slab,/Slab/Humanist,20
+Porter Sans Block,/Expressive/Business,49
+Porter Sans Block,/Expressive/Calm,37
+Porter Sans Block,/Expressive/Innovative,93
+Porter Sans Block,/Expressive/Vintage,92
+Porter Sans Block,/Theme/Inline,100
+Porter Sans Block,/Theme/Shaded,100
+Porter Sans Block,/Theme/Woodtype,100
+Porter Sans Block,/Expressive/Stiff,91
+Post No Bills Colombo Medium,/Expressive/Stiff,92
 Post No Bills Jaffna,/Expressive/Calm,6
 Post No Bills Jaffna,/Expressive/Innovative,32
 Post No Bills Jaffna,/Expressive/Rugged,98
@@ -6137,14 +6737,17 @@ Potta One,/Theme/Distressed,20
 Potta One,/Theme/Wacky,20
 Pragati Narrow,/Expressive/Business,19
 Pragati Narrow,/Expressive/Calm,99
-Pragati Narrow,/Expressive/Competent,68
+Pragati Narrow,/Expressive/Competent,86
 Pragati Narrow,/Indic/Low contrast,100
 Pragati Narrow,/Sans/Grotesque,70
 Praise,/Expressive/Artistic,97
+Praise,/Expressive/Loud,83
+Praise,/Expressive/Vintage,67.5
 Praise,/Script/Formal,70
-Prata,/Expressive/Business,27
+Prata,/Expressive/Business,55.3
 Prata,/Expressive/Calm,98
 Prata,/Expressive/Sincere,86
+Prata,/Expressive/Vintage,84.5
 Prata,/Serif/Didone,100
 Preahvihear,/Expressive/Awkward,71
 Preahvihear,/Expressive/Calm,81
@@ -6158,82 +6761,94 @@ Press Start 2P,/Expressive/Awkward,51
 Press Start 2P,/Expressive/Calm,45
 Press Start 2P,/Expressive/Futuristic,78
 Press Start 2P,/Expressive/Innovative,64
+Press Start 2P,/Expressive/Vintage,77
 Press Start 2P,/Theme/Techno,100
 Pridi,/Expressive/Business,46
 Pridi,/Expressive/Calm,97
 Pridi,/Expressive/Sincere,71
-Pridi,/Expressive/Stiff,51
+Pridi,/Expressive/Vintage,81
 Pridi,/Serif/Modern,50
 Pridi,/Slab/Clarendon,100
+Pridi,/Expressive/Stiff,51
 Princess Sofia,/Expressive/Artistic,19
 Princess Sofia,/Expressive/Childlike,68
 Princess Sofia,/Expressive/Excited,72
 Princess Sofia,/Expressive/Fancy,25
 Princess Sofia,/Expressive/Happy,20
 Princess Sofia,/Expressive/Innovative,64
+Princess Sofia,/Expressive/Vintage,14.3
 Princess Sofia,/Script/Informal,100
 Princess Sofia,/Theme/Wacky,80
 Prociono,/Expressive/Business,42
 Prociono,/Expressive/Calm,95
 Prociono,/Expressive/Sincere,81
+Prociono,/Expressive/Vintage,81
 Prociono,/Expressive/Stiff,40
 Prompt,/Expressive/Business,45
 Prompt,/Expressive/Calm,99
 Prompt,/Expressive/Competent,21
-Prompt,/Expressive/Stiff,40
 Prompt,/Sans/Geometric,50
 Prompt,/Sans/Neo Grotesque,50
 Prompt,"/South East Asian (Thai, Khmer, Lao)/Loopless",100
+Prompt,/Expressive/Stiff,40
 Prosto One,/Expressive/Calm,65
 Prosto One,/Expressive/Futuristic,89
-Prosto One,/Expressive/Stiff,83
+Prosto One,/Expressive/Loud,55
 Prosto One,/Theme/Techno,100
-Proza Libre,/Expressive/Business,69
+Prosto One,/Expressive/Stiff,83
+Proza Libre,/Expressive/Business,69.7
 Proza Libre,/Expressive/Calm,97
-Proza Libre,/Expressive/Stiff,40
+Proza Libre,/Expressive/Vintage,57.6
 Proza Libre,/Sans/Humanist,100
+Proza Libre,/Expressive/Stiff,40
 PT Mono,/Expressive/Calm,98
 PT Mono,/Expressive/Sincere,63
+PT Mono,/Expressive/Vintage,83.5
 PT Mono,/Monospace/Monospace,100
 PT Mono,/Slab/Humanist,100
-PT Sans Caption,/Expressive/Business,75
-PT Sans Caption,/Expressive/Calm,99
-PT Sans Caption,/Expressive/Stiff,40
-PT Sans Caption,/Sans/Humanist,100
-PT Sans,/Expressive/Business,75
+PT Sans,/Expressive/Business,86.1
 PT Sans,/Expressive/Calm,99
-PT Sans,/Expressive/Stiff,40
-PT Sans Narrow,/Expressive/Business,75
-PT Sans Narrow,/Expressive/Calm,99
-PT Sans Narrow,/Expressive/Competent,88
-PT Sans Narrow,/Expressive/Stiff,40
-PT Sans Narrow,/Sans/Humanist,100
 PT Sans,/Sans/Humanist,100
-PT Serif Caption,/Expressive/Business,79
-PT Serif Caption,/Expressive/Calm,97
-PT Serif Caption,/Expressive/Sincere,100
-PT Serif Caption,/Expressive/Stiff,40
-PT Serif Caption,/Slab/Humanist,80
-PT Serif,/Expressive/Business,79
+PT Sans,/Expressive/Stiff,40
+PT Sans Caption,/Expressive/Business,86.1
+PT Sans Caption,/Expressive/Calm,99
+PT Sans Caption,/Sans/Humanist,100
+PT Sans Caption,/Expressive/Stiff,40
+PT Sans Narrow,/Expressive/Business,86.1
+PT Sans Narrow,/Expressive/Calm,99
+PT Sans Narrow,/Expressive/Competent,90.2
+PT Sans Narrow,/Sans/Humanist,100
+PT Sans Narrow,/Expressive/Stiff,40
+PT Serif,/Expressive/Business,98
 PT Serif,/Expressive/Calm,97
-PT Serif,/Expressive/Sincere,100
-PT Serif,/Expressive/Stiff,40
+PT Serif,/Expressive/Sincere,93
 PT Serif,/Serif/Transitional,100
-Public Sans,/Expressive/Business,76
+PT Serif,/Expressive/Stiff,40
+PT Serif Caption,/Expressive/Business,98
+PT Serif Caption,/Expressive/Calm,97
+PT Serif Caption,/Expressive/Sincere,93
+PT Serif Caption,/Slab/Humanist,80
+PT Serif Caption,/Expressive/Stiff,40
+Public Sans,/Expressive/Business,97.5
 Public Sans,/Expressive/Calm,99
-Public Sans,/Expressive/Stiff,72
+Public Sans,/Expressive/Vintage,47.3
 Public Sans,/Sans/Grotesque,100
+Public Sans,/Expressive/Stiff,72
 Puppies Play,/Expressive/Artistic,50
 Puppies Play,/Expressive/Cute,54
 Puppies Play,/Expressive/Fancy,80
 Puppies Play,/Expressive/Innovative,32
+Puppies Play,/Expressive/Loud,33
+Puppies Play,/Expressive/Vintage,58.4
 Puppies Play,/Script/Informal,100
 Puritan,/Expressive/Business,13
 Puritan,/Expressive/Calm,98
-Puritan,/Expressive/Stiff,81
+Puritan,/Expressive/Vintage,47
 Puritan,/Sans/Grotesque,100
+Puritan,/Expressive/Stiff,81
 Purple Purse,/Expressive/Calm,63
 Purple Purse,/Expressive/Innovative,41
+Purple Purse,/Expressive/Loud,73
 Purple Purse,/Expressive/Playful,32
 Purple Purse,/Expressive/Rugged,43
 Purple Purse,/Serif/Didone,50
@@ -6242,6 +6857,7 @@ Purple Purse,/Theme/Wacky,20
 Qahiri,/Expressive/Artistic,95
 Qahiri,/Expressive/Awkward,98
 Qahiri,/Expressive/Innovative,95
+Qahiri,/Expressive/Loud,93
 Qahiri,/Expressive/Rugged,73
 Qahiri,/Expressive/Stiff,40
 Quando,/Expressive/Calm,77
@@ -6252,17 +6868,15 @@ Quantico,/Expressive/Calm,58
 Quantico,/Expressive/Competent,19
 Quantico,/Expressive/Futuristic,100
 Quantico,/Expressive/Innovative,13
-Quantico,/Expressive/Stiff,99
 Quantico,/Sans/Geometric,50
 Quantico,/Sans/Glyphic,50
 Quantico,/Theme/Techno,100
-Quattrocento,/Expressive/Business,36
-Quattrocento,/Expressive/Sincere,91
-Quattrocento Sans,/Expressive/Calm,97
-Quattrocento Sans,/Sans/Humanist,100
+Quantico,/Expressive/Stiff,99
+Quattrocento,/Expressive/Business,54.6
 Quattrocento,/Serif/Humanist Venetian,50
 Quattrocento,/Serif/Old Style Garalde,50
-Questrial,/Expressive/Business,95
+Quattrocento Sans,/Expressive/Calm,97
+Quattrocento Sans,/Sans/Humanist,100
 Questrial,/Expressive/Calm,100
 Questrial,/Sans/Geometric,100
 Quicksand,/Expressive/Business,19
@@ -6272,12 +6886,14 @@ Quicksand,/Expressive/Playful,11
 Quicksand,/Sans/Geometric,100
 Quicksand,/Sans/Rounded,100
 Quintessential,/Expressive/Sophisticated,97
+Quintessential,/Expressive/Vintage,99
 Quintessential,/Script/Formal,50
 Quintessential,/Script/Handwritten,50
 Quintessential,/Script/Upright Script,20
 Qwigley,/Expressive/Artistic,80
 Qwigley,/Expressive/Fancy,73
 Qwigley,/Expressive/Sophisticated,55
+Qwigley,/Expressive/Vintage,64.5
 Qwigley,/Script/Handwritten,100
 Qwigley,/Script/Informal,100
 Qwitcher Grypen,/Expressive/Active,98
@@ -6286,105 +6902,116 @@ Qwitcher Grypen,/Expressive/Awkward,46
 Qwitcher Grypen,/Expressive/Excited,59
 Qwitcher Grypen,/Expressive/Fancy,54
 Qwitcher Grypen,/Expressive/Rugged,14
+Qwitcher Grypen,/Expressive/Vintage,69
 Qwitcher Grypen,/Script/Handwritten,100
 Qwitcher Grypen,/Script/Informal,100
 Racing Sans One,/Expressive/Active,5
 Racing Sans One,/Expressive/Calm,68
-Racing Sans One,/Expressive/Competent,91
+Racing Sans One,/Expressive/Competent,51
+Racing Sans One,/Expressive/Loud,91
 Racing Sans One,/Expressive/Rugged,97
-Racing Sans One,/Expressive/Stiff,92
+Racing Sans One,/Expressive/Vintage,33.2
 Racing Sans One,/Sans/Humanist,100
+Racing Sans One,/Expressive/Stiff,92
 Radio Canada,/Expressive/Business,44
 Radio Canada,/Expressive/Calm,98
-Radio Canada,/Expressive/Competent,47
+Radio Canada,/Expressive/Competent,99.3
 Radio Canada,/Sans/Humanist,100
-Radley,/Expressive/Business,96
+Radley,/Expressive/Business,98.2
 Radley,/Expressive/Calm,99
-Radley,/Expressive/Sincere,98
-Radley,/Expressive/Stiff,60
+Radley,/Expressive/Vintage,83
 Radley,/Serif/Old Style Garalde,100
+Radley,/Expressive/Stiff,60
 Rajdhani,/Expressive/Calm,67
 Rajdhani,/Expressive/Futuristic,97
-Rajdhani,/Expressive/Stiff,96
 Rajdhani,/Sans/Humanist,40
 Rajdhani,/Sans/Superellipse,100
+Rajdhani,/Expressive/Stiff,96
 Rakkas,/Expressive/Excited,31
 Rakkas,/Expressive/Innovative,12
+Rakkas,/Expressive/Loud,88
 Rakkas,/Expressive/Rugged,56
+Rakkas,/Expressive/Vintage,82
 Rakkas,/Serif/Humanist Venetian,100
+Raleway,/Expressive/Business,55.5
+Raleway,/Expressive/Calm,100
+Raleway,/Expressive/Competent,12
+Raleway,/Sans/Geometric,80
+Raleway,/Sans/Humanist,20
+Raleway,/Expressive/Stiff,51
 Raleway Dots,/Expressive/Calm,55
 Raleway Dots,/Expressive/Innovative,93
 Raleway Dots,/Expressive/Playful,50
 Raleway Dots,/Sans/Geometric,80
 Raleway Dots,/Sans/Humanist,20
 Raleway Dots,/Theme/Wacky,100
-Raleway,/Expressive/Business,55
-Raleway,/Expressive/Calm,100
-Raleway,/Expressive/Competent,12
-Raleway,/Expressive/Stiff,51
-Raleway,/Sans/Geometric,80
-Raleway,/Sans/Humanist,20
-Ramabhadra,/Expressive/Business,58
+Ramabhadra,/Expressive/Business,58.7
 Ramabhadra,/Expressive/Calm,98
 Ramabhadra,/Expressive/Competent,11
 Ramabhadra,/Expressive/Rugged,22
-Ramabhadra,/Expressive/Stiff,51
 Ramabhadra,/Sans/Grotesque,100
-Ramaraja,/Expressive/Business,80
-Ramaraja,/Expressive/Sincere,92
+Ramabhadra,/Expressive/Stiff,51
+Ramaraja,/Expressive/Business,88.8
 Ramaraja,/Serif/Old Style Garalde,100
-Rambla,/Expressive/Business,33
+Rambla,/Expressive/Business,65.3
 Rambla,/Expressive/Calm,97
-Rambla,/Expressive/Competent,64
-Rambla,/Expressive/Stiff,30
+Rambla,/Expressive/Competent,78.3
 Rambla,/Sans/Humanist,100
+Rambla,/Expressive/Stiff,30
 Rammetto One,/Expressive/Calm,68
-Rammetto One,/Expressive/Competent,19
+Rammetto One,/Expressive/Loud,99
 Rammetto One,/Expressive/Playful,12
 Rammetto One,/Expressive/Rugged,57
-Rammetto One,/Expressive/Stiff,51
 Rammetto One,/Sans/Humanist,100
+Rammetto One,/Expressive/Stiff,51
 Rampart One,/Expressive/Excited,34
 Rampart One,/Expressive/Innovative,99
 Rampart One,/Expressive/Playful,20
 Rampart One,/Theme/Shaded,100
 Ranchers,/Expressive/Artistic,31
 Ranchers,/Expressive/Excited,36
+Ranchers,/Expressive/Loud,99
+Ranchers,/Expressive/Vintage,76.9
 Ranchers,/Theme/Brush,80
 Rancho,/Expressive/Artistic,12
 Rancho,/Expressive/Childlike,71
 Rancho,/Expressive/Excited,44
+Rancho,/Expressive/Loud,45
 Rancho,/Expressive/Rugged,21
+Rancho,/Expressive/Sincere,95
+Rancho,/Expressive/Vintage,48.9
 Rancho,/Script/Handwritten,100
 Rancho,/Script/Informal,100
 Rancho,/Theme/Brush,100
 Ranga,/Expressive/Active,24
 Ranga,/Script/Informal,100
 Ranga,/Theme/Brush,100
-Rasa,/Expressive/Business,97
-Rasa,/Expressive/Sincere,100
+Rasa,/Expressive/Business,99
+Rasa,/Expressive/Sincere,98
 Rasa,/Expressive/Stiff,30
 Rationale,/Expressive/Futuristic,99
-Rationale,/Expressive/Stiff,100
+Rationale,/Expressive/Vintage,38.7
 Rationale,/Theme/Techno,100
+Rationale,/Expressive/Stiff,100
+Ravi Prakash,/Expressive/Loud,82
+Ravi Prakash,/Expressive/Vintage,84.5
 Readex Pro,/Expressive/Calm,99
-Readex Pro,/Expressive/Competent,71
+Readex Pro,/Expressive/Competent,70.5
 Readex Pro,/Sans/Geometric,100
-Recursive,/Expressive/Business,95
+Recursive,/Expressive/Business,80.8
 Recursive,/Expressive/Calm,76
 Recursive,/Expressive/Competent,71
 Recursive,/Expressive/Futuristic,58
-Recursive,/Expressive/Stiff,73
 Recursive,/Sans/Humanist,100
 Recursive,/Sans/Superellipse,40
-Redacted,/Not text/Symbols,100
-Redacted Script,/Not text/Symbols,100
+Recursive,/Expressive/Stiff,73
 Red Hat Display,/Expressive/Calm,100
 Red Hat Display,/Expressive/Competent,52
 Red Hat Display,/Sans/Geometric,90
 Red Hat Display,/Sans/Humanist,10
 Red Hat Mono,/Expressive/Calm,75
-Red Hat Mono,/Expressive/Competent,91
+Red Hat Mono,/Expressive/Competent,61
+Red Hat Mono,/Expressive/Vintage,38.9
 Red Hat Mono,/Sans/Geometric,60
 Red Hat Mono,/Sans/Humanist,10
 Red Hat Mono,/Slab/Geometric,20
@@ -6392,28 +7019,36 @@ Red Hat Text,/Expressive/Calm,100
 Red Hat Text,/Expressive/Competent,52
 Red Hat Text,/Sans/Geometric,80
 Red Hat Text,/Sans/Humanist,20
-Redressed,/Expressive/Stiff,10
-Redressed,/Script/Upright Script,100
-Red Rose,/Expressive/Business,71
+Red Rose,/Expressive/Business,49
 Red Rose,/Expressive/Calm,69
-Red Rose,/Expressive/Competent,46
+Red Rose,/Expressive/Competent,89.4
 Red Rose,/Expressive/Futuristic,72
-Red Rose,/Expressive/Stiff,81
+Red Rose,/Expressive/Vintage,68
 Red Rose,/Sans/Glyphic,100
+Red Rose,/Expressive/Stiff,81
+Redacted,/Not text/Symbols,100
+Redacted,/Expressive/Stiff,100
+Redacted Script,/Not text/Symbols,100
+Redressed,/Expressive/Vintage,86
+Redressed,/Script/Upright Script,100
+Redressed,/Expressive/Stiff,10
 Reem Kufi,/Arabic/Kufi,100
 Reem Kufi,/Expressive/Artistic,71
 Reem Kufi,/Expressive/Calm,96
+Reem Kufi,/Expressive/Vintage,76.8
+Reem Kufi,/Sans/Geometric,100
 Reem Kufi Fun,/Arabic/Kufi,100
 Reem Kufi Fun,/Expressive/Artistic,71
 Reem Kufi Fun,/Expressive/Calm,96
 Reem Kufi Fun,/Expressive/Innovative,100
+Reem Kufi Fun,/Expressive/Vintage,76.8
 Reem Kufi Fun,/Sans/Geometric,100
 Reem Kufi Ink,/Arabic/Kufi,100
 Reem Kufi Ink,/Expressive/Artistic,71
 Reem Kufi Ink,/Expressive/Calm,96
 Reem Kufi Ink,/Expressive/Innovative,100
+Reem Kufi Ink,/Expressive/Vintage,76.8
 Reem Kufi Ink,/Sans/Geometric,100
-Reem Kufi,/Sans/Geometric,100
 Reenie Beanie,/Expressive/Active,31
 Reenie Beanie,/Expressive/Awkward,42
 Reenie Beanie,/Expressive/Childlike,69
@@ -6422,101 +7057,114 @@ Reenie Beanie,/Expressive/Happy,54
 Reenie Beanie,/Expressive/Innovative,21
 Reenie Beanie,/Expressive/Playful,14
 Reenie Beanie,/Expressive/Rugged,45
+Reenie Beanie,/Expressive/Sincere,96
 Reenie Beanie,/Script/Handwritten,100
 Reggae One,/Expressive/Awkward,72
 Reggae One,/Expressive/Calm,56
 Reggae One,/Expressive/Excited,65
 Reggae One,/Theme/Techno,10
 Reggae One,/Theme/Wacky,30
-REM,/Expressive/Business,58
+REM,/Expressive/Business,90.9
 REM,/Expressive/Calm,98
 REM,/Expressive/Competent,12
-REM,/Expressive/Stiff,65
 REM,/Sans/Grotesque,10
 REM,/Sans/Humanist,70
-Rethink Sans,/Expressive/Business,94
+REM,/Expressive/Stiff,65
+Rethink Sans,/Expressive/Business,88
 Rethink Sans,/Expressive/Calm,99
-Rethink Sans,/Expressive/Stiff,51
+Rethink Sans,/Expressive/Vintage,62
 Rethink Sans,/Sans/Grotesque,100
+Rethink Sans,/Expressive/Stiff,51
 Revalia,/Expressive/Awkward,38
 Revalia,/Expressive/Futuristic,95
 Revalia,/Expressive/Happy,54
 Revalia,/Expressive/Innovative,24
-Revalia,/Expressive/Stiff,75
+Revalia,/Expressive/Vintage,68.6
 Revalia,/Theme/Art Deco,10
 Revalia,/Theme/Techno,30
 Revalia,/Theme/Wacky,40
+Revalia,/Expressive/Stiff,75
 Rhodium Libre,/Expressive/Business,46
 Rhodium Libre,/Expressive/Calm,96
 Rhodium Libre,/Expressive/Sincere,77
-Rhodium Libre,/Expressive/Stiff,75
 Rhodium Libre,/Indic/Low contrast,100
 Rhodium Libre,/Indic/Reverse-contrast,40
 Rhodium Libre,/Serif/Transitional,30
+Rhodium Libre,/Expressive/Stiff,75
 Ribeye,/Expressive/Awkward,92
 Ribeye,/Expressive/Childlike,32
 Ribeye,/Expressive/Excited,46
 Ribeye,/Expressive/Futuristic,18
+Ribeye,/Expressive/Loud,76
+Ribeye,/Expressive/Vintage,46
+Ribeye,/Theme/Art Deco,10
+Ribeye,/Theme/Wacky,10
 Ribeye Marrow,/Expressive/Awkward,92
 Ribeye Marrow,/Expressive/Childlike,32
 Ribeye Marrow,/Expressive/Excited,46
 Ribeye Marrow,/Expressive/Futuristic,25
 Ribeye Marrow,/Expressive/Innovative,63
+Ribeye Marrow,/Expressive/Vintage,46
 Ribeye Marrow,/Theme/Art Deco,10
 Ribeye Marrow,/Theme/Inline,20
 Ribeye Marrow,/Theme/Wacky,10
-Ribeye,/Theme/Art Deco,10
-Ribeye,/Theme/Wacky,10
 Righteous,/Expressive/Calm,92
 Righteous,/Expressive/Competent,57
 Righteous,/Expressive/Happy,21
-Righteous,/Expressive/Stiff,71
 Righteous,/Sans/Geometric,100
 Righteous,/Theme/Techno,30
+Righteous,/Expressive/Stiff,71
 Risque,/Expressive/Awkward,94
 Risque,/Expressive/Childlike,71
 Risque,/Expressive/Excited,37
 Risque,/Expressive/Happy,29
+Risque,/Expressive/Loud,48
 Risque,/Expressive/Sincere,1
+Risque,/Expressive/Vintage,57.8
 Risque,/Theme/Wacky,70
 Road Rage,/Expressive/Futuristic,28
 Road Rage,/Expressive/Innovative,92
 Road Rage,/Expressive/Rugged,94
-Road Rage,/Expressive/Stiff,91
 Road Rage,/Theme/Distressed,100
-Roboto Condensed,/Expressive/Business,50
-Roboto Condensed,/Expressive/Calm,99
-Roboto Condensed,/Expressive/Competent,74
-Roboto Condensed,/Expressive/Stiff,51
-Roboto Condensed,/Sans/Neo Grotesque,100
-Roboto,/Expressive/Business,50
+Road Rage,/Expressive/Stiff,91
+Roboto,/Expressive/Business,99.6
 Roboto,/Expressive/Calm,99
+Roboto,/Expressive/Competent,98.5
+Roboto,/Sans/Neo Grotesque,100
 Roboto,/Expressive/Stiff,51
-Roboto Flex,/Expressive/Business,60
+Roboto Condensed,/Expressive/Business,99.4
+Roboto Condensed,/Expressive/Calm,99
+Roboto Condensed,/Expressive/Competent,98.5
+Roboto Condensed,/Sans/Neo Grotesque,100
+Roboto Condensed,/Expressive/Stiff,51
+Roboto Flex,/Expressive/Business,99.8
 Roboto Flex,/Expressive/Calm,99
-Roboto Flex,/Expressive/Competent,100
-Roboto Flex,/Expressive/Stiff,51
 Roboto Flex,/Sans/Neo Grotesque,100
+Roboto Flex,/Expressive/Stiff,51
 Roboto Mono,/Expressive/Calm,99
 Roboto Mono,/Expressive/Competent,62
-Roboto Mono,/Expressive/Stiff,51
+Roboto Mono,/Expressive/Vintage,24.3
 Roboto Mono,/Monospace/Monospace,100
 Roboto Mono,/Sans/Neo Grotesque,100
-Roboto,/Sans/Neo Grotesque,100
-Roboto Serif,/Expressive/Business,50
+Roboto Mono,/Expressive/Stiff,51
+Roboto Serif,/Expressive/Business,67.6
 Roboto Serif,/Expressive/Calm,98
+Roboto Serif,/Expressive/Competent,99.1
 Roboto Serif,/Expressive/Sincere,80
-Roboto Serif,/Expressive/Stiff,60
 Roboto Serif,/Serif/Modern,40
 Roboto Serif,/Serif/Transitional,30
+Roboto Serif,/Expressive/Stiff,60
 Roboto Slab,/Expressive/Business,70
 Roboto Slab,/Expressive/Calm,98
-Roboto Slab,/Expressive/Sincere,99
-Roboto Slab,/Expressive/Stiff,71
+Roboto Slab,/Expressive/Competent,98.8
+Roboto Slab,/Expressive/Vintage,37.3
 Roboto Slab,/Slab/Geometric,70
 Roboto Slab,/Slab/Humanist,10
+Roboto Slab,/Expressive/Stiff,71
 Rochester,/Expressive/Artistic,80
 Rochester,/Expressive/Fancy,73
+Rochester,/Expressive/Loud,53
+Rochester,/Expressive/Vintage,74.5
 Rochester,/Script/Formal,50
 Rochester,/Script/Informal,50
 Rock 3D,/Expressive/Excited,39
@@ -6528,6 +7176,13 @@ Rock 3D,/Theme/Distressed,80
 Rock 3D,/Theme/Inline,30
 Rock 3D,/Theme/Shaded,10
 Rock 3D,/Theme/Wacky,50
+Rock Salt,/Expressive/Artistic,21
+Rock Salt,/Expressive/Awkward,41
+Rock Salt,/Expressive/Excited,58
+Rock Salt,/Expressive/Innovative,41
+Rock Salt,/Expressive/Rugged,36
+Rock Salt,/Script/Handwritten,100
+Rock Salt,/Script/Informal,100
 RocknRoll One,/Expressive/Awkward,51
 RocknRoll One,/Expressive/Calm,66
 RocknRoll One,/Expressive/Happy,43
@@ -6537,66 +7192,73 @@ RocknRoll One,/Sans/Grotesque,50
 RocknRoll One,/Theme/Blobby,20
 RocknRoll One,/Theme/Distressed,20
 RocknRoll One,/Theme/Wacky,20
-Rock Salt,/Expressive/Artistic,21
-Rock Salt,/Expressive/Awkward,41
-Rock Salt,/Expressive/Excited,58
-Rock Salt,/Expressive/Innovative,41
-Rock Salt,/Expressive/Rugged,36
-Rock Salt,/Script/Handwritten,100
-Rock Salt,/Script/Informal,100
-Rokkitt,/Expressive/Business,72
+Rokkitt,/Expressive/Business,66.9
 Rokkitt,/Expressive/Calm,95
 Rokkitt,/Expressive/Sincere,86
-Rokkitt,/Expressive/Stiff,52
+Rokkitt,/Expressive/Vintage,78.3
 Rokkitt,/Slab/Geometric,100
+Rokkitt,/Expressive/Stiff,52
 Romanesco,/Expressive/Artistic,57
 Romanesco,/Expressive/Fancy,53
+Romanesco,/Expressive/Loud,76
 Romanesco,/Expressive/Sophisticated,77
+Romanesco,/Expressive/Vintage,63.4
 Romanesco,/Script/Formal,80
-Ropa Sans,/Expressive/Business,54
+Ropa Sans,/Expressive/Business,54.5
 Ropa Sans,/Expressive/Calm,99
-Ropa Sans,/Expressive/Competent,65
-Ropa Sans,/Expressive/Stiff,81
+Ropa Sans,/Expressive/Competent,95.9
 Ropa Sans,/Sans/Humanist,60
 Ropa Sans,/Sans/Neo Grotesque,20
+Ropa Sans,/Expressive/Stiff,81
 Rosario,/Expressive/Business,36
 Rosario,/Expressive/Calm,69
-Rosario,/Expressive/Stiff,30
+Rosario,/Expressive/Vintage,58.7
 Rosario,/Sans/Humanist,100
-Rosarivo,/Expressive/Business,66
+Rosario,/Expressive/Stiff,30
+Rosarivo,/Expressive/Business,66.7
 Rosarivo,/Expressive/Calm,94
-Rosarivo,/Expressive/Sincere,97
+Rosarivo,/Expressive/Sincere,98
+Rosarivo,/Expressive/Vintage,89.5
 Rosarivo,/Serif/Humanist Venetian,100
 Rouge Script,/Expressive/Artistic,69
 Rouge Script,/Expressive/Cute,27
 Rouge Script,/Expressive/Fancy,99
+Rouge Script,/Expressive/Vintage,64.3
 Rouge Script,/Script/Formal,80
 Rowdies,/Expressive/Calm,63
-Rowdies,/Expressive/Stiff,82
+Rowdies,/Expressive/Loud,88
 Rowdies,/Sans/Humanist,80
 Rowdies,/Theme/Wacky,10
 Rowdies,/Theme/Woodtype,30
+Rowdies,/Expressive/Stiff,82
 Rozha One,/Expressive/Business,48
 Rozha One,/Expressive/Calm,94
+Rozha One,/Expressive/Loud,73
 Rozha One,/Expressive/Sincere,71
+Rozha One,/Expressive/Vintage,74
 Rozha One,/Serif/Didone,100
+Rubik,/Expressive/Business,69.2
+Rubik,/Expressive/Calm,98
+Rubik,/Expressive/Cute,1
+Rubik,/Sans/Neo Grotesque,100
+Rubik,/Expressive/Stiff,66
 Rubik 80s Fade,/Expressive/Excited,56
 Rubik 80s Fade,/Expressive/Innovative,99
 Rubik 80s Fade,/Expressive/Playful,70
 Rubik 80s Fade,/Expressive/Rugged,67
-Rubik 80s Fade,/Expressive/Stiff,91
 Rubik 80s Fade,/Theme/Distressed,30
 Rubik 80s Fade,/Theme/Techno,100
 Rubik 80s Fade,/Theme/Woodtype,10
+Rubik 80s Fade,/Expressive/Stiff,91
 Rubik Beastly,/Expressive/Awkward,64
 Rubik Beastly,/Expressive/Excited,80
 Rubik Beastly,/Expressive/Innovative,99
 Rubik Beastly,/Expressive/Playful,80
 Rubik Beastly,/Expressive/Rugged,98
-Rubik Beastly,/Expressive/Stiff,40
 Rubik Beastly,/Theme/Distressed,80
 Rubik Beastly,/Theme/Techno,20
 Rubik Beastly,/Theme/Wacky,80
+Rubik Beastly,/Expressive/Stiff,40
 Rubik Bubbles,/Expressive/Awkward,73
 Rubik Bubbles,/Expressive/Cute,24
 Rubik Bubbles,/Expressive/Excited,85
@@ -6604,10 +7266,10 @@ Rubik Bubbles,/Expressive/Happy,33
 Rubik Bubbles,/Expressive/Innovative,99
 Rubik Bubbles,/Expressive/Playful,90
 Rubik Bubbles,/Expressive/Rugged,67
-Rubik Bubbles,/Expressive/Stiff,40
 Rubik Bubbles,/Theme/Distressed,50
 Rubik Bubbles,/Theme/Wacky,30
 Rubik Bubbles,/Theme/Woodtype,10
+Rubik Bubbles,/Expressive/Stiff,40
 Rubik Burned,/Expressive/Awkward,100
 Rubik Burned,/Expressive/Excited,95
 Rubik Burned,/Expressive/Innovative,99
@@ -6619,46 +7281,43 @@ Rubik Dirt,/Expressive/Excited,19
 Rubik Dirt,/Expressive/Innovative,79
 Rubik Dirt,/Expressive/Playful,20
 Rubik Dirt,/Expressive/Rugged,96
-Rubik Dirt,/Expressive/Stiff,72
+Rubik Dirt,/Expressive/Vintage,37.9
 Rubik Dirt,/Theme/Distressed,100
 Rubik Dirt,/Theme/Woodtype,100
+Rubik Dirt,/Expressive/Stiff,72
 Rubik Distressed,/Expressive/Awkward,64
 Rubik Distressed,/Expressive/Excited,47
 Rubik Distressed,/Expressive/Innovative,99
 Rubik Distressed,/Expressive/Playful,50
 Rubik Distressed,/Expressive/Rugged,99
-Rubik Distressed,/Expressive/Stiff,85
 Rubik Distressed,/Theme/Distressed,100
 Rubik Distressed,/Theme/Techno,10
-Rubik,/Expressive/Business,69
-Rubik,/Expressive/Calm,98
-Rubik,/Expressive/Cute,1
-Rubik,/Expressive/Stiff,66
+Rubik Distressed,/Expressive/Stiff,85
 Rubik Gemstones,/Expressive/Awkward,90
 Rubik Gemstones,/Expressive/Excited,69
 Rubik Gemstones,/Expressive/Innovative,99
 Rubik Gemstones,/Expressive/Playful,40
 Rubik Gemstones,/Expressive/Rugged,67
-Rubik Gemstones,/Expressive/Stiff,52
 Rubik Gemstones,/Theme/Distressed,100
+Rubik Gemstones,/Expressive/Stiff,52
 Rubik Glitch,/Expressive/Awkward,100
 Rubik Glitch,/Expressive/Excited,80
 Rubik Glitch,/Expressive/Innovative,99
 Rubik Glitch,/Expressive/Playful,20
 Rubik Glitch,/Expressive/Rugged,89
-Rubik Glitch,/Expressive/Stiff,40
 Rubik Glitch,/Theme/Distressed,90
 Rubik Glitch,/Theme/Techno,40
 Rubik Glitch,/Theme/Wacky,40
+Rubik Glitch,/Expressive/Stiff,40
 Rubik Iso,/Expressive/Awkward,90
 Rubik Iso,/Expressive/Excited,69
 Rubik Iso,/Expressive/Innovative,99
 Rubik Iso,/Expressive/Playful,50
 Rubik Iso,/Expressive/Rugged,88
-Rubik Iso,/Expressive/Stiff,61
 Rubik Iso,/Theme/Distressed,100
 Rubik Iso,/Theme/Techno,80
 Rubik Iso,/Theme/Wacky,40
+Rubik Iso,/Expressive/Stiff,61
 Rubik Marker Hatch,/Expressive/Awkward,64
 Rubik Marker Hatch,/Expressive/Excited,56
 Rubik Marker Hatch,/Expressive/Innovative,99
@@ -6678,75 +7337,75 @@ Rubik Microbe,/Expressive/Rugged,100
 Rubik Mono One,/Expressive/Business,12
 Rubik Mono One,/Expressive/Calm,87
 Rubik Mono One,/Expressive/Rugged,96
-Rubik Mono One,/Expressive/Stiff,97
 Rubik Mono One,/Sans/Neo Grotesque,100
+Rubik Mono One,/Expressive/Stiff,97
 Rubik Moonrocks,/Expressive/Awkward,47
 Rubik Moonrocks,/Expressive/Excited,48
 Rubik Moonrocks,/Expressive/Innovative,99
 Rubik Moonrocks,/Expressive/Playful,60
 Rubik Moonrocks,/Expressive/Stiff,53
-Rubik One,/Expressive/Business,56
+Rubik One,/Expressive/Business,56.2
 Rubik One,/Expressive/Calm,87
 Rubik One,/Expressive/Rugged,96
-Rubik One,/Expressive/Stiff,97
 Rubik One,/Sans/Neo Grotesque,100
 Rubik One,/Theme/Woodtype,60
+Rubik One,/Expressive/Stiff,97
 Rubik Pixels,/Expressive/Awkward,100
 Rubik Pixels,/Expressive/Excited,69
 Rubik Pixels,/Expressive/Innovative,99
 Rubik Pixels,/Expressive/Playful,100
 Rubik Pixels,/Expressive/Rugged,100
-Rubik Pixels,/Expressive/Stiff,30
 Rubik Pixels,/Theme/Techno,100
+Rubik Pixels,/Expressive/Stiff,30
 Rubik Puddles,/Expressive/Awkward,79
 Rubik Puddles,/Expressive/Excited,88
 Rubik Puddles,/Expressive/Innovative,99
 Rubik Puddles,/Expressive/Playful,100
 Rubik Puddles,/Expressive/Rugged,86
 Rubik Puddles,/Theme/Wacky,90
-Rubik,/Sans/Neo Grotesque,100
 Rubik Spray Paint,/Expressive/Awkward,73
 Rubik Spray Paint,/Expressive/Excited,95
 Rubik Spray Paint,/Expressive/Innovative,99
 Rubik Spray Paint,/Expressive/Playful,100
 Rubik Spray Paint,/Expressive/Rugged,48
-Rubik Spray Paint,/Expressive/Stiff,61
 Rubik Spray Paint,/Theme/Distressed,70
 Rubik Spray Paint,/Theme/Wacky,10
+Rubik Spray Paint,/Expressive/Stiff,61
 Rubik Storm,/Expressive/Awkward,77
 Rubik Storm,/Expressive/Excited,95
 Rubik Storm,/Expressive/Innovative,99
 Rubik Storm,/Expressive/Playful,100
 Rubik Storm,/Expressive/Rugged,100
-Rubik Storm,/Expressive/Stiff,72
 Rubik Storm,/Theme/Distressed,70
 Rubik Storm,/Theme/Techno,100
 Rubik Storm,/Theme/Wacky,40
+Rubik Storm,/Expressive/Stiff,72
 Rubik Vinyl,/Expressive/Awkward,11
 Rubik Vinyl,/Expressive/Excited,77
 Rubik Vinyl,/Expressive/Innovative,79
 Rubik Vinyl,/Expressive/Playful,60
 Rubik Vinyl,/Expressive/Rugged,100
-Rubik Vinyl,/Expressive/Stiff,61
 Rubik Vinyl,/Theme/Distressed,90
 Rubik Vinyl,/Theme/Wacky,20
+Rubik Vinyl,/Expressive/Stiff,61
 Rubik Wet Paint,/Expressive/Awkward,33
 Rubik Wet Paint,/Expressive/Excited,77
 Rubik Wet Paint,/Expressive/Innovative,79
 Rubik Wet Paint,/Expressive/Playful,60
 Rubik Wet Paint,/Expressive/Rugged,47
-Rubik Wet Paint,/Expressive/Stiff,61
 Rubik Wet Paint,/Theme/Distressed,80
+Rubik Wet Paint,/Expressive/Stiff,61
 Ruda,/Expressive/Business,46
 Ruda,/Expressive/Calm,97
 Ruda,/Expressive/Competent,52
-Ruda,/Expressive/Stiff,73
 Ruda,/Sans/Humanist,100
-Rufina,/Expressive/Business,58
+Ruda,/Expressive/Stiff,73
+Rufina,/Expressive/Business,58.5
 Rufina,/Expressive/Calm,95
 Rufina,/Expressive/Sincere,97
-Rufina,/Expressive/Stiff,31
+Rufina,/Expressive/Vintage,38.9
 Rufina,/Serif/Didone,90
+Rufina,/Expressive/Stiff,31
 Ruge Boogie,/Expressive/Awkward,76
 Ruge Boogie,/Expressive/Childlike,72
 Ruge Boogie,/Expressive/Excited,76
@@ -6759,11 +7418,11 @@ Ruge Boogie,/Script/Informal,100
 Ruge Boogie,/Theme/Distressed,40
 Ruge Boogie,/Theme/Wacky,50
 Ruluko,/Expressive/Calm,72
-Ruluko,/Expressive/Competent,68
+Ruluko,/Expressive/Competent,88.9
 Ruluko,/Expressive/Cute,13
-Ruluko,/Expressive/Stiff,10
 Ruluko,/Sans/Geometric,10
 Ruluko,/Sans/Humanist,100
+Ruluko,/Expressive/Stiff,10
 Rum Raisin,/Expressive/Awkward,11
 Rum Raisin,/Expressive/Calm,28
 Rum Raisin,/Expressive/Childlike,85
@@ -6775,180 +7434,202 @@ Ruslan Display,/Expressive/Awkward,54
 Ruslan Display,/Expressive/Calm,26
 Ruslan Display,/Expressive/Childlike,30
 Ruslan Display,/Expressive/Innovative,54
+Ruslan Display,/Expressive/Loud,85
 Ruslan Display,/Theme/Wacky,20
 Russo One,/Expressive/Business,12
 Russo One,/Expressive/Calm,88
 Russo One,/Expressive/Futuristic,98
-Russo One,/Expressive/Stiff,99
+Russo One,/Expressive/Vintage,47.3
 Russo One,/Sans/Geometric,10
 Russo One,/Sans/Superellipse,60
 Russo One,/Theme/Techno,40
+Russo One,/Expressive/Stiff,99
 Ruthie,/Expressive/Artistic,60
 Ruthie,/Expressive/Cute,6
 Ruthie,/Expressive/Fancy,75
+Ruthie,/Expressive/Vintage,57.3
 Ruthie,/Script/Formal,30
 Ruthie,/Script/Informal,50
 Ruwudu,/Expressive/Business,18
 Ruwudu,/Expressive/Calm,78
 Ruwudu,/Expressive/Sincere,77
-Ruwudu,/Expressive/Stiff,50
+Ruwudu,/Expressive/Vintage,77.9
 Ruwudu,/Serif/Old Style Garalde,80
+Ruwudu,/Expressive/Stiff,50
 Rye,/Expressive/Artistic,82
 Rye,/Expressive/Calm,95
 Rye,/Expressive/Innovative,76
-Rye,/Expressive/Stiff,81
+Rye,/Expressive/Vintage,93
 Rye,/Theme/Inline,20
 Rye,/Theme/Tuscan,100
 Rye,/Theme/Woodtype,100
+Rye,/Expressive/Stiff,81
 Sacramento,/Expressive/Artistic,62
 Sacramento,/Expressive/Cute,75
 Sacramento,/Expressive/Fancy,65
 Sacramento,/Expressive/Sophisticated,39
+Sacramento,/Expressive/Vintage,89
 Sacramento,/Script/Informal,90
-Sahitya,/Expressive/Business,60
+Sahitya,/Expressive/Business,66.2
+Sahitya,/Expressive/Loud,50
 Sahitya,/Expressive/Sincere,98
+Sahitya,/Expressive/Vintage,78.2
 Sahitya,/Serif/Humanist Venetian,100
 Sail,/Expressive/Active,12
 Sail,/Expressive/Artistic,40
 Sail,/Expressive/Cute,28
-Saira Condensed,/Expressive/Business,66
-Saira Condensed,/Expressive/Calm,78
-Saira Condensed,/Expressive/Competent,73
-Saira Condensed,/Expressive/Futuristic,97
-Saira Condensed,/Expressive/Stiff,98
-Saira Condensed,/Sans/Superellipse,80
-Saira,/Expressive/Business,65
+Sail,/Expressive/Loud,71
+Sail,/Expressive/Vintage,78.8
+Saira,/Expressive/Business,66.5
 Saira,/Expressive/Calm,78
+Saira,/Expressive/Competent,99.5
 Saira,/Expressive/Futuristic,97
+Saira,/Sans/Superellipse,80
 Saira,/Expressive/Stiff,98
+Saira Condensed,/Expressive/Business,66.1
+Saira Condensed,/Expressive/Calm,78
+Saira Condensed,/Expressive/Competent,99.5
+Saira Condensed,/Expressive/Futuristic,97
+Saira Condensed,/Sans/Superellipse,80
+Saira Condensed,/Expressive/Stiff,98
 Saira ExtraCondensed,/Expressive/Business,68
 Saira ExtraCondensed,/Expressive/Calm,78
-Saira ExtraCondensed,/Expressive/Competent,96
+Saira ExtraCondensed,/Expressive/Competent,99.5
 Saira ExtraCondensed,/Expressive/Futuristic,97
-Saira ExtraCondensed,/Expressive/Stiff,98
 Saira ExtraCondensed,/Sans/Superellipse,80
-Saira,/Sans/Superellipse,80
+Saira ExtraCondensed,/Expressive/Stiff,98
 Saira SemiCondensed,/Expressive/Business,69
 Saira SemiCondensed,/Expressive/Calm,78
-Saira SemiCondensed,/Expressive/Competent,73
+Saira SemiCondensed,/Expressive/Competent,99.5
 Saira SemiCondensed,/Expressive/Futuristic,97
-Saira SemiCondensed,/Expressive/Stiff,98
 Saira SemiCondensed,/Sans/Superellipse,80
+Saira SemiCondensed,/Expressive/Stiff,98
 Saira Stencil One,/Expressive/Calm,31
-Saira Stencil One,/Expressive/Competent,90
 Saira Stencil One,/Expressive/Futuristic,99
 Saira Stencil One,/Expressive/Innovative,32
-Saira Stencil One,/Expressive/Stiff,98
 Saira Stencil One,/Sans/Superellipse,80
 Saira Stencil One,/Theme/Stencil,100
+Saira Stencil One,/Expressive/Stiff,98
 Salsa,/Expressive/Calm,66
 Salsa,/Expressive/Cute,12
 Salsa,/Expressive/Excited,42
+Salsa,/Expressive/Loud,46
 Salsa,/Expressive/Playful,12
 Salsa,/Script/Upright Script,20
 Sanchez,/Expressive/Business,29
 Sanchez,/Expressive/Calm,98
-Sanchez,/Expressive/Sincere,95
-Sanchez,/Expressive/Stiff,71
+Sanchez,/Expressive/Vintage,78.9
 Sanchez,/Slab/Humanist,90
+Sanchez,/Expressive/Stiff,71
 Sancreek,/Expressive/Artistic,50
 Sancreek,/Expressive/Calm,73
 Sancreek,/Expressive/Innovative,76
+Sancreek,/Expressive/Vintage,93
 Sancreek,/Theme/Tuscan,100
 Sancreek,/Theme/Woodtype,90
 Sansation,/Expressive/Calm,79
 Sansation,/Expressive/Futuristic,88
-Sansation,/Expressive/Stiff,83
 Sansation,/Sans/Humanist,50
 Sansation,/Sans/Superellipse,70
+Sansation,/Expressive/Stiff,83
 Sansita,/Expressive/Calm,76
-Sansita,/Expressive/Competent,49
+Sansita,/Expressive/Competent,79.6
 Sansita,/Expressive/Cute,61
+Sansita,/Sans/Humanist,80
 Sansita,/Expressive/Stiff,50
 Sansita One,/Expressive/Calm,76
-Sansita One,/Expressive/Competent,49
+Sansita One,/Expressive/Competent,79.6
 Sansita One,/Expressive/Cute,61
+Sansita One,/Expressive/Loud,71
 Sansita One,/Expressive/Stiff,50
-Sansita,/Sans/Humanist,80
 Sansita Swashed,/Expressive/Active,72
 Sansita Swashed,/Expressive/Artistic,16
 Sansita Swashed,/Expressive/Childlike,50
 Sansita Swashed,/Expressive/Cute,77
-Sarabun,/Expressive/Business,57
+Sansita Swashed,/Expressive/Sincere,92
+Sarabun,/Expressive/Business,56.7
 Sarabun,/Expressive/Calm,99
-Sarabun,/Expressive/Stiff,71
 Sarabun,/Sans/Humanist,100
-Sarala,/Expressive/Business,74
+Sarabun,/Expressive/Stiff,71
+Sarala,/Expressive/Business,96.7
 Sarala,/Expressive/Calm,99
-Sarala,/Expressive/Stiff,83
 Sarala,/Sans/Humanist,100
+Sarala,/Expressive/Stiff,83
 Sarina,/Expressive/Artistic,74
 Sarina,/Expressive/Cute,78
+Sarina,/Expressive/Sincere,93
+Sarina,/Expressive/Vintage,88
 Sarina,/Script/Informal,90
 Sarina,/Theme/Blobby,55
 Sarina,/Theme/Brush,30
 Sarpanch,/Expressive/Calm,73
 Sarpanch,/Expressive/Futuristic,99
-Sarpanch,/Expressive/Stiff,99
+Sarpanch,/Expressive/Vintage,69
 Sarpanch,/Sans/Superellipse,80
 Sarpanch,/Theme/Techno,90
+Sarpanch,/Expressive/Stiff,99
 Sassy Frass,/Expressive/Artistic,80
 Sassy Frass,/Expressive/Childlike,54
 Sassy Frass,/Expressive/Fancy,80
+Sassy Frass,/Expressive/Sincere,94
+Sassy Frass,/Expressive/Vintage,58.4
 Sassy Frass,/Script/Informal,100
 Satisfy,/Expressive/Artistic,49
 Satisfy,/Expressive/Cute,65
+Satisfy,/Expressive/Sincere,94
+Satisfy,/Expressive/Vintage,81
 Satisfy,/Script/Handwritten,40
 Satisfy,/Script/Informal,70
 Sawarabi Mincho,/Expressive/Calm,91
 Sawarabi Mincho,/Expressive/Sincere,43
+Sawarabi Mincho,/Expressive/Vintage,52
 Sawarabi Mincho,/Serif/Old Style Garalde,50
 Scada,/Expressive/Calm,98
 Scada,/Expressive/Competent,35
-Scada,/Expressive/Stiff,72
 Scada,/Sans/Humanist,80
-Scheherazade New,/Expressive/Business,100
+Scada,/Expressive/Stiff,72
+Scheherazade New,/Expressive/Business,98
 Scheherazade New,/Expressive/Calm,99
-Scheherazade New,/Expressive/Sincere,96
-Scheherazade New,/Expressive/Stiff,60
+Scheherazade New,/Expressive/Vintage,84.5
 Scheherazade New,/Serif/Transitional,100
-Schibsted Grotesk,/Expressive/Business,65
+Scheherazade New,/Expressive/Stiff,60
+Schibsted Grotesk,/Expressive/Business,96.9
 Schibsted Grotesk,/Expressive/Calm,98
-Schibsted Grotesk,/Expressive/Stiff,71
+Schibsted Grotesk,/Expressive/Vintage,83.5
 Schibsted Grotesk,/Sans/Grotesque,100
+Schibsted Grotesk,/Expressive/Stiff,71
 Schoolbell,/Expressive/Artistic,22
 Schoolbell,/Expressive/Awkward,54
 Schoolbell,/Expressive/Childlike,100
 Schoolbell,/Expressive/Cute,69
 Schoolbell,/Expressive/Happy,27
+Schoolbell,/Expressive/Vintage,63.4
 Schoolbell,/Script/Handwritten,100
-Scope One,/Expressive/Business,95
+Scope One,/Expressive/Business,89.7
 Scope One,/Expressive/Calm,97
 Scope One,/Expressive/Sincere,82
-Scope One,/Expressive/Stiff,72
+Scope One,/Expressive/Vintage,25.4
 Scope One,/Slab/Humanist,100
+Scope One,/Expressive/Stiff,72
 Seaweed Script,/Expressive/Artistic,49
 Seaweed Script,/Expressive/Awkward,12
 Seaweed Script,/Expressive/Innovative,41
 Seaweed Script,/Expressive/Rugged,53
+Seaweed Script,/Expressive/Vintage,53.3
 Seaweed Script,/Script/Handwritten,20
 Seaweed Script,/Theme/Brush,20
 Secular One,/Expressive/Business,66
 Secular One,/Expressive/Calm,96
-Secular One,/Expressive/Stiff,65
 Secular One,/Sans/Humanist,100
-Sedan,/Expressive/Sincere,80
-Sedan SC,/Expressive/Sincere,80
-Sedan SC,/Serif/Old Style Garalde,90
+Secular One,/Expressive/Stiff,65
+Sedan,/Expressive/Business,50
+Sedan,/Expressive/Sincere,99
+Sedan,/Expressive/Vintage,82.5
 Sedan,/Serif/Old Style Garalde,90
-Sedgwick Ave Display,/Expressive/Active,93
-Sedgwick Ave Display,/Expressive/Artistic,14
-Sedgwick Ave Display,/Expressive/Awkward,68
-Sedgwick Ave Display,/Expressive/Cute,15
-Sedgwick Ave Display,/Expressive/Excited,60
-Sedgwick Ave Display,/Expressive/Happy,79
-Sedgwick Ave Display,/Expressive/Innovative,13
-Sedgwick Ave Display,/Script/Handwritten,100
+Sedan SC,/Expressive/Business,50
+Sedan SC,/Expressive/Sincere,96
+Sedan SC,/Expressive/Vintage,83
+Sedan SC,/Serif/Old Style Garalde,90
 Sedgwick Ave,/Expressive/Active,66
 Sedgwick Ave,/Expressive/Artistic,12
 Sedgwick Ave,/Expressive/Awkward,32
@@ -6957,19 +7638,35 @@ Sedgwick Ave,/Expressive/Excited,24
 Sedgwick Ave,/Expressive/Happy,55
 Sedgwick Ave,/Expressive/Innovative,13
 Sedgwick Ave,/Expressive/Rugged,42
+Sedgwick Ave,/Expressive/Sincere,98
+Sedgwick Ave,/Expressive/Vintage,24.6
 Sedgwick Ave,/Script/Handwritten,100
+Sedgwick Ave Display,/Expressive/Active,93
+Sedgwick Ave Display,/Expressive/Artistic,14
+Sedgwick Ave Display,/Expressive/Awkward,68
+Sedgwick Ave Display,/Expressive/Cute,15
+Sedgwick Ave Display,/Expressive/Excited,60
+Sedgwick Ave Display,/Expressive/Happy,79
+Sedgwick Ave Display,/Expressive/Innovative,13
+Sedgwick Ave Display,/Expressive/Vintage,25
+Sedgwick Ave Display,/Script/Handwritten,100
+Sen,/Expressive/Business,68.1
+Sen,/Expressive/Calm,99
+Sen,/Expressive/Vintage,75.4
+Sen,/Sans/Humanist,100
+Sen,/Expressive/Stiff,51
 Send Flowers,/Expressive/Artistic,57
 Send Flowers,/Expressive/Cute,90
 Send Flowers,/Expressive/Fancy,36
+Send Flowers,/Expressive/Sincere,94
 Send Flowers,/Script/Informal,100
-Sen,/Expressive/Business,76
-Sen,/Expressive/Calm,99
-Sen,/Expressive/Stiff,51
-Sen,/Sans/Humanist,100
 Sevillana,/Expressive/Artistic,20
 Sevillana,/Expressive/Childlike,81
 Sevillana,/Expressive/Cute,32
 Sevillana,/Expressive/Innovative,43
+Sevillana,/Expressive/Loud,47
+Sevillana,/Expressive/Sincere,93
+Sevillana,/Expressive/Vintage,57.6
 Seymour One,/Expressive/Business,1
 Seymour One,/Expressive/Calm,75
 Seymour One,/Expressive/Happy,42
@@ -6983,6 +7680,7 @@ Shadows Into Light,/Expressive/Cute,8
 Shadows Into Light,/Expressive/Excited,56
 Shadows Into Light,/Expressive/Innovative,31
 Shadows Into Light,/Expressive/Rugged,43
+Shadows Into Light,/Expressive/Sincere,98
 Shadows Into Light,/Script/Handwritten,100
 Shadows Into Light,/Script/Informal,100
 Shadows Into Light,/Theme/Distressed,50
@@ -6991,11 +7689,14 @@ Shadows Into Light Two,/Expressive/Awkward,72
 Shadows Into Light Two,/Expressive/Childlike,100
 Shadows Into Light Two,/Expressive/Cute,36
 Shadows Into Light Two,/Expressive/Excited,24
+Shadows Into Light Two,/Expressive/Sincere,98
 Shadows Into Light Two,/Script/Handwritten,100
 Shadows Into Light Two,/Script/Informal,100
 Shalimar,/Expressive/Artistic,59
 Shalimar,/Expressive/Childlike,68
 Shalimar,/Expressive/Excited,56
+Shalimar,/Expressive/Loud,42
+Shalimar,/Expressive/Vintage,53.4
 Shalimar,/Script/Formal,70
 Shantell Sans,/Expressive/Artistic,22
 Shantell Sans,/Expressive/Awkward,32
@@ -7007,47 +7708,47 @@ Shantell Sans,/Expressive/Playful,34
 Shantell Sans,/Script/Handwritten,100
 Shanti,/Expressive/Calm,98
 Shanti,/Expressive/Competent,22
-Shanti,/Expressive/Stiff,72
 Shanti,/Sans/Humanist,100
+Shanti,/Expressive/Stiff,72
 Share,/Expressive/Calm,95
-Share,/Expressive/Competent,67
-Share,/Expressive/Stiff,75
+Share,/Expressive/Competent,88.3
 Share,/Sans/Humanist,60
 Share,/Sans/Neo Grotesque,30
 Share,/Sans/Superellipse,20
+Share,/Expressive/Stiff,75
 Share Tech,/Expressive/Calm,85
-Share Tech,/Expressive/Competent,84
 Share Tech,/Expressive/Futuristic,67
+Share Tech,/Sans/Neo Grotesque,70
+Share Tech,/Sans/Superellipse,50
+Share Tech,/Theme/Techno,30
 Share Tech,/Expressive/Stiff,90
 Share Tech Mono,/Expressive/Calm,85
-Share Tech Mono,/Expressive/Competent,64
+Share Tech Mono,/Expressive/Competent,77.7
 Share Tech Mono,/Expressive/Futuristic,79
-Share Tech Mono,/Expressive/Stiff,90
 Share Tech Mono,/Monospace/Monospace,100
 Share Tech Mono,/Sans/Neo Grotesque,70
 Share Tech Mono,/Sans/Superellipse,50
 Share Tech Mono,/Theme/Techno,50
-Share Tech,/Sans/Neo Grotesque,70
-Share Tech,/Sans/Superellipse,50
-Share Tech,/Theme/Techno,30
+Share Tech Mono,/Expressive/Stiff,90
+Shippori Antique,/Expressive/Business,49
+Shippori Antique,/Expressive/Calm,98
+Shippori Antique,/Expressive/Vintage,75.3
+Shippori Antique,/Sans/Grotesque,100
+Shippori Antique,/Expressive/Stiff,51
 Shippori Antique B1,/Expressive/Business,11
 Shippori Antique B1,/Expressive/Calm,98
 Shippori Antique B1,/Expressive/Competent,31
-Shippori Antique B1,/Expressive/Stiff,51
 Shippori Antique B1,/Sans/Grotesque,100
 Shippori Antique B1,/Sans/Rounded,30
-Shippori Antique,/Expressive/Business,49
-Shippori Antique,/Expressive/Calm,98
-Shippori Antique,/Expressive/Stiff,51
-Shippori Antique,/Sans/Grotesque,100
-Shippori Mincho B1,/Expressive/Business,72
-Shippori Mincho B1,/Expressive/Calm,96
-Shippori Mincho B1,/Expressive/Sincere,90
-Shippori Mincho B1,/Serif/Transitional,100
-Shippori Mincho,/Expressive/Business,72
+Shippori Antique B1,/Expressive/Stiff,51
+Shippori Mincho,/Expressive/Business,77
 Shippori Mincho,/Expressive/Calm,96
 Shippori Mincho,/Expressive/Sincere,90
 Shippori Mincho,/Serif/Transitional,100
+Shippori Mincho B1,/Expressive/Business,77
+Shippori Mincho B1,/Expressive/Calm,96
+Shippori Mincho B1,/Expressive/Sincere,90
+Shippori Mincho B1,/Serif/Transitional,100
 Shizuru,/Expressive/Awkward,75
 Shizuru,/Expressive/Childlike,18
 Shizuru,/Expressive/Excited,78
@@ -7062,6 +7763,7 @@ Shojumaru,/Expressive/Artistic,20
 Shojumaru,/Expressive/Awkward,57
 Shojumaru,/Expressive/Innovative,16
 Shojumaru,/Expressive/Playful,30
+Shojumaru,/Expressive/Vintage,82.5
 Shojumaru,/Theme/Wacky,10
 Short Stack,/Expressive/Awkward,71
 Short Stack,/Expressive/Childlike,99
@@ -7070,52 +7772,63 @@ Short Stack,/Expressive/Excited,51
 Short Stack,/Script/Handwritten,100
 Shrikhand,/Expressive/Active,25
 Shrikhand,/Expressive/Cute,33
+Shrikhand,/Expressive/Loud,99
 Shrikhand,/Expressive/Sincere,12
+Shrikhand,/Expressive/Vintage,59.5
 Shrikhand,/Serif/Transitional,70
 Shrikhand,/Theme/Blobby,20
 Siemreap,"/South East Asian (Thai, Khmer, Lao)/Chrieng (Khmer)",100
 Sigmar,/Expressive/Calm,49
 Sigmar,/Expressive/Excited,42
 Sigmar,/Expressive/Innovative,25
+Sigmar,/Expressive/Loud,100
 Sigmar,/Expressive/Rugged,41
+Sigmar,/Expressive/Vintage,34.5
+Sigmar,/Sans/Humanist,100
+Sigmar,/Theme/Distressed,60
+Sigmar,/Theme/Woodtype,20
 Sigmar,/Expressive/Stiff,10
 Sigmar One,/Expressive/Calm,49
 Sigmar One,/Expressive/Excited,42
 Sigmar One,/Expressive/Innovative,24
+Sigmar One,/Expressive/Loud,100
 Sigmar One,/Expressive/Rugged,74
-Sigmar One,/Expressive/Stiff,10
+Sigmar One,/Expressive/Vintage,34.5
 Sigmar One,/Sans/Humanist,100
 Sigmar One,/Theme/Distressed,60
 Sigmar One,/Theme/Woodtype,20
-Sigmar,/Sans/Humanist,100
-Sigmar,/Theme/Distressed,60
-Sigmar,/Theme/Woodtype,20
-Signika,/Expressive/Business,55
+Sigmar One,/Expressive/Stiff,10
+Signika,/Expressive/Business,55.9
 Signika,/Expressive/Calm,97
-Signika,/Expressive/Competent,49
-Signika,/Expressive/Stiff,74
-Signika Negative,/Expressive/Business,55
-Signika Negative,/Expressive/Calm,97
-Signika Negative,/Expressive/Competent,49
-Signika Negative,/Expressive/Stiff,74
-Signika Negative,/Sans/Humanist,100
-Signika Negative SC,/Expressive/Business,55
-Signika Negative SC,/Expressive/Calm,97
-Signika Negative SC,/Expressive/Competent,49
-Signika Negative SC,/Expressive/Stiff,71
-Signika Negative SC,/Sans/Humanist,100
+Signika,/Expressive/Competent,78.2
+Signika,/Expressive/Vintage,14.5
 Signika,/Sans/Humanist,100
-Signika SC,/Expressive/Business,55
+Signika,/Expressive/Stiff,74
+Signika Negative,/Expressive/Business,55.9
+Signika Negative,/Expressive/Calm,97
+Signika Negative,/Expressive/Competent,78.2
+Signika Negative,/Expressive/Vintage,14.5
+Signika Negative,/Sans/Humanist,100
+Signika Negative,/Expressive/Stiff,74
+Signika Negative SC,/Expressive/Business,55.9
+Signika Negative SC,/Expressive/Calm,97
+Signika Negative SC,/Expressive/Competent,78.2
+Signika Negative SC,/Expressive/Vintage,14.5
+Signika Negative SC,/Sans/Humanist,100
+Signika Negative SC,/Expressive/Stiff,71
+Signika SC,/Expressive/Business,55.9
 Signika SC,/Expressive/Calm,97
-Signika SC,/Expressive/Competent,49
-Signika SC,/Expressive/Stiff,71
+Signika SC,/Expressive/Competent,78.2
+Signika SC,/Expressive/Vintage,14.5
 Signika SC,/Sans/Humanist,100
+Signika SC,/Expressive/Stiff,71
 Silkscreen,/Expressive/Calm,44
 Silkscreen,/Expressive/Futuristic,94
-Silkscreen,/Expressive/Stiff,98
 Silkscreen,/Theme/Techno,100
+Silkscreen,/Expressive/Stiff,98
 Simonetta,/Expressive/Business,50
-Simonetta,/Expressive/Sincere,92
+Simonetta,/Expressive/Sincere,98
+Simonetta,/Expressive/Vintage,84.5
 Simonetta,/Serif/Humanist Venetian,100
 Single Day,/Expressive/Childlike,79
 Single Day,/Expressive/Excited,54
@@ -7126,50 +7839,54 @@ Single Day,/Expressive/Rugged,14
 Single Day,/Theme/Brush,80
 Single Day,/Theme/Distressed,20
 Single Day,/Theme/Wacky,10
-Sintony,/Expressive/Business,57
+Sintony,/Expressive/Business,57.2
 Sintony,/Expressive/Calm,95
-Sintony,/Expressive/Stiff,75
 Sintony,/Sans/Neo Grotesque,100
+Sintony,/Expressive/Stiff,75
 Sirin Stencil,/Expressive/Calm,65
 Sirin Stencil,/Expressive/Innovative,78
 Sirin Stencil,/Expressive/Rugged,43
-Sirin Stencil,/Expressive/Stiff,62
 Sirin Stencil,/Theme/Stencil,100
+Sirin Stencil,/Expressive/Stiff,62
 Sitara,/Indic/Contemporary,100
 Six Caps,/Expressive/Business,38
 Six Caps,/Expressive/Calm,89
-Six Caps,/Expressive/Competent,88
+Six Caps,/Expressive/Competent,96.8
 Six Caps,/Expressive/Rugged,78
-Six Caps,/Expressive/Stiff,94
+Six Caps,/Expressive/Vintage,37.8
 Six Caps,/Sans/Grotesque,100
 Six Caps,/Theme/Woodtype,50
+Six Caps,/Expressive/Stiff,94
 Skranji,/Expressive/Awkward,69
 Skranji,/Expressive/Calm,85
 Skranji,/Expressive/Excited,21
 Skranji,/Expressive/Innovative,43
+Skranji,/Expressive/Loud,89
 Skranji,/Expressive/Rugged,62
-Skranji,/Expressive/Stiff,40
+Skranji,/Expressive/Vintage,89
 Skranji,/Theme/Distressed,20
 Skranji,/Theme/Medieval,50
-Slabo 13px,/Expressive/Business,96
+Skranji,/Expressive/Stiff,40
+Slabo 13px,/Expressive/Business,97.8
 Slabo 13px,/Expressive/Calm,96
-Slabo 13px,/Expressive/Sincere,95
-Slabo 13px,/Expressive/Stiff,75
+Slabo 13px,/Expressive/Vintage,25
 Slabo 13px,/Slab/Humanist,100
-Slabo 27px,/Expressive/Business,96
+Slabo 13px,/Expressive/Stiff,75
+Slabo 27px,/Expressive/Business,97.8
 Slabo 27px,/Expressive/Calm,96
-Slabo 27px,/Expressive/Sincere,94
-Slabo 27px,/Expressive/Stiff,75
+Slabo 27px,/Expressive/Vintage,65
 Slabo 27px,/Slab/Humanist,100
+Slabo 27px,/Expressive/Stiff,75
 Slackey,/Expressive/Awkward,77
 Slackey,/Expressive/Excited,20
 Slackey,/Expressive/Happy,58
 Slackey,/Expressive/Innovative,25
 Slackey,/Expressive/Playful,60
 Slackey,/Expressive/Rugged,42
-Slackey,/Expressive/Stiff,10
+Slackey,/Expressive/Vintage,75.4
 Slackey,/Theme/Distressed,10
 Slackey,/Theme/Wacky,50
+Slackey,/Expressive/Stiff,10
 Slackside One,/Expressive/Active,78
 Slackside One,/Expressive/Awkward,87
 Slackside One,/Expressive/Childlike,60
@@ -7178,6 +7895,7 @@ Slackside One,/Expressive/Excited,17
 Slackside One,/Expressive/Innovative,32
 Slackside One,/Expressive/Playful,75
 Slackside One,/Expressive/Rugged,56
+Slackside One,/Expressive/Sincere,98
 Slackside One,/Script/Handwritten,100
 Slackside One,/Theme/Blobby,30
 Slackside One,/Theme/Brush,20
@@ -7185,26 +7903,29 @@ Slackside One,/Theme/Distressed,50
 Slackside One,/Theme/Wacky,40
 Smokum,/Expressive/Awkward,99
 Smokum,/Expressive/Innovative,23
-Smokum,/Expressive/Stiff,74
+Smokum,/Expressive/Loud,80
+Smokum,/Expressive/Vintage,92.5
 Smokum,/Theme/Tuscan,80
 Smokum,/Theme/Woodtype,60
+Smokum,/Expressive/Stiff,74
 Smooch,/Expressive/Artistic,88
 Smooch,/Expressive/Fancy,94
 Smooch,/Expressive/Innovative,11
 Smooch,/Expressive/Rugged,45
+Smooch,/Expressive/Vintage,66.5
+Smooch,/Script/Informal,60
 Smooch Sans,/Expressive/Calm,68
-Smooch Sans,/Expressive/Competent,77
 Smooch Sans,/Expressive/Futuristic,98
-Smooch Sans,/Expressive/Stiff,90
 Smooch Sans,/Sans/Superellipse,80
 Smooch Sans,/Theme/Techno,30
-Smooch,/Script/Informal,60
+Smooch Sans,/Expressive/Stiff,90
 Smythe,/Expressive/Calm,73
 Smythe,/Expressive/Happy,14
 Smythe,/Expressive/Rugged,18
 Smythe,/Expressive/Sincere,19
-Smythe,/Expressive/Stiff,50
+Smythe,/Expressive/Vintage,74.3
 Smythe,/Theme/Art Deco,50
+Smythe,/Expressive/Stiff,50
 Sniglet,/Expressive/Calm,51
 Sniglet,/Expressive/Childlike,78
 Sniglet,/Expressive/Cute,48
@@ -7232,170 +7953,193 @@ Sofadi One,/Theme/Blobby,20
 Sofia,/Expressive/Artistic,26
 Sofia,/Expressive/Cute,17
 Sofia,/Expressive/Fancy,26
-Sofia Sans Condensed,/Expressive/Business,44
-Sofia Sans Condensed,/Expressive/Calm,79
-Sofia Sans Condensed,/Expressive/Competent,84
-Sofia Sans Condensed,/Expressive/Futuristic,74
-Sofia Sans Condensed,/Expressive/Stiff,75
-Sofia Sans Condensed,/Sans/Neo Grotesque,80
-Sofia Sans Condensed,/Sans/Rounded,20
+Sofia,/Expressive/Loud,54
+Sofia,/Expressive/Vintage,53.4
+Sofia,/Script/Upright Script,100
 Sofia Sans,/Expressive/Business,43
 Sofia Sans,/Expressive/Calm,79
 Sofia Sans,/Expressive/Competent,37
 Sofia Sans,/Expressive/Futuristic,74
-Sofia Sans,/Expressive/Stiff,75
-Sofia Sans Extra Condensed,/Expressive/Business,45
-Sofia Sans Extra Condensed,/Expressive/Calm,79
-Sofia Sans Extra Condensed,/Expressive/Competent,94
-Sofia Sans Extra Condensed,/Expressive/Futuristic,74
-Sofia Sans Extra Condensed,/Expressive/Stiff,76
-Sofia Sans Extra Condensed,/Sans/Neo Grotesque,80
-Sofia Sans Extra Condensed,/Sans/Rounded,20
 Sofia Sans,/Sans/Neo Grotesque,80
 Sofia Sans,/Sans/Rounded,20
+Sofia Sans,/Expressive/Stiff,75
+Sofia Sans Condensed,/Expressive/Business,44
+Sofia Sans Condensed,/Expressive/Calm,79
+Sofia Sans Condensed,/Expressive/Futuristic,74
+Sofia Sans Condensed,/Sans/Neo Grotesque,80
+Sofia Sans Condensed,/Sans/Rounded,20
+Sofia Sans Condensed,/Expressive/Stiff,75
+Sofia Sans Extra Condensed,/Expressive/Business,45
+Sofia Sans Extra Condensed,/Expressive/Calm,79
+Sofia Sans Extra Condensed,/Expressive/Futuristic,74
+Sofia Sans Extra Condensed,/Sans/Neo Grotesque,80
+Sofia Sans Extra Condensed,/Sans/Rounded,20
+Sofia Sans Extra Condensed,/Expressive/Stiff,76
 Sofia Sans Semi Condensed,/Expressive/Business,42
 Sofia Sans Semi Condensed,/Expressive/Calm,79
-Sofia Sans Semi Condensed,/Expressive/Competent,76
+Sofia Sans Semi Condensed,/Expressive/Competent,79
 Sofia Sans Semi Condensed,/Expressive/Futuristic,75
-Sofia Sans Semi Condensed,/Expressive/Stiff,75
 Sofia Sans Semi Condensed,/Sans/Neo Grotesque,80
 Sofia Sans Semi Condensed,/Sans/Rounded,20
-Sofia,/Script/Upright Script,100
+Sofia Sans Semi Condensed,/Expressive/Stiff,75
 Solitreo,/Expressive/Active,79
 Solitreo,/Expressive/Artistic,42
 Solitreo,/Expressive/Awkward,32
 Solitreo,/Expressive/Childlike,70
 Solitreo,/Expressive/Cute,25
 Solitreo,/Expressive/Happy,13
+Solitreo,/Expressive/Sincere,98
 Solitreo,/Script/Handwritten,100
 Solitreo,/Script/Informal,100
 Solitreo,/Theme/Brush,100
 Solway,/Expressive/Business,32
 Solway,/Expressive/Calm,93
 Solway,/Expressive/Sincere,56
-Solway,/Expressive/Stiff,81
+Solway,/Expressive/Vintage,70.3
 Solway,/Slab/Humanist,100
+Solway,/Expressive/Stiff,81
 Sometype Mono,/Expressive/Business,12
 Sometype Mono,/Expressive/Calm,69
 Sometype Mono,/Expressive/Competent,22
 Sometype Mono,/Expressive/Futuristic,64
-Sometype Mono,/Expressive/Stiff,91
+Sometype Mono,/Expressive/Vintage,28.9
 Sometype Mono,/Monospace/Monospace,100
 Sometype Mono,/Sans/Humanist,80
-Song Myung,/Expressive/Business,99
+Sometype Mono,/Expressive/Stiff,91
 Song Myung,/Expressive/Calm,97
-Song Myung,/Expressive/Sincere,97
-Song Myung,/Expressive/Stiff,30
+Song Myung,/Expressive/Loud,28
+Song Myung,/Expressive/Vintage,58
 Song Myung,/Serif/Transitional,100
+Song Myung,/Expressive/Stiff,30
 Sono,/Expressive/Business,33
 Sono,/Expressive/Competent,44
 Sono,/Expressive/Futuristic,92
-Sono,/Expressive/Stiff,84
+Sono,/Expressive/Vintage,54
 Sono,/Monospace/Monospace,100
 Sono,/Sans/Neo Grotesque,80
 Sono,/Sans/Rounded,100
+Sono,/Expressive/Stiff,84
 Sonsie One,/Expressive/Artistic,18
 Sonsie One,/Expressive/Cute,35
+Sonsie One,/Expressive/Loud,95
+Sonsie One,/Expressive/Vintage,63.4
 Sonsie One,/Theme/Brush,30
 Sora,/Expressive/Business,34
 Sora,/Expressive/Calm,98
 Sora,/Expressive/Competent,12
-Sora,/Expressive/Stiff,72
 Sora,/Sans/Neo Grotesque,100
-Sorts Mill Goudy,/Expressive/Business,68
+Sora,/Expressive/Stiff,72
+Sorts Mill Goudy,/Expressive/Business,68.6
 Sorts Mill Goudy,/Expressive/Calm,94
 Sorts Mill Goudy,/Expressive/Sincere,99
+Sorts Mill Goudy,/Expressive/Vintage,73.5
 Sorts Mill Goudy,/Serif/Old Style Garalde,100
 Source Code Pro,/Expressive/Business,32
 Source Code Pro,/Expressive/Calm,78
 Source Code Pro,/Expressive/Competent,21
 Source Code Pro,/Expressive/Futuristic,62
-Source Code Pro,/Expressive/Stiff,84
+Source Code Pro,/Expressive/Vintage,14
 Source Code Pro,/Monospace/Monospace,100
 Source Code Pro,/Sans/Humanist,100
-Source Sans 3,/Expressive/Business,74
+Source Code Pro,/Expressive/Stiff,84
+Source Sans 3,/Expressive/Business,97.4
 Source Sans 3,/Expressive/Calm,99
-Source Sans 3,/Expressive/Stiff,71
+Source Sans 3,/Expressive/Competent,98.8
 Source Sans 3,/Sans/Humanist,100
-Source Serif 4,/Expressive/Business,99
+Source Sans 3,/Expressive/Stiff,71
+Source Serif 4,/Expressive/Business,99.1
 Source Serif 4,/Expressive/Calm,98
-Source Serif 4,/Expressive/Sincere,100
+Source Serif 4,/Expressive/Competent,99.1
+Source Serif 4,/Expressive/Loud,62
+Source Serif 4,/Expressive/Sincere,94
+Source Serif 4,/Expressive/Vintage,62.4
 Source Serif 4,/Serif/Transitional,100
-Space Grotesk,/Expressive/Business,81
+Space Grotesk,/Expressive/Business,89.4
 Space Grotesk,/Expressive/Calm,95
-Space Grotesk,/Expressive/Competent,76
-Space Grotesk,/Expressive/Stiff,84
+Space Grotesk,/Expressive/Competent,78.5
 Space Grotesk,/Sans/Grotesque,80
 Space Grotesk,/Sans/Neo Grotesque,100
 Space Grotesk,/Theme/Techno,100
+Space Grotesk,/Expressive/Stiff,84
 Space Mono,/Expressive/Business,17
 Space Mono,/Expressive/Calm,72
-Space Mono,/Expressive/Competent,76
+Space Mono,/Expressive/Competent,78.5
 Space Mono,/Expressive/Futuristic,98
-Space Mono,/Expressive/Stiff,84
 Space Mono,/Monospace/Monospace,100
 Space Mono,/Sans/Grotesque,80
 Space Mono,/Sans/Neo Grotesque,100
 Space Mono,/Theme/Techno,100
+Space Mono,/Expressive/Stiff,84
 Special Elite,/Expressive/Awkward,74
 Special Elite,/Expressive/Business,41
 Special Elite,/Expressive/Excited,22
 Special Elite,/Expressive/Innovative,83
 Special Elite,/Expressive/Rugged,98
 Special Elite,/Expressive/Sincere,15
+Special Elite,/Expressive/Vintage,86
 Special Elite,/Slab/Clarendon,100
 Special Elite,/Theme/Distressed,100
 Special Elite,/Theme/Techno,40
-Spectral,/Expressive/Business,79
+Spectral,/Expressive/Business,98.6
 Spectral,/Expressive/Calm,96
-Spectral,/Expressive/Sincere,99
-Spectral,/Expressive/Stiff,60
-Spectral SC,/Expressive/Business,79
-Spectral SC,/Expressive/Calm,96
-Spectral SC,/Expressive/Sincere,99
-Spectral SC,/Expressive/Stiff,60
-Spectral SC,/Serif/Transitional,100
+Spectral,/Expressive/Competent,98.2
+Spectral,/Expressive/Loud,58
+Spectral,/Expressive/Sincere,96
+Spectral,/Expressive/Vintage,82.5
 Spectral,/Serif/Transitional,100
+Spectral,/Expressive/Stiff,60
+Spectral SC,/Expressive/Business,98.6
+Spectral SC,/Expressive/Calm,96
+Spectral SC,/Expressive/Loud,58
+Spectral SC,/Expressive/Sincere,96
+Spectral SC,/Expressive/Vintage,82.5
+Spectral SC,/Serif/Transitional,100
+Spectral SC,/Expressive/Stiff,60
 Spicy Rice,/Expressive/Calm,53
 Spicy Rice,/Expressive/Excited,45
 Spicy Rice,/Expressive/Happy,33
 Spicy Rice,/Expressive/Innovative,34
+Spicy Rice,/Expressive/Loud,94
 Spicy Rice,/Expressive/Rugged,23
-Spicy Rice,/Expressive/Stiff,30
+Spicy Rice,/Expressive/Vintage,90.5
 Spicy Rice,/Theme/Wacky,10
+Spicy Rice,/Expressive/Stiff,30
 Spinnaker,/Expressive/Business,24
 Spinnaker,/Expressive/Calm,95
-Spinnaker,/Expressive/Stiff,62
 Spinnaker,/Sans/Humanist,100
+Spinnaker,/Expressive/Stiff,62
 Spirax,/Expressive/Calm,61
 Spirax,/Expressive/Happy,32
 Spirax,/Expressive/Innovative,55
+Spirax,/Expressive/Vintage,60.2
 Splash,/Expressive/Artistic,97
 Splash,/Expressive/Fancy,93
 Splash,/Expressive/Happy,16
 Splash,/Expressive/Innovative,91
+Splash,/Expressive/Loud,52
 Splash,/Expressive/Rugged,95
+Splash,/Expressive/Vintage,53
 Splash,/Script/Informal,100
 Splash,/Theme/Distressed,50
-Spline Sans,/Expressive/Business,47
+Spline Sans,/Expressive/Business,96.5
 Spline Sans,/Expressive/Calm,97
 Spline Sans,/Expressive/Competent,11
+Spline Sans,/Sans/Neo Grotesque,100
 Spline Sans,/Expressive/Stiff,73
 Spline Sans Mono,/Expressive/Business,14
 Spline Sans Mono,/Expressive/Calm,77
 Spline Sans Mono,/Expressive/Competent,37
 Spline Sans Mono,/Expressive/Futuristic,74
-Spline Sans Mono,/Expressive/Stiff,73
 Spline Sans Mono,/Sans/Neo Grotesque,100
-Spline Sans,/Sans/Neo Grotesque,100
-Squada One,/Expressive/Business,77
+Spline Sans Mono,/Expressive/Stiff,73
 Squada One,/Expressive/Calm,65
-Squada One,/Expressive/Competent,85
+Squada One,/Expressive/Competent,94.9
 Squada One,/Expressive/Futuristic,72
-Squada One,/Expressive/Stiff,98
+Squada One,/Expressive/Vintage,79.4
 Squada One,/Sans/Grotesque,100
 Squada One,/Sans/Superellipse,80
 Squada One,/Theme/Woodtype,70
+Squada One,/Expressive/Stiff,98
 Square Peg,/Expressive/Active,78
 Square Peg,/Expressive/Artistic,12
 Square Peg,/Expressive/Awkward,55
@@ -7403,10 +8147,13 @@ Square Peg,/Expressive/Childlike,43
 Square Peg,/Expressive/Cute,15
 Square Peg,/Expressive/Innovative,41
 Square Peg,/Expressive/Playful,34
+Square Peg,/Expressive/Sincere,98
+Square Peg,/Expressive/Vintage,24.5
 Square Peg,/Script/Informal,100
-Sree Krushnadevaraya,/Expressive/Business,68
+Sree Krushnadevaraya,/Expressive/Business,68.9
 Sree Krushnadevaraya,/Expressive/Calm,97
-Sree Krushnadevaraya,/Expressive/Sincere,97
+Sree Krushnadevaraya,/Expressive/Loud,20
+Sree Krushnadevaraya,/Expressive/Vintage,74.2
 Sree Krushnadevaraya,/Serif/Modern,100
 Sriracha,/Expressive/Active,99
 Sriracha,/Expressive/Artistic,3
@@ -7415,6 +8162,8 @@ Sriracha,/Expressive/Cute,27
 Sriracha,/Expressive/Excited,44
 Sriracha,/Expressive/Innovative,31
 Sriracha,/Expressive/Rugged,7
+Sriracha,/Expressive/Sincere,94
+Sriracha,/Expressive/Vintage,67.5
 Sriracha,/Script/Handwritten,100
 Srisakdi,/Expressive/Active,23
 Srisakdi,/Expressive/Artistic,13
@@ -7428,86 +8177,95 @@ Srisakdi,/Theme/Techno,10
 Srisakdi,/Theme/Wacky,10
 Staatliches,/Expressive/Business,38
 Staatliches,/Expressive/Calm,99
-Staatliches,/Expressive/Competent,89
+Staatliches,/Expressive/Competent,94.8
 Staatliches,/Expressive/Futuristic,74
-Staatliches,/Expressive/Stiff,91
+Staatliches,/Expressive/Vintage,69.3
 Staatliches,/Sans/Grotesque,100
+Staatliches,/Expressive/Stiff,91
 Stalemate,/Expressive/Artistic,69
 Stalemate,/Expressive/Fancy,35
+Stalemate,/Expressive/Vintage,90.5
 Stalemate,/Script/Upright Script,100
 Stalinist One,/Expressive/Artistic,91
 Stalinist One,/Expressive/Awkward,12
 Stalinist One,/Expressive/Calm,52
-Stalinist One,/Expressive/Competent,48
 Stalinist One,/Expressive/Futuristic,99
-Stalinist One,/Expressive/Stiff,99
+Stalinist One,/Expressive/Vintage,90.5
 Stalinist One,/Theme/Techno,80
 Stalinist One,/Theme/Woodtype,30
+Stalinist One,/Expressive/Stiff,99
 Stardos Stencil,/Expressive/Business,11
 Stardos Stencil,/Expressive/Calm,99
 Stardos Stencil,/Expressive/Sincere,27
-Stardos Stencil,/Expressive/Stiff,71
+Stardos Stencil,/Expressive/Vintage,83
 Stardos Stencil,/Serif/Scotch,50
 Stardos Stencil,/Theme/Stencil,100
+Stardos Stencil,/Expressive/Stiff,71
 Stick,/Expressive/Awkward,80
 Stick,/Expressive/Childlike,73
 Stick,/Expressive/Excited,53
 Stick,/Expressive/Happy,30
 Stick,/Expressive/Innovative,46
+Stick,/Theme/Wacky,40
 Stick No Bills,/Expressive/Innovative,32
 Stick No Bills,/Expressive/Rugged,95
-Stick No Bills,/Expressive/Stiff,92
 Stick No Bills,/Theme/Stencil,100
-Stick,/Theme/Wacky,40
-Stint Ultra Condensed,/Expressive/Business,72
+Stick No Bills,/Expressive/Stiff,92
+Stint Ultra Condensed,/Expressive/Business,50.4
 Stint Ultra Condensed,/Expressive/Futuristic,54
 Stint Ultra Condensed,/Expressive/Sincere,33
-Stint Ultra Condensed,/Expressive/Stiff,75
+Stint Ultra Condensed,/Expressive/Vintage,81.5
 Stint Ultra Condensed,/Slab/Geometric,50
-Stint Ultra Expanded,/Expressive/Business,51
+Stint Ultra Condensed,/Expressive/Stiff,75
+Stint Ultra Expanded,/Expressive/Business,52.9
 Stint Ultra Expanded,/Expressive/Calm,98
 Stint Ultra Expanded,/Expressive/Sincere,33
-Stint Ultra Expanded,/Expressive/Stiff,74
+Stint Ultra Expanded,/Expressive/Vintage,38.7
 Stint Ultra Expanded,/Slab/Geometric,50
-STIX Two Math,/Expressive/Business,100
+Stint Ultra Expanded,/Expressive/Stiff,74
+STIX Two Math,/Expressive/Business,99.1
 STIX Two Math,/Expressive/Calm,99
-STIX Two Math,/Expressive/Sincere,100
-STIX Two Math,/Expressive/Stiff,70
+STIX Two Math,/Expressive/Vintage,81
 STIX Two Math,/Serif/Transitional,100
-STIX Two Text,/Expressive/Business,100
+STIX Two Math,/Expressive/Stiff,70
+STIX Two Text,/Expressive/Business,99.1
 STIX Two Text,/Expressive/Calm,99
-STIX Two Text,/Expressive/Sincere,100
-STIX Two Text,/Expressive/Stiff,70
+STIX Two Text,/Expressive/Vintage,81
 STIX Two Text,/Serif/Transitional,100
+STIX Two Text,/Expressive/Stiff,70
 Stoke,/Expressive/Business,42
 Stoke,/Expressive/Calm,93
-Stoke,/Expressive/Sincere,90
-Stoke,/Expressive/Stiff,50
+Stoke,/Expressive/Sincere,95
+Stoke,/Expressive/Vintage,70.1
 Stoke,/Serif/Old Style Garalde,100
-Strait,/Expressive/Business,54
+Stoke,/Expressive/Stiff,50
+Strait,/Expressive/Business,54.1
 Strait,/Expressive/Calm,97
-Strait,/Expressive/Competent,75
-Strait,/Expressive/Stiff,79
+Strait,/Expressive/Competent,89.5
 Strait,/Sans/Geometric,10
 Strait,/Sans/Humanist,50
 Strait,/Sans/Neo Grotesque,20
 Strait,/Sans/Superellipse,60
+Strait,/Expressive/Stiff,79
 Strong,/Expressive/Calm,85
-Strong,/Expressive/Competent,54
+Strong,/Expressive/Competent,79.4
 Strong,/Expressive/Futuristic,97
-Strong,/Expressive/Stiff,99
 Strong,/Sans/Geometric,10
 Strong,/Sans/Humanist,60
 Strong,/Sans/Superellipse,80
+Strong,/Expressive/Stiff,99
 Style Script,/Expressive/Artistic,80
 Style Script,/Expressive/Childlike,61
 Style Script,/Expressive/Fancy,74
+Style Script,/Expressive/Loud,23
+Style Script,/Expressive/Vintage,78.1
 Style Script,/Script/Upright Script,100
 Stylish,/Expressive/Awkward,77
 Stylish,/Expressive/Calm,65
 Stylish,/Expressive/Innovative,33
 Stylish,/Expressive/Playful,46
 Stylish,/Expressive/Rugged,71
+Stylish,/Expressive/Vintage,49.5
 Stylish,/Theme/Blobby,90
 Stylish,/Theme/Distressed,60
 Sue Ellen Francisco,/Expressive/Awkward,72
@@ -7517,26 +8275,27 @@ Sue Ellen Francisco,/Expressive/Cute,14
 Sue Ellen Francisco,/Expressive/Innovative,11
 Sue Ellen Francisco,/Expressive/Playful,48
 Sue Ellen Francisco,/Expressive/Rugged,9
+Sue Ellen Francisco,/Expressive/Sincere,97
 Sue Ellen Francisco,/Script/Handwritten,100
-Suez One,/Expressive/Business,95
 Suez One,/Expressive/Calm,97
-Suez One,/Expressive/Sincere,90
+Suez One,/Expressive/Vintage,32.4
 Suez One,/Expressive/Stiff,52
 Sulphur Point,/Expressive/Business,17
 Sulphur Point,/Expressive/Calm,99
+Sulphur Point,/Expressive/Vintage,82.5
 Sulphur Point,/Sans/Geometric,100
-Sumana,/Expressive/Business,58
+Sumana,/Expressive/Business,58.8
 Sumana,/Expressive/Calm,97
-Sumana,/Expressive/Sincere,91
-Sumana,/Expressive/Stiff,51
+Sumana,/Expressive/Vintage,76.3
 Sumana,/Serif/Transitional,60
-Sunflower,/Expressive/Business,66
+Sumana,/Expressive/Stiff,51
+Sunflower,/Expressive/Business,61.3
 Sunflower,/Expressive/Calm,82
 Sunflower,/Expressive/Futuristic,59
-Sunflower,/Expressive/Stiff,56
 Sunflower,/Sans/Geometric,20
 Sunflower,/Sans/Humanist,40
 Sunflower,/Sans/Superellipse,40
+Sunflower,/Expressive/Stiff,56
 Sunshiney,/Expressive/Awkward,73
 Sunshiney,/Expressive/Childlike,97
 Sunshiney,/Expressive/Cute,38
@@ -7549,96 +8308,95 @@ Sunshiney,/Expressive/Rugged,64
 Sunshiney,/Script/Handwritten,100
 Supermercado One,/Expressive/Business,22
 Supermercado One,/Expressive/Calm,74
-Supermercado One,/Expressive/Competent,89
 Supermercado One,/Expressive/Cute,13
 Supermercado One,/Expressive/Futuristic,73
-Supermercado One,/Expressive/Stiff,65
 Supermercado One,/Sans/Neo Grotesque,40
 Supermercado One,/Sans/Rounded,100
 Supermercado One,/Sans/Superellipse,80
+Supermercado One,/Expressive/Stiff,65
 Sura,/Expressive/Business,37
 Sura,/Expressive/Calm,95
-Sura,/Expressive/Sincere,98
+Sura,/Slab/Humanist,100
 Suranna,/Expressive/Business,27
 Suranna,/Expressive/Calm,94
 Suranna,/Expressive/Sincere,84
+Suranna,/Expressive/Vintage,78.7
 Suranna,/Serif/Didone,100
-Sura,/Slab/Humanist,100
-Suravaram,/Expressive/Business,71
+Suravaram,/Expressive/Business,51.8
 Suravaram,/Expressive/Calm,94
-Suravaram,/Expressive/Sincere,95
-SUSE,/Expressive/Business,100
+Suravaram,/Expressive/Vintage,69.3
 SUSE,/Expressive/Calm,80
-SUSE,/Expressive/Competent,100
 SUSE,/Expressive/Futuristic,70
 SUSE,/Expressive/Happy,70
 SUSE,/Expressive/Innovative,80
-SUSE,/Expressive/Sincere,60
 SUSE,/Sans/Geometric,100
 SUSE,/Sans/Humanist,40
 SUSE,/Sans/Superellipse,50
 Suwannaphum,/Expressive/Business,70
 Suwannaphum,/Expressive/Calm,98
-Suwannaphum,/Expressive/Sincere,99
-Suwannaphum,/Expressive/Stiff,72
+Suwannaphum,/Expressive/Vintage,78.7
 Suwannaphum,/Slab/Geometric,70
 Suwannaphum,/Slab/Humanist,10
+Suwannaphum,/Expressive/Stiff,72
 Swanky and Moo Moo,/Expressive/Awkward,75
 Swanky and Moo Moo,/Expressive/Childlike,79
 Swanky and Moo Moo,/Expressive/Happy,76
 Swanky and Moo Moo,/Expressive/Innovative,73
 Swanky and Moo Moo,/Expressive/Rugged,53
+Swanky and Moo Moo,/Expressive/Sincere,96
 Swanky and Moo Moo,/Script/Handwritten,100
-Syncopate,/Expressive/Business,73
 Syncopate,/Expressive/Calm,73
-Syncopate,/Expressive/Competent,71
+Syncopate,/Expressive/Competent,85.2
 Syncopate,/Expressive/Futuristic,92
 Syncopate,/Expressive/Happy,19
 Syncopate,/Expressive/Playful,61
-Syncopate,/Expressive/Stiff,75
 Syncopate,/Sans/Geometric,60
 Syncopate,/Sans/Humanist,50
 Syncopate,/Theme/Techno,10
 Syncopate,/Theme/Wacky,30
+Syncopate,/Expressive/Stiff,75
 Syne,/Expressive/Business,46
 Syne,/Expressive/Calm,97
 Syne,/Expressive/Competent,78
+Syne,/Sans/Neo Grotesque,100
 Syne,/Expressive/Stiff,63
 Syne Mono,/Expressive/Awkward,78
 Syne Mono,/Expressive/Futuristic,94
 Syne Mono,/Expressive/Happy,72
 Syne Mono,/Expressive/Innovative,73
+Syne Mono,/Expressive/Loud,5
 Syne Mono,/Expressive/Playful,58
 Syne Mono,/Expressive/Rugged,77
-Syne Mono,/Expressive/Stiff,82
 Syne Mono,/Monospace/Monospace,100
 Syne Mono,/Theme/Distressed,90
 Syne Mono,/Theme/Techno,100
 Syne Mono,/Theme/Wacky,20
-Syne,/Sans/Neo Grotesque,100
+Syne Mono,/Expressive/Stiff,82
 Syne Tactile,/Expressive/Awkward,63
 Syne Tactile,/Expressive/Childlike,23
 Syne Tactile,/Expressive/Excited,66
 Syne Tactile,/Expressive/Innovative,83
 Syne Tactile,/Expressive/Playful,12
 Syne Tactile,/Expressive/Rugged,80
+Syne Tactile,/Expressive/Sincere,97
 Syne Tactile,/Theme/Distressed,50
 Syne Tactile,/Theme/Wacky,30
-Tai Heritage Pro,/Expressive/Business,99
+Tai Heritage Pro,/Expressive/Business,98.8
 Tai Heritage Pro,/Expressive/Calm,98
-Tai Heritage Pro,/Expressive/Sincere,97
-Tai Heritage Pro,/Expressive/Stiff,60
+Tai Heritage Pro,/Expressive/Vintage,76
 Tai Heritage Pro,/Serif/Transitional,100
+Tai Heritage Pro,/Expressive/Stiff,60
 Tajawal,/Arabic/Kufi,30
 Tajawal,/Arabic/Naskh,50
-Tajawal,/Expressive/Business,56
+Tajawal,/Expressive/Business,56.3
 Tajawal,/Expressive/Calm,99
 Tajawal,/Expressive/Competent,11
-Tajawal,/Expressive/Stiff,61
 Tajawal,/Sans/Humanist,100
+Tajawal,/Expressive/Stiff,61
 Tangerine,/Expressive/Artistic,89
 Tangerine,/Expressive/Childlike,16
 Tangerine,/Expressive/Fancy,92
+Tangerine,/Expressive/Loud,22
 Tangerine,/Script/Formal,100
 Tapestry,/Expressive/Active,21
 Tapestry,/Expressive/Innovative,91
@@ -7650,67 +8408,75 @@ Taprom,/Expressive/Happy,13
 Taprom,/Expressive/Innovative,82
 Taprom,/Expressive/Rugged,88
 Taprom,/Theme/Distressed,100
-Tauri,/Expressive/Business,68
+Tauri,/Expressive/Business,68.5
 Tauri,/Expressive/Calm,98
 Tauri,/Expressive/Competent,43
-Tauri,/Expressive/Stiff,64
+Tauri,/Expressive/Vintage,28
 Tauri,/Sans/Grotesque,20
 Tauri,/Sans/Humanist,80
+Tauri,/Expressive/Stiff,64
 Taviraj,/Expressive/Business,38
 Taviraj,/Expressive/Calm,96
+Taviraj,/Expressive/Loud,45
 Taviraj,/Expressive/Sincere,77
 Taviraj,/Serif/Modern,50
-Teko,/Expressive/Business,57
+Teko,/Expressive/Business,56
 Teko,/Expressive/Calm,87
-Teko,/Expressive/Competent,89
+Teko,/Expressive/Competent,93
 Teko,/Expressive/Futuristic,98
-Teko,/Expressive/Stiff,100
 Teko,/Indic/Low contrast,100
 Teko,/Sans/Geometric,10
 Teko,/Sans/Superellipse,40
+Teko,/Expressive/Stiff,100
 Tektur,/Expressive/Calm,72
 Tektur,/Expressive/Futuristic,100
-Tektur,/Expressive/Stiff,100
+Tektur,/Expressive/Vintage,57.8
 Tektur,/Sans/Geometric,80
 Tektur,/Sans/Superellipse,50
 Tektur,/Theme/Techno,80
-Telex,/Expressive/Business,66
+Tektur,/Expressive/Stiff,100
+Telex,/Expressive/Business,94.2
 Telex,/Expressive/Calm,99
 Telex,/Expressive/Competent,44
-Telex,/Expressive/Stiff,65
 Telex,/Sans/Humanist,100
+Telex,/Expressive/Stiff,65
 Tenali Ramakrishna,/Expressive/Awkward,41
 Tenali Ramakrishna,/Expressive/Business,41
 Tenali Ramakrishna,/Expressive/Calm,91
 Tenali Ramakrishna,/Expressive/Sincere,20
+Tenali Ramakrishna,/Expressive/Vintage,78.9
 Tenali Ramakrishna,/Sans/Geometric,30
 Tenali Ramakrishna,/Sans/Humanist,30
 Tenali Ramakrishna,/Sans/Neo Grotesque,50
 Tenor Sans,/Expressive/Calm,97
+Tenor Sans,/Expressive/Loud,61
+Tenor Sans,/Expressive/Vintage,83
 Tenor Sans,/Sans/Geometric,40
 Tenor Sans,/Sans/Humanist,50
 Text Me One,/Expressive/Calm,72
-Text Me One,/Expressive/Competent,75
 Text Me One,/Expressive/Futuristic,92
-Text Me One,/Expressive/Stiff,83
 Text Me One,/Sans/Geometric,80
 Text Me One,/Sans/Neo Grotesque,30
 Text Me One,/Sans/Superellipse,70
+Text Me One,/Expressive/Stiff,83
 Texturina,/Expressive/Futuristic,95
 Texturina,/Expressive/Innovative,72
+Texturina,/Expressive/Loud,63
 Texturina,/Expressive/Sincere,37
-Texturina,/Expressive/Stiff,71
+Texturina,/Expressive/Vintage,98
 Texturina,/Theme/Blackletter,80
+Texturina,/Expressive/Stiff,71
 Thabit,/Expressive/Futuristic,83
 Thabit,/Expressive/Sincere,65
-Thabit,/Expressive/Stiff,81
+Thabit,/Expressive/Vintage,78.3
 Thabit,/Slab/Geometric,100
+Thabit,/Expressive/Stiff,81
 Thasadith,/Expressive/Business,38
 Thasadith,/Expressive/Calm,93
 Thasadith,/Expressive/Competent,56
-Thasadith,/Expressive/Stiff,62
 Thasadith,/Sans/Humanist,100
 Thasadith,/Sans/Rounded,90
+Thasadith,/Expressive/Stiff,62
 The Girl Next Door,/Expressive/Awkward,74
 The Girl Next Door,/Expressive/Childlike,99
 The Girl Next Door,/Expressive/Excited,32
@@ -7721,13 +8487,17 @@ The Girl Next Door,/Script/Handwritten,100
 The Nautigal,/Expressive/Artistic,89
 The Nautigal,/Expressive/Fancy,74
 The Nautigal,/Expressive/Innovative,62
+The Nautigal,/Expressive/Loud,71
 The Nautigal,/Expressive/Rugged,31
+The Nautigal,/Expressive/Vintage,57.3
 The Nautigal,/Script/Formal,60
 Tienne,/Expressive/Business,47
 Tienne,/Expressive/Calm,96
+Tienne,/Expressive/Loud,56
 Tienne,/Expressive/Sincere,78
-Tienne,/Expressive/Stiff,70
+Tienne,/Expressive/Vintage,58.9
 Tienne,/Serif/Modern,30
+Tienne,/Expressive/Stiff,70
 Tillana,/Expressive/Active,62
 Tillana,/Expressive/Awkward,51
 Tillana,/Expressive/Happy,18
@@ -7741,182 +8511,189 @@ Tilt Neon,/Expressive/Calm,94
 Tilt Neon,/Expressive/Competent,26
 Tilt Neon,/Expressive/Happy,51
 Tilt Neon,/Expressive/Innovative,100
-Tilt Neon,/Expressive/Stiff,20
+Tilt Neon,/Expressive/Vintage,69.7
 Tilt Neon,/Sans/Geometric,100
 Tilt Neon,/Theme/Techno,70
+Tilt Neon,/Expressive/Stiff,20
 Tilt Prism,/Expressive/Artistic,74
-Tilt Prism,/Expressive/Business,78
 Tilt Prism,/Expressive/Futuristic,94
 Tilt Prism,/Expressive/Innovative,100
-Tilt Prism,/Expressive/Stiff,82
+Tilt Prism,/Expressive/Vintage,84.5
 Tilt Prism,/Serif/Humanist Venetian,100
 Tilt Prism,/Theme/Inline,50
-Tilt Warp,/Expressive/Business,79
+Tilt Prism,/Expressive/Stiff,82
 Tilt Warp,/Expressive/Calm,98
 Tilt Warp,/Expressive/Innovative,100
-Tilt Warp,/Expressive/Stiff,63
+Tilt Warp,/Expressive/Vintage,84.5
 Tilt Warp,/Sans/Geometric,80
 Tilt Warp,/Sans/Humanist,10
+Tilt Warp,/Expressive/Stiff,63
 Timmana,/Expressive/Business,61
 Timmana,/Expressive/Calm,69
-Timmana,/Expressive/Competent,79
-Timmana,/Expressive/Stiff,52
+Timmana,/Expressive/Competent,83
 Timmana,/Sans/Humanist,100
-Tinos,/Expressive/Business,98
+Timmana,/Expressive/Stiff,52
+Tinos,/Expressive/Business,99.9
 Tinos,/Expressive/Calm,97
-Tinos,/Expressive/Sincere,98
-Tinos,/Expressive/Stiff,70
+Tinos,/Expressive/Vintage,72.1
 Tinos,/Serif/Transitional,50
+Tinos,/Expressive/Stiff,70
 Tiny5,/Theme/Pixel,100
-Tiro Bangla,/Expressive/Business,100
 Tiro Bangla,/Expressive/Calm,99
-Tiro Bangla,/Expressive/Sincere,100
-Tiro Bangla,/Expressive/Stiff,70
+Tiro Bangla,/Expressive/Loud,71
+Tiro Bangla,/Expressive/Vintage,76.3
 Tiro Bangla,/Indic/Contemporary,100
 Tiro Bangla,/Serif/Transitional,100
-Tiro Devanagari Hindi,/Expressive/Business,100
+Tiro Bangla,/Expressive/Stiff,70
 Tiro Devanagari Hindi,/Expressive/Calm,99
-Tiro Devanagari Hindi,/Expressive/Sincere,100
-Tiro Devanagari Hindi,/Expressive/Stiff,70
+Tiro Devanagari Hindi,/Expressive/Loud,71
+Tiro Devanagari Hindi,/Expressive/Vintage,76.3
 Tiro Devanagari Hindi,/Indic/Contemporary,100
 Tiro Devanagari Hindi,/Serif/Transitional,100
-Tiro Devanagari Marathi,/Expressive/Business,100
+Tiro Devanagari Hindi,/Expressive/Stiff,70
 Tiro Devanagari Marathi,/Expressive/Calm,99
-Tiro Devanagari Marathi,/Expressive/Sincere,100
-Tiro Devanagari Marathi,/Expressive/Stiff,70
+Tiro Devanagari Marathi,/Expressive/Loud,71
+Tiro Devanagari Marathi,/Expressive/Vintage,76.3
 Tiro Devanagari Marathi,/Indic/Contemporary,100
 Tiro Devanagari Marathi,/Serif/Transitional,100
-Tiro Devanagari Sanskrit,/Expressive/Business,100
+Tiro Devanagari Marathi,/Expressive/Stiff,70
 Tiro Devanagari Sanskrit,/Expressive/Calm,99
-Tiro Devanagari Sanskrit,/Expressive/Sincere,100
-Tiro Devanagari Sanskrit,/Expressive/Stiff,70
+Tiro Devanagari Sanskrit,/Expressive/Loud,71
+Tiro Devanagari Sanskrit,/Expressive/Vintage,76.3
 Tiro Devanagari Sanskrit,/Indic/Contemporary,100
 Tiro Devanagari Sanskrit,/Serif/Transitional,100
-Tiro Gurmukhi,/Expressive/Business,100
+Tiro Devanagari Sanskrit,/Expressive/Stiff,70
 Tiro Gurmukhi,/Expressive/Calm,99
-Tiro Gurmukhi,/Expressive/Sincere,100
-Tiro Gurmukhi,/Expressive/Stiff,70
+Tiro Gurmukhi,/Expressive/Loud,71
+Tiro Gurmukhi,/Expressive/Vintage,76.3
 Tiro Gurmukhi,/Indic/Contemporary,100
 Tiro Gurmukhi,/Serif/Transitional,100
-Tiro Kannada,/Expressive/Business,100
+Tiro Gurmukhi,/Expressive/Stiff,70
 Tiro Kannada,/Expressive/Calm,99
-Tiro Kannada,/Expressive/Sincere,100
-Tiro Kannada,/Expressive/Stiff,70
+Tiro Kannada,/Expressive/Loud,71
+Tiro Kannada,/Expressive/Vintage,76.3
 Tiro Kannada,/Indic/Contemporary,100
 Tiro Kannada,/Serif/Transitional,100
-Tiro Tamil,/Expressive/Business,100
+Tiro Kannada,/Expressive/Stiff,70
 Tiro Tamil,/Expressive/Calm,99
-Tiro Tamil,/Expressive/Sincere,100
-Tiro Tamil,/Expressive/Stiff,70
+Tiro Tamil,/Expressive/Loud,71
+Tiro Tamil,/Expressive/Vintage,76.3
 Tiro Tamil,/Indic/Contemporary,100
 Tiro Tamil,/Serif/Transitional,100
-Tiro Telugu,/Expressive/Business,100
+Tiro Tamil,/Expressive/Stiff,70
 Tiro Telugu,/Expressive/Calm,99
-Tiro Telugu,/Expressive/Sincere,100
-Tiro Telugu,/Expressive/Stiff,70
+Tiro Telugu,/Expressive/Loud,71
+Tiro Telugu,/Expressive/Vintage,76.3
 Tiro Telugu,/Indic/Contemporary,100
 Tiro Telugu,/Serif/Transitional,100
-Titan One,/Expressive/Business,51
+Tiro Telugu,/Expressive/Stiff,70
+Titan One,/Expressive/Business,50.2
 Titan One,/Expressive/Calm,63
-Titan One,/Expressive/Competent,63
+Titan One,/Expressive/Competent,88.5
 Titan One,/Expressive/Cute,30
 Titan One,/Expressive/Futuristic,42
+Titan One,/Expressive/Loud,100
 Titan One,/Expressive/Playful,35
-Titan One,/Expressive/Stiff,92
 Titan One,/Sans/Humanist,100
+Titan One,/Expressive/Stiff,92
 Titillium Web,/Expressive/Business,44
 Titillium Web,/Expressive/Calm,99
-Titillium Web,/Expressive/Competent,59
-Titillium Web,/Expressive/Stiff,67
+Titillium Web,/Expressive/Competent,88.9
 Titillium Web,/Sans/Geometric,20
 Titillium Web,/Sans/Grotesque,60
 Titillium Web,/Sans/Humanist,20
+Titillium Web,/Expressive/Stiff,67
 Tomorrow,/Expressive/Business,35
 Tomorrow,/Expressive/Calm,86
 Tomorrow,/Expressive/Competent,53
 Tomorrow,/Expressive/Futuristic,98
-Tomorrow,/Expressive/Stiff,100
 Tomorrow,/Sans/Geometric,80
 Tomorrow,/Theme/Techno,50
+Tomorrow,/Expressive/Stiff,100
 Tourney,/Expressive/Futuristic,99
 Tourney,/Expressive/Innovative,71
-Tourney,/Expressive/Stiff,100
 Tourney,/Sans/Geometric,80
 Tourney,/Theme/Techno,80
+Tourney,/Expressive/Stiff,100
 Trade Winds,/Expressive/Active,93
 Trade Winds,/Expressive/Awkward,13
 Trade Winds,/Expressive/Excited,52
 Trade Winds,/Expressive/Innovative,71
 Trade Winds,/Expressive/Rugged,78
+Trade Winds,/Expressive/Vintage,89.5
 Trade Winds,/Theme/Distressed,90
 Train One,/Expressive/Futuristic,36
 Train One,/Expressive/Innovative,97
-Train One,/Expressive/Stiff,51
 Train One,/Theme/Inline,100
 Train One,/Theme/Techno,30
-Trirong,/Expressive/Business,80
+Train One,/Expressive/Stiff,51
+Trirong,/Expressive/Business,87.7
 Trirong,/Expressive/Calm,96
+Trirong,/Expressive/Loud,55
 Trirong,/Expressive/Sincere,78
+Trirong,/Expressive/Vintage,43.9
 Trirong,/Serif/Modern,30
 Trispace,/Expressive/Business,11
 Trispace,/Expressive/Calm,74
 Trispace,/Expressive/Competent,19
 Trispace,/Expressive/Futuristic,92
-Trispace,/Expressive/Stiff,71
+Trispace,/Expressive/Vintage,64.7
 Trispace,/Sans/Humanist,50
 Trispace,/Sans/Neo Grotesque,30
-Trocchi,/Expressive/Business,93
+Trispace,/Expressive/Stiff,71
+Trocchi,/Expressive/Business,89.8
 Trocchi,/Expressive/Calm,97
-Trocchi,/Expressive/Sincere,92
-Trocchi,/Expressive/Stiff,70
+Trocchi,/Expressive/Vintage,84.5
 Trocchi,/Serif/Scotch,100
+Trocchi,/Expressive/Stiff,70
 Trochut,/Expressive/Awkward,11
 Trochut,/Expressive/Calm,76
 Trochut,/Expressive/Futuristic,52
 Trochut,/Expressive/Happy,33
+Trochut,/Expressive/Loud,77
 Trochut,/Expressive/Stiff,70
 Truculenta,/Expressive/Calm,62
 Truculenta,/Expressive/Childlike,46
-Truculenta,/Expressive/Competent,76
 Truculenta,/Expressive/Futuristic,72
 Truculenta,/Expressive/Innovative,32
 Truculenta,/Expressive/Playful,34
-Truculenta,/Expressive/Stiff,71
 Truculenta,/Sans/Grotesque,80
 Truculenta,/Sans/Neo Grotesque,30
-Trykker,/Expressive/Business,80
+Truculenta,/Expressive/Stiff,71
+Trykker,/Expressive/Business,79.7
 Trykker,/Expressive/Calm,97
-Trykker,/Expressive/Sincere,98
-Trykker,/Expressive/Stiff,70
+Trykker,/Expressive/Sincere,92
+Trykker,/Expressive/Vintage,78.7
 Trykker,/Serif/Transitional,100
+Trykker,/Expressive/Stiff,70
 Tsukimi Rounded,/Expressive/Calm,71
 Tsukimi Rounded,/Expressive/Childlike,34
 Tsukimi Rounded,/Expressive/Competent,41
 Tsukimi Rounded,/Expressive/Cute,4
 Tsukimi Rounded,/Expressive/Happy,53
 Tsukimi Rounded,/Expressive/Playful,52
-Tsukimi Rounded,/Expressive/Stiff,60
 Tsukimi Rounded,/Sans/Geometric,80
 Tsukimi Rounded,/Sans/Rounded,100
 Tsukimi Rounded,/Theme/Blobby,3
 Tsukimi Rounded,/Theme/Techno,10
 Tsukimi Rounded,/Theme/Wacky,10
-Tuffy,/Expressive/Business,53
+Tsukimi Rounded,/Expressive/Stiff,60
+Tuffy,/Expressive/Business,53.1
 Tuffy,/Expressive/Calm,99
-Tuffy,/Expressive/Stiff,72
+Tuffy,/Expressive/Vintage,62
 Tuffy,/Sans/Grotesque,40
 Tuffy,/Sans/Neo Grotesque,80
+Tuffy,/Expressive/Stiff,72
 Tulpen One,/Expressive/Calm,63
-Tulpen One,/Expressive/Competent,79
 Tulpen One,/Expressive/Futuristic,82
-Tulpen One,/Expressive/Stiff,100
 Tulpen One,/Sans/Geometric,80
 Tulpen One,/Sans/Superellipse,20
 Tulpen One,/Theme/Techno,10
+Tulpen One,/Expressive/Stiff,100
 Turret Road,/Expressive/Calm,78
 Turret Road,/Expressive/Futuristic,97
-Turret Road,/Expressive/Stiff,99
 Turret Road,/Theme/Techno,100
+Turret Road,/Expressive/Stiff,99
 Twinkle Star,/Expressive/Awkward,11
 Twinkle Star,/Expressive/Childlike,96
 Twinkle Star,/Expressive/Excited,52
@@ -7926,47 +8703,53 @@ Twinkle Star,/Expressive/Innovative,41
 Twinkle Star,/Expressive/Playful,16
 Twinkle Star,/Script/Handwritten,80
 Twinkle Star,/Script/Informal,70
-Ubuntu Condensed,/Expressive/Business,85
-Ubuntu Condensed,/Expressive/Calm,79
-Ubuntu Condensed,/Expressive/Competent,74
-Ubuntu Condensed,/Expressive/Futuristic,18
-Ubuntu Condensed,/Expressive/Stiff,74
-Ubuntu Condensed,/Sans/Neo Grotesque,100
-Ubuntu,/Expressive/Business,85
+Ubuntu,/Expressive/Business,55.6
 Ubuntu,/Expressive/Calm,79
-Ubuntu,/Expressive/Competent,46
+Ubuntu,/Expressive/Competent,94.7
 Ubuntu,/Expressive/Futuristic,18
+Ubuntu,/Sans/Neo Grotesque,100
 Ubuntu,/Expressive/Stiff,74
-Ubuntu Mono,/Expressive/Business,85
+Ubuntu Condensed,/Expressive/Business,55.6
+Ubuntu Condensed,/Expressive/Calm,79
+Ubuntu Condensed,/Expressive/Competent,94.7
+Ubuntu Condensed,/Expressive/Futuristic,18
+Ubuntu Condensed,/Sans/Neo Grotesque,100
+Ubuntu Condensed,/Expressive/Stiff,74
+Ubuntu Mono,/Expressive/Business,55.6
 Ubuntu Mono,/Expressive/Calm,73
-Ubuntu Mono,/Expressive/Competent,64
+Ubuntu Mono,/Expressive/Competent,94.7
 Ubuntu Mono,/Expressive/Futuristic,77
-Ubuntu Mono,/Expressive/Stiff,74
 Ubuntu Mono,/Monospace/Monospace,100
 Ubuntu Mono,/Sans/Neo Grotesque,100
-Ubuntu,/Sans/Neo Grotesque,100
+Ubuntu Mono,/Expressive/Stiff,74
 Uchen,/Expressive/Business,37
 Uchen,/Expressive/Calm,97
 Uchen,/Expressive/Rugged,22
 Uchen,/Expressive/Sincere,71
-Uchen,/Expressive/Stiff,60
+Uchen,/Expressive/Vintage,70.7
 Uchen,/Serif/Modern,100
+Uchen,/Expressive/Stiff,60
 Ultra,/Expressive/Calm,97
-Ultra,/Expressive/Stiff,60
+Ultra,/Expressive/Competent,95
+Ultra,/Expressive/Loud,100
+Ultra,/Expressive/Vintage,84.5
 Ultra,/Slab/Clarendon,90
+Ultra,/Expressive/Stiff,60
 Unbounded,/Expressive/Awkward,31
 Unbounded,/Expressive/Business,21
 Unbounded,/Expressive/Calm,77
 Unbounded,/Expressive/Competent,69
 Unbounded,/Expressive/Futuristic,20
 Unbounded,/Expressive/Happy,24
-Unbounded,/Expressive/Stiff,74
 Unbounded,/Sans/Humanist,50
 Unbounded,/Sans/Neo Grotesque,50
+Unbounded,/Expressive/Stiff,74
 Uncial Antiqua,/Expressive/Artistic,39
 Uncial Antiqua,/Expressive/Calm,74
 Uncial Antiqua,/Expressive/Innovative,73
+Uncial Antiqua,/Expressive/Loud,65
 Uncial Antiqua,/Expressive/Playful,41
+Uncial Antiqua,/Expressive/Vintage,98
 Uncial Antiqua,/Theme/Medieval,80
 Underdog,/Expressive/Awkward,76
 Underdog,/Expressive/Calm,16
@@ -7978,18 +8761,21 @@ Underdog,/Expressive/Rugged,16
 Underdog,/Theme/Distressed,70
 Underdog,/Theme/Wacky,70
 Unica One,/Expressive/Calm,79
-Unica One,/Expressive/Competent,87
+Unica One,/Expressive/Competent,85.1
 Unica One,/Expressive/Futuristic,93
 Unica One,/Expressive/Innovative,51
-Unica One,/Expressive/Stiff,96
 Unica One,/Sans/Geometric,80
 Unica One,/Sans/Neo Grotesque,40
+Unica One,/Expressive/Stiff,96
 UnifrakturCook,/Expressive/Artistic,90
 UnifrakturCook,/Expressive/Awkward,16
 UnifrakturCook,/Expressive/Calm,62
+UnifrakturCook,/Expressive/Loud,79
+UnifrakturCook,/Expressive/Vintage,100
 UnifrakturCook,/Theme/Blackletter,100
 UnifrakturMaguntia,/Expressive/Artistic,100
 UnifrakturMaguntia,/Expressive/Calm,35
+UnifrakturMaguntia,/Expressive/Vintage,100
 UnifrakturMaguntia,/Theme/Blackletter,100
 Unkempt,/Expressive/Awkward,41
 Unkempt,/Expressive/Childlike,92
@@ -7999,72 +8785,85 @@ Unkempt,/Expressive/Happy,55
 Unkempt,/Expressive/Innovative,72
 Unkempt,/Expressive/Playful,77
 Unkempt,/Expressive/Rugged,65
+Unkempt,/Expressive/Vintage,46.7
 Unkempt,/Script/Handwritten,60
 Unkempt,/Script/Informal,80
 Unkempt,/Theme/Distressed,50
 Unkempt,/Theme/Wacky,20
 Unlock,/Expressive/Awkward,71
-Unlock,/Expressive/Business,71
+Unlock,/Expressive/Business,60.8
 Unlock,/Expressive/Futuristic,84
 Unlock,/Expressive/Happy,32
+Unlock,/Expressive/Loud,88
 Unlock,/Expressive/Sincere,3
-Unlock,/Expressive/Stiff,71
 Unlock,/Theme/Techno,40
-Unna,/Expressive/Business,95
+Unlock,/Expressive/Stiff,71
+Unna,/Expressive/Business,97.3
 Unna,/Expressive/Calm,97
-Unna,/Expressive/Sincere,99
-Unna,/Expressive/Stiff,60
+Unna,/Expressive/Sincere,98
+Unna,/Expressive/Vintage,71.5
 Unna,/Serif/Modern,80
+Unna,/Expressive/Stiff,60
 Updock,/Expressive/Artistic,100
 Updock,/Expressive/Childlike,26
 Updock,/Expressive/Fancy,79
 Updock,/Expressive/Sophisticated,58
+Updock,/Expressive/Vintage,77.8
 Updock,/Script/Formal,80
-Urbanist,/Expressive/Business,73
+Urbanist,/Expressive/Business,61.8
 Urbanist,/Expressive/Calm,100
-Urbanist,/Expressive/Stiff,62
+Urbanist,/Expressive/Vintage,81
 Urbanist,/Sans/Geometric,100
+Urbanist,/Expressive/Stiff,62
 Vampiro One,/Expressive/Artistic,67
 Vampiro One,/Expressive/Excited,55
 Vampiro One,/Expressive/Innovative,68
+Vampiro One,/Expressive/Sincere,91
+Vampiro One,/Expressive/Vintage,68.7
 Vampiro One,/Script/Informal,50
 Vampiro One,/Theme/Brush,20
-Varela,/Expressive/Business,78
+Varela,/Expressive/Business,91.2
 Varela,/Expressive/Calm,99
 Varela,/Expressive/Competent,11
+Varela,/Expressive/Vintage,84.5
+Varela,/Sans/Geometric,20
+Varela,/Sans/Humanist,80
 Varela,/Expressive/Stiff,62
 Varela Round,/Expressive/Business,41
 Varela Round,/Expressive/Calm,99
 Varela Round,/Expressive/Competent,35
 Varela Round,/Expressive/Cute,2
-Varela Round,/Expressive/Stiff,62
+Varela Round,/Expressive/Vintage,42.3
 Varela Round,/Sans/Geometric,20
 Varela Round,/Sans/Humanist,80
 Varela Round,/Sans/Rounded,80
-Varela,/Sans/Geometric,20
-Varela,/Sans/Humanist,80
-Varta,/Expressive/Business,95
+Varela Round,/Expressive/Stiff,62
+Varta,/Expressive/Business,89.1
 Varta,/Expressive/Calm,99
-Varta,/Expressive/Stiff,63
 Varta,/Sans/Humanist,100
+Varta,/Expressive/Stiff,63
 Vast Shadow,/Expressive/Business,38
 Vast Shadow,/Expressive/Futuristic,72
 Vast Shadow,/Expressive/Innovative,93
-Vast Shadow,/Expressive/Stiff,72
+Vast Shadow,/Expressive/Vintage,91.5
 Vast Shadow,/Theme/Shaded,100
 Vast Shadow,/Theme/Stencil,80
+Vast Shadow,/Expressive/Stiff,72
 Vazirmatn,/Expressive/Business,46
 Vazirmatn,/Expressive/Calm,100
-Vazirmatn,/Expressive/Stiff,51
 Vazirmatn,/Sans/Neo Grotesque,100
-Vesper Libre,/Expressive/Business,79
+Vazirmatn,/Expressive/Stiff,51
+Vesper Libre,/Expressive/Business,79.1
 Vesper Libre,/Expressive/Calm,96
-Vesper Libre,/Expressive/Sincere,98
-Vesper Libre,/Expressive/Stiff,60
+Vesper Libre,/Expressive/Loud,57
+Vesper Libre,/Expressive/Vintage,28.7
 Vesper Libre,/Serif/Transitional,30
+Vesper Libre,/Expressive/Stiff,60
 Viaoda Libre,/Expressive/Calm,88
 Viaoda Libre,/Expressive/Innovative,51
+Viaoda Libre,/Expressive/Loud,73
 Viaoda Libre,/Expressive/Playful,34
+Viaoda Libre,/Expressive/Vintage,67.8
 Viaoda Libre,/Theme/Art Nouveau,10
 Vibes,/Expressive/Awkward,73
 Vibes,/Expressive/Calm,12
@@ -8079,71 +8878,80 @@ Vibur,/Expressive/Childlike,66
 Vibur,/Expressive/Cute,80
 Vibur,/Expressive/Excited,24
 Vibur,/Expressive/Playful,46
+Vibur,/Expressive/Sincere,94
 Vibur,/Script/Handwritten,100
 Victor Mono,/Expressive/Business,21
 Victor Mono,/Expressive/Calm,96
 Victor Mono,/Expressive/Competent,38
-Victor Mono,/Expressive/Stiff,67
 Victor Mono,/Sans/Neo Grotesque,60
 Victor Mono,/Sans/Superellipse,80
-Vidaloka,/Expressive/Business,77
+Victor Mono,/Expressive/Stiff,67
+Vidaloka,/Expressive/Business,82.2
 Vidaloka,/Expressive/Calm,98
-Vidaloka,/Expressive/Sincere,96
-Vidaloka,/Expressive/Stiff,60
+Vidaloka,/Expressive/Competent,90.1
+Vidaloka,/Expressive/Loud,59
+Vidaloka,/Expressive/Vintage,84.5
 Vidaloka,/Serif/Didone,100
+Vidaloka,/Expressive/Stiff,60
 Viga,/Expressive/Calm,62
 Viga,/Expressive/Competent,34
 Viga,/Expressive/Futuristic,76
 Viga,/Expressive/Playful,31
-Viga,/Expressive/Stiff,83
 Viga,/Sans/Humanist,50
 Viga,/Sans/Neo Grotesque,50
+Viga,/Expressive/Stiff,83
 Vina Sans,/Expressive/Calm,69
-Vina Sans,/Expressive/Competent,99
 Vina Sans,/Expressive/Futuristic,96
 Vina Sans,/Expressive/Innovative,12
-Vina Sans,/Expressive/Stiff,91
+Vina Sans,/Expressive/Loud,98
 Vina Sans,/Sans/Geometric,100
 Vina Sans,/Theme/Wacky,10
 Vina Sans,/Theme/Woodtype,70
+Vina Sans,/Expressive/Stiff,91
+Voces,/Expressive/Business,90.8
 Voces,/Expressive/Calm,100
-Voces,/Expressive/Stiff,65
 Voces,/Sans/Humanist,100
-Volkhov,/Expressive/Business,88
+Voces,/Expressive/Stiff,65
+Volkhov,/Expressive/Business,95.9
 Volkhov,/Expressive/Calm,97
-Volkhov,/Expressive/Sincere,100
-Volkhov,/Expressive/Stiff,70
+Volkhov,/Expressive/Sincere,92
+Volkhov,/Expressive/Vintage,68.4
 Volkhov,/Serif/Transitional,80
-Vollkorn,/Expressive/Business,93
+Volkhov,/Expressive/Stiff,70
+Vollkorn,/Expressive/Business,95.9
 Vollkorn,/Expressive/Calm,97
-Vollkorn,/Expressive/Sincere,97
-Vollkorn,/Expressive/Stiff,60
-Vollkorn SC,/Expressive/Business,93
-Vollkorn SC,/Expressive/Calm,97
-Vollkorn SC,/Expressive/Sincere,97
-Vollkorn SC,/Expressive/Stiff,60
-Vollkorn SC,/Serif/Transitional,80
+Vollkorn,/Expressive/Sincere,94
+Vollkorn,/Expressive/Vintage,81
 Vollkorn,/Serif/Transitional,80
+Vollkorn,/Expressive/Stiff,60
+Vollkorn SC,/Expressive/Business,95.9
+Vollkorn SC,/Expressive/Calm,97
+Vollkorn SC,/Expressive/Sincere,94
+Vollkorn SC,/Expressive/Vintage,81
+Vollkorn SC,/Serif/Transitional,80
+Vollkorn SC,/Expressive/Stiff,60
 Voltaire,/Expressive/Business,23
 Voltaire,/Expressive/Calm,98
-Voltaire,/Expressive/Competent,79
-Voltaire,/Expressive/Stiff,60
+Voltaire,/Expressive/Competent,96
 Voltaire,/Sans/Geometric,50
 Voltaire,/Sans/Grotesque,50
+Voltaire,/Expressive/Stiff,60
 VT323,/Expressive/Awkward,76
 VT323,/Expressive/Calm,55
 VT323,/Expressive/Futuristic,79
 VT323,/Expressive/Innovative,95
 VT323,/Expressive/Rugged,15
-VT323,/Expressive/Stiff,93
+VT323,/Expressive/Vintage,78
 VT323,/Monospace/Monospace,100
 VT323,/Theme/Techno,100
+VT323,/Expressive/Stiff,93
 Vujahday Script,/Expressive/Active,94
 Vujahday Script,/Expressive/Artistic,56
 Vujahday Script,/Expressive/Awkward,14
 Vujahday Script,/Expressive/Innovative,31
 Vujahday Script,/Expressive/Rugged,73
 Vujahday Script,/Expressive/Sophisticated,73
+Vujahday Script,/Expressive/Vintage,25.4
 Vujahday Script,/Script/Handwritten,70
 Vujahday Script,/Script/Informal,70
 Waiting for the Sunrise,/Expressive/Awkward,53
@@ -8155,15 +8963,16 @@ Waiting for the Sunrise,/Script/Informal,80
 Wallpoet,/Expressive/Awkward,31
 Wallpoet,/Expressive/Innovative,11
 Wallpoet,/Expressive/Rugged,96
-Wallpoet,/Expressive/Stiff,100
 Wallpoet,/Theme/Stencil,100
 Wallpoet,/Theme/Techno,10
+Wallpoet,/Expressive/Stiff,100
 Walter Turncoat,/Expressive/Childlike,100
 Walter Turncoat,/Expressive/Excited,43
 Walter Turncoat,/Expressive/Happy,16
 Walter Turncoat,/Expressive/Innovative,32
 Walter Turncoat,/Expressive/Playful,24
 Walter Turncoat,/Expressive/Rugged,64
+Walter Turncoat,/Expressive/Sincere,97
 Walter Turncoat,/Script/Informal,80
 Walter Turncoat,/Theme/Brush,50
 Walter Turncoat,/Theme/Distressed,40
@@ -8172,114 +8981,125 @@ Warnes,/Expressive/Awkward,12
 Warnes,/Expressive/Calm,52
 Warnes,/Expressive/Cute,22
 Warnes,/Expressive/Happy,34
+Warnes,/Expressive/Vintage,90
 Warnes,/Script/Handwritten,50
 Warnes,/Theme/Techno,20
 Water Brush,/Expressive/Artistic,80
 Water Brush,/Expressive/Fancy,59
 Water Brush,/Expressive/Innovative,52
 Water Brush,/Expressive/Rugged,76
+Water Brush,/Expressive/Vintage,35.4
 Water Brush,/Script/Informal,70
 Waterfall,/Expressive/Artistic,70
 Waterfall,/Expressive/Cute,35
 Waterfall,/Expressive/Fancy,55
+Waterfall,/Expressive/Loud,42
+Waterfall,/Expressive/Vintage,58.7
 Waterfall,/Script/Informal,50
 Wavefont,/Not text/Symbols,100
+Wavefont,/Expressive/Stiff,100
 Wellfleet,/Expressive/Calm,44
 Wellfleet,/Expressive/Excited,22
 Wellfleet,/Expressive/Happy,31
 Wellfleet,/Expressive/Playful,53
-Wellfleet,/Expressive/Sincere,10
-Wellfleet,/Expressive/Stiff,54
+Wellfleet,/Expressive/Sincere,10.1
 Wellfleet,/Slab/Humanist,100
 Wellfleet,/Theme/Wacky,40
 Wellfleet,/Theme/Woodtype,10
+Wellfleet,/Expressive/Stiff,54
 Wendy One,/Expressive/Calm,64
 Wendy One,/Expressive/Childlike,40
 Wendy One,/Expressive/Happy,23
+Wendy One,/Expressive/Loud,88
 Wendy One,/Expressive/Playful,45
-Wendy One,/Expressive/Stiff,40
+Wendy One,/Expressive/Vintage,89
 Wendy One,/Sans/Humanist,100
+Wendy One,/Expressive/Stiff,40
 Whisper,/Expressive/Artistic,89
 Whisper,/Expressive/Fancy,76
 Whisper,/Expressive/Innovative,31
+Whisper,/Expressive/Loud,51
 Whisper,/Expressive/Rugged,62
+Whisper,/Expressive/Vintage,37.6
 Whisper,/Script/Informal,70
 WindSong,/Expressive/Artistic,80
 WindSong,/Expressive/Awkward,31
 WindSong,/Expressive/Fancy,78
+WindSong,/Expressive/Vintage,37.6
 WindSong,/Script/Informal,70
 Wire One,/Expressive/Calm,77
-Wire One,/Expressive/Competent,95
 Wire One,/Expressive/Cute,48
 Wire One,/Expressive/Futuristic,79
-Wire One,/Expressive/Stiff,68
 Wire One,/Sans/Neo Grotesque,50
 Wire One,/Sans/Rounded,100
-Wix Madefor Display,/Expressive/Business,94
+Wire One,/Expressive/Stiff,68
 Wix Madefor Display,/Expressive/Calm,100
-Wix Madefor Display,/Expressive/Competent,24
-Wix Madefor Display,/Expressive/Stiff,40
 Wix Madefor Display,/Sans/Geometric,80
 Wix Madefor Display,/Sans/Neo Grotesque,20
-Wix Madefor Text,/Expressive/Business,94
+Wix Madefor Display,/Expressive/Stiff,40
+Wix Madefor Text,/Expressive/Business,92.8
 Wix Madefor Text,/Expressive/Calm,100
-Wix Madefor Text,/Expressive/Competent,24
-Wix Madefor Text,/Expressive/Stiff,40
 Wix Madefor Text,/Sans/Geometric,80
 Wix Madefor Text,/Sans/Neo Grotesque,20
-Work Sans,/Expressive/Business,96
+Wix Madefor Text,/Expressive/Stiff,40
+Work Sans,/Expressive/Business,99.2
 Work Sans,/Expressive/Calm,100
 Work Sans,/Expressive/Competent,51
-Work Sans,/Expressive/Stiff,40
+Work Sans,/Expressive/Vintage,69
 Work Sans,/Sans/Grotesque,50
 Work Sans,/Sans/Neo Grotesque,60
+Work Sans,/Expressive/Stiff,40
 Xanh Mono,/Expressive/Business,16
 Xanh Mono,/Expressive/Futuristic,68
-Xanh Mono,/Expressive/Sincere,70
-Xanh Mono,/Expressive/Stiff,60
+Xanh Mono,/Expressive/Sincere,70.1
+Xanh Mono,/Expressive/Vintage,83
 Xanh Mono,/Monospace/Monospace,100
 Xanh Mono,/Serif/Modern,100
-Yaldevi Colombo,/Expressive/Business,63
-Yaldevi Colombo,/Expressive/Calm,99
-Yaldevi Colombo,/Expressive/Competent,75
-Yaldevi Colombo,/Expressive/Stiff,62
-Yaldevi Colombo,/Sans/Humanist,20
-Yaldevi Colombo,/Sans/Neo Grotesque,80
-Yaldevi,/Expressive/Business,63
+Xanh Mono,/Expressive/Stiff,60
+Yaldevi,/Expressive/Business,69.1
 Yaldevi,/Expressive/Calm,99
-Yaldevi,/Expressive/Competent,75
-Yaldevi,/Expressive/Stiff,61
+Yaldevi,/Expressive/Competent,89.1
 Yaldevi,/Sans/Humanist,20
 Yaldevi,/Sans/Neo Grotesque,80
-Yanone Kaffeesatz,/Expressive/Business,52
+Yaldevi,/Expressive/Stiff,61
+Yaldevi Colombo,/Expressive/Business,69.1
+Yaldevi Colombo,/Expressive/Calm,99
+Yaldevi Colombo,/Expressive/Competent,79.1
+Yaldevi Colombo,/Sans/Humanist,20
+Yaldevi Colombo,/Sans/Neo Grotesque,80
+Yaldevi Colombo,/Expressive/Stiff,62
+Yanone Kaffeesatz,/Expressive/Business,90.1
 Yanone Kaffeesatz,/Expressive/Calm,75
 Yanone Kaffeesatz,/Expressive/Childlike,5
-Yanone Kaffeesatz,/Expressive/Competent,79
+Yanone Kaffeesatz,/Expressive/Competent,97
 Yanone Kaffeesatz,/Expressive/Excited,31
 Yanone Kaffeesatz,/Expressive/Playful,11
-Yanone Kaffeesatz,/Expressive/Stiff,30
 Yanone Kaffeesatz,/Sans/Humanist,100
 Yanone Kaffeesatz,/Sans/Neo Grotesque,20
 Yanone Kaffeesatz,/Sans/Rounded,10
 Yanone Kaffeesatz,/Sans/Superellipse,50
+Yanone Kaffeesatz,/Expressive/Stiff,30
 Yantramanav,/Expressive/Business,50
 Yantramanav,/Expressive/Calm,99
-Yantramanav,/Expressive/Stiff,51
 Yantramanav,/Sans/Neo Grotesque,100
-Yarndings 12 Charted,/Not text/Symbols,100
+Yantramanav,/Expressive/Stiff,51
 Yarndings 12,/Not text/Symbols,100
-Yarndings 20 Charted,/Not text/Symbols,100
+Yarndings 12 Charted,/Not text/Symbols,100
 Yarndings 20,/Not text/Symbols,100
+Yarndings 20 Charted,/Not text/Symbols,100
 Yatra One,/Expressive/Awkward,99
 Yatra One,/Expressive/Calm,58
 Yatra One,/Expressive/Futuristic,64
 Yatra One,/Expressive/Happy,60
 Yatra One,/Expressive/Innovative,14
-Yatra One,/Expressive/Stiff,52
+Yatra One,/Expressive/Loud,57
+Yatra One,/Expressive/Vintage,76.8
 Yatra One,/Theme/Brush,100
 Yatra One,/Theme/Wacky,40
+Yatra One,/Expressive/Stiff,52
 Yellowtail,/Expressive/Artistic,52
 Yellowtail,/Expressive/Cute,99
+Yellowtail,/Expressive/Vintage,88
 Yellowtail,/Script/Handwritten,70
 Yellowtail,/Script/Informal,30
 Yeon Sung,/Expressive/Awkward,53
@@ -8287,53 +9107,61 @@ Yeon Sung,/Expressive/Childlike,70
 Yeon Sung,/Expressive/Happy,37
 Yeon Sung,/Expressive/Innovative,22
 Yeon Sung,/Expressive/Rugged,41
+Yeon Sung,/Expressive/Vintage,77.4
 Yeon Sung,/Script/Handwritten,100
-Yeseva One,/Expressive/Business,75
 Yeseva One,/Expressive/Calm,96
 Yeseva One,/Expressive/Rugged,44
 Yeseva One,/Expressive/Sincere,52
-Yeseva One,/Expressive/Stiff,50
+Yeseva One,/Expressive/Vintage,82
 Yeseva One,/Serif/Didone,70
 Yeseva One,/Serif/Fat Face,10
+Yeseva One,/Expressive/Stiff,50
 Yesteryear,/Expressive/Childlike,36
 Yesteryear,/Expressive/Fancy,91
+Yesteryear,/Expressive/Loud,73
+Yesteryear,/Expressive/Vintage,47.6
 Yesteryear,/Script/Handwritten,40
 Yomogi,/Expressive/Awkward,62
 Yomogi,/Expressive/Childlike,93
 Yomogi,/Expressive/Excited,42
 Yomogi,/Expressive/Playful,66
 Yomogi,/Script/Handwritten,100
-Young Serif,/Expressive/Business,73
 Young Serif,/Expressive/Calm,92
+Young Serif,/Expressive/Loud,65
 Young Serif,/Expressive/Sincere,71
-Young Serif,/Expressive/Stiff,50
+Young Serif,/Expressive/Vintage,82.5
 Young Serif,/Serif/Old Style Garalde,70
-Yrsa,/Expressive/Business,97
+Young Serif,/Expressive/Stiff,50
+Yrsa,/Expressive/Business,99
 Yrsa,/Expressive/Calm,95
-Yrsa,/Expressive/Sincere,100
-Yrsa,/Expressive/Stiff,50
+Yrsa,/Expressive/Sincere,98
 Yrsa,/Serif/Transitional,100
-Ysabeau,/Expressive/Business,94
+Yrsa,/Expressive/Stiff,50
+Ysabeau,/Expressive/Business,68.2
 Ysabeau,/Expressive/Calm,93
 Ysabeau,/Expressive/Competent,52
+Ysabeau,/Expressive/Vintage,84.5
+Ysabeau,/Sans/Humanist,100
 Ysabeau,/Expressive/Stiff,51
 Ysabeau Infant,/Expressive/Business,13
 Ysabeau Infant,/Expressive/Calm,74
 Ysabeau Infant,/Expressive/Childlike,10
 Ysabeau Infant,/Expressive/Competent,52
-Ysabeau Infant,/Expressive/Stiff,51
+Ysabeau Infant,/Expressive/Vintage,84.5
 Ysabeau Infant,/Sans/Humanist,100
-Ysabeau Office,/Expressive/Business,94
+Ysabeau Infant,/Expressive/Stiff,51
+Ysabeau Office,/Expressive/Business,68.2
 Ysabeau Office,/Expressive/Calm,93
 Ysabeau Office,/Expressive/Competent,52
-Ysabeau Office,/Expressive/Stiff,51
+Ysabeau Office,/Expressive/Vintage,84.5
 Ysabeau Office,/Sans/Humanist,100
-Ysabeau,/Sans/Humanist,100
-Ysabeau SC,/Expressive/Business,94
+Ysabeau Office,/Expressive/Stiff,51
+Ysabeau SC,/Expressive/Business,68.2
 Ysabeau SC,/Expressive/Calm,93
 Ysabeau SC,/Expressive/Competent,52
-Ysabeau SC,/Expressive/Stiff,51
+Ysabeau SC,/Expressive/Vintage,84.5
 Ysabeau SC,/Sans/Humanist,100
+Ysabeau SC,/Expressive/Stiff,51
 Yuji Boku,/Expressive/Active,66
 Yuji Boku,/Expressive/Awkward,52
 Yuji Boku,/Expressive/Childlike,70
@@ -8368,11 +9196,12 @@ Yuji Syuku,/Theme/Distressed,60
 Yusei Magic,/Expressive/Awkward,75
 Yusei Magic,/Expressive/Calm,75
 Yusei Magic,/Expressive/Happy,27
+Yusei Magic,/Expressive/Loud,46
 Yusei Magic,/Expressive/Playful,42
 Yusei Magic,/Expressive/Rugged,4
-Yusei Magic,/Expressive/Stiff,20
 Yusei Magic,/Theme/Blobby,30
 Yusei Magic,/Theme/Brush,30
+Yusei Magic,/Expressive/Stiff,20
 ZCOOL KuaiLe,/Expressive/Awkward,53
 ZCOOL KuaiLe,/Expressive/Childlike,73
 ZCOOL KuaiLe,/Expressive/Excited,45
@@ -8386,85 +9215,87 @@ ZCOOL QingKe HuangYou,/Expressive/Calm,67
 ZCOOL QingKe HuangYou,/Expressive/Futuristic,98
 ZCOOL QingKe HuangYou,/Expressive/Happy,51
 ZCOOL QingKe HuangYou,/Expressive/Playful,77
-ZCOOL QingKe HuangYou,/Expressive/Stiff,80
 ZCOOL QingKe HuangYou,/Sans/Geometric,80
 ZCOOL QingKe HuangYou,/Sans/Superellipse,40
 ZCOOL QingKe HuangYou,/Theme/Blobby,10
 ZCOOL QingKe HuangYou,/Theme/Techno,40
+ZCOOL QingKe HuangYou,/Expressive/Stiff,80
 ZCOOL XiaoWei,/Expressive/Calm,92
 ZCOOL XiaoWei,/Expressive/Happy,13
-ZCOOL XiaoWei,/Expressive/Stiff,50
+ZCOOL XiaoWei,/Expressive/Loud,69
 ZCOOL XiaoWei,/Sans/Humanist,50
-Zen Antique,/Expressive/Business,98
+ZCOOL XiaoWei,/Expressive/Stiff,50
+Zen Antique,/Expressive/Business,97.9
 Zen Antique,/Expressive/Calm,93
-Zen Antique,/Expressive/Sincere,93
-Zen Antique,/Expressive/Stiff,60
+Zen Antique,/Expressive/Vintage,55
 Zen Antique,/Serif/Scotch,40
 Zen Antique,/Serif/Transitional,80
-Zen Antique Soft,/Expressive/Business,98
+Zen Antique,/Expressive/Stiff,60
+Zen Antique Soft,/Expressive/Business,97.9
 Zen Antique Soft,/Expressive/Calm,93
-Zen Antique Soft,/Expressive/Sincere,93
-Zen Antique Soft,/Expressive/Stiff,60
+Zen Antique Soft,/Expressive/Vintage,73.4
 Zen Antique Soft,/Serif/Scotch,40
 Zen Antique Soft,/Serif/Transitional,80
+Zen Antique Soft,/Expressive/Stiff,60
 Zen Dots,/Expressive/Calm,72
-Zen Dots,/Expressive/Competent,69
+Zen Dots,/Expressive/Competent,88.7
 Zen Dots,/Expressive/Futuristic,100
-Zen Dots,/Expressive/Stiff,99
 Zen Dots,/Theme/Techno,100
+Zen Dots,/Expressive/Stiff,99
 Zen Kaku Gothic Antique,/Expressive/Business,2
 Zen Kaku Gothic Antique,/Expressive/Calm,98
 Zen Kaku Gothic Antique,/Expressive/Happy,5
-Zen Kaku Gothic Antique,/Expressive/Stiff,51
 Zen Kaku Gothic Antique,/Sans/Grotesque,30
 Zen Kaku Gothic Antique,/Sans/Neo Grotesque,80
+Zen Kaku Gothic Antique,/Expressive/Stiff,51
 Zen Kaku Gothic New,/Expressive/Business,2
 Zen Kaku Gothic New,/Expressive/Calm,98
 Zen Kaku Gothic New,/Expressive/Happy,5
-Zen Kaku Gothic New,/Expressive/Stiff,51
 Zen Kaku Gothic New,/Sans/Grotesque,30
 Zen Kaku Gothic New,/Sans/Neo Grotesque,80
+Zen Kaku Gothic New,/Expressive/Stiff,51
 Zen Kurenaido,/Expressive/Calm,96
 Zen Kurenaido,/Expressive/Happy,41
-Zen Kurenaido,/Expressive/Stiff,73
 Zen Kurenaido,/Sans/Neo Grotesque,90
 Zen Kurenaido,/Sans/Rounded,100
+Zen Kurenaido,/Expressive/Stiff,73
 Zen Loop,/Expressive/Active,97
 Zen Loop,/Expressive/Calm,98
 Zen Loop,/Expressive/Childlike,24
-Zen Loop,/Expressive/Competent,78
 Zen Loop,/Expressive/Happy,51
 Zen Loop,/Expressive/Innovative,8
 Zen Loop,/Expressive/Playful,13
-Zen Loop,/Expressive/Stiff,72
 Zen Loop,/Sans/Geometric,20
 Zen Loop,/Sans/Neo Grotesque,50
 Zen Loop,/Sans/Rounded,100
 Zen Loop,/Script/Handwritten,80
 Zen Loop,/Script/Informal,60
+Zen Loop,/Expressive/Stiff,72
 Zen Maru Gothic,/Expressive/Business,1
 Zen Maru Gothic,/Expressive/Calm,98
 Zen Maru Gothic,/Expressive/Happy,5
-Zen Maru Gothic,/Expressive/Stiff,51
 Zen Maru Gothic,/Sans/Grotesque,30
 Zen Maru Gothic,/Sans/Neo Grotesque,80
-Zen Old Mincho,/Expressive/Business,98
+Zen Maru Gothic,/Expressive/Stiff,51
+Zen Old Mincho,/Expressive/Business,97.9
 Zen Old Mincho,/Expressive/Calm,96
-Zen Old Mincho,/Expressive/Sincere,93
-Zen Old Mincho,/Expressive/Stiff,60
+Zen Old Mincho,/Expressive/Vintage,74
 Zen Old Mincho,/Serif/Scotch,40
 Zen Old Mincho,/Serif/Transitional,80
+Zen Old Mincho,/Expressive/Stiff,60
 Zen Tokyo Zoo,/Expressive/Futuristic,92
 Zen Tokyo Zoo,/Expressive/Innovative,93
-Zen Tokyo Zoo,/Expressive/Stiff,82
+Zen Tokyo Zoo,/Expressive/Vintage,73.6
 Zen Tokyo Zoo,/Theme/Art Deco,30
 Zen Tokyo Zoo,/Theme/Inline,70
+Zen Tokyo Zoo,/Expressive/Stiff,82
 Zeyada,/Expressive/Awkward,55
 Zeyada,/Expressive/Childlike,64
 Zeyada,/Expressive/Happy,52
 Zeyada,/Expressive/Innovative,11
 Zeyada,/Expressive/Playful,34
 Zeyada,/Expressive/Rugged,48
+Zeyada,/Expressive/Sincere,97
 Zeyada,/Script/Informal,90
 Zhi Mang Xing,/Expressive/Active,61
 Zhi Mang Xing,/Expressive/Artistic,67
@@ -8472,933 +9303,20 @@ Zhi Mang Xing,/Expressive/Childlike,37
 Zhi Mang Xing,/Expressive/Cute,23
 Zhi Mang Xing,/Expressive/Innovative,10
 Zhi Mang Xing,/Script/Handwritten,100
-Zilla Slab,/Expressive/Business,94
+Zilla Slab,/Expressive/Business,88.5
 Zilla Slab,/Expressive/Calm,99
 Zilla Slab,/Expressive/Futuristic,21
-Zilla Slab,/Expressive/Sincere,99
+Zilla Slab,/Expressive/Vintage,28
+Zilla Slab,/Slab/Clarendon,10
+Zilla Slab,/Slab/Geometric,20
+Zilla Slab,/Slab/Humanist,70
 Zilla Slab,/Expressive/Stiff,72
 Zilla Slab Highlight,/Expressive/Calm,99
 Zilla Slab Highlight,/Expressive/Futuristic,21
 Zilla Slab Highlight,/Expressive/Innovative,94
-Zilla Slab Highlight,/Expressive/Stiff,72
 Zilla Slab Highlight,/Slab/Clarendon,10
 Zilla Slab Highlight,/Slab/Geometric,20
 Zilla Slab Highlight,/Slab/Humanist,70
 Zilla Slab Highlight,/Theme/Shaded,10
 Zilla Slab Highlight,/Theme/Techno,30
-Zilla Slab,/Slab/Clarendon,10
-Zilla Slab,/Slab/Geometric,20
-Zilla Slab,/Slab/Humanist,70
-Climate Crisis,/Expressive/Loud,100
-Asset,/Expressive/Loud,100
-Modak,/Expressive/Loud,100
-Gasoek One,/Expressive/Loud,100
-Oi,/Expressive/Loud,100
-Alumni Sans Collegiate One,/Expressive/Loud,100
-Ultra,/Expressive/Loud,100
-Erica One,/Expressive/Loud,100
-Sigmar,/Expressive/Loud,100
-Titan One,/Expressive/Loud,100
-Luckiest Guy,/Expressive/Loud,100
-Sigmar One,/Expressive/Loud,100
-Alfa Slab One,/Expressive/Loud,100
-Plaster,/Expressive/Loud,99
-Alumni Sans Inline One,/Expressive/Loud,99
-Ranchers,/Expressive/Loud,99
-Bevan,/Expressive/Loud,99
-Shrikhand,/Expressive/Loud,99
-Gravitas One,/Expressive/Loud,99
-Angkor,/Expressive/Loud,99
-Diplomata,/Expressive/Loud,99
-Diplomata SC,/Expressive/Loud,99
-Bowlby One,/Expressive/Loud,99
-Rammetto One,/Expressive/Loud,99
-Nosifer,/Expressive/Loud,99
-Nosifer Caps,/Expressive/Loud,99
-Bowlby One SC,/Expressive/Loud,99
-Notable,/Expressive/Loud,98
-Blaka Hollow,/Expressive/Loud,98
-Carter One,/Expressive/Loud,98
-Poller One,/Expressive/Loud,98
-Vina Sans,/Expressive/Loud,98
-Emblema One,/Expressive/Loud,97
-Fascinate,/Expressive/Loud,97
-Fascinate Inline,/Expressive/Loud,97
-Caprasimo,/Expressive/Loud,97
-Holtwood One SC,/Expressive/Loud,97
-Chango,/Expressive/Loud,97
-Candal,/Expressive/Loud,97
-Blaka,/Expressive/Loud,97
-Goblin One,/Expressive/Loud,97
-Karantina,/Expressive/Loud,96
-Sonsie One,/Expressive/Loud,95
-Kumar One,/Expressive/Loud,95
-Spicy Rice,/Expressive/Loud,94
-Limelight,/Expressive/Loud,93
-Qahiri,/Expressive/Loud,93
-Chonburi,/Expressive/Loud,93
-Kavoon,/Expressive/Loud,92
-Barriecito,/Expressive/Loud,92
-Barrio,/Expressive/Loud,92
-Racing Sans One,/Expressive/Loud,91
-Kenia,/Expressive/Loud,91
-Black Ops One,/Expressive/Loud,90
-Fruktur,/Expressive/Loud,90
-Cherry Bomb One,/Expressive/Loud,89
-Ceviche One,/Expressive/Loud,89
-Oleo Script,/Expressive/Loud,89
-Belanosima,/Expressive/Loud,89
-Skranji,/Expressive/Loud,89
-Rakkas,/Expressive/Loud,88
-New Rocker,/Expressive/Loud,88
-Bangers,/Expressive/Loud,88
-Unlock,/Expressive/Loud,88
-Wendy One,/Expressive/Loud,88
-Anton,/Expressive/Loud,88
-Mrs Sheppards,/Expressive/Loud,88
-Rowdies,/Expressive/Loud,88
-Passion One,/Expressive/Loud,88
-Chicle,/Expressive/Loud,87
-Knewave,/Expressive/Loud,86
-Ruslan Display,/Expressive/Loud,85
-Coiny,/Expressive/Loud,84
-Praise,/Expressive/Loud,83
-Oleo Script Swash Caps,/Expressive/Loud,83
-Joti One,/Expressive/Loud,82
-Ravi Prakash,/Expressive/Loud,82
-Abril Fatface,/Expressive/Loud,82
-Chela One,/Expressive/Loud,81
-Almendra,/Expressive/Loud,81
-Chewy,/Expressive/Loud,81
-Smokum,/Expressive/Loud,80
-Kablammo,/Expressive/Loud,80
-Arbutus,/Expressive/Loud,79
-UnifrakturCook,/Expressive/Loud,79
-Lakki Reddy,/Expressive/Loud,79
-Concert One,/Expressive/Loud,79
-Freckle Face,/Expressive/Loud,79
-Pirata One,/Expressive/Loud,78
-Mitr,/Expressive/Loud,78
-Trochut,/Expressive/Loud,77
-Gorditas,/Expressive/Loud,77
-Dr Sugiyama,/Expressive/Loud,76
-Romanesco,/Expressive/Loud,76
-Ribeye,/Expressive/Loud,76
-Henny Penny,/Expressive/Loud,74
-Playball,/Expressive/Loud,74
-Julee,/Expressive/Loud,74
-Miltonian Tattoo,/Expressive/Loud,74
-Lily Script One,/Expressive/Loud,74
-Mouse Memoirs,/Expressive/Loud,74
-Rozha One,/Expressive/Loud,73
-Yesteryear,/Expressive/Loud,73
-Purple Purse,/Expressive/Loud,73
-Griffy,/Expressive/Loud,73
-Emilys Candy,/Expressive/Loud,73
-Viaoda Libre,/Expressive/Loud,73
-Galada,/Expressive/Loud,73
-Lobster,/Expressive/Loud,73
-Lobster Two,/Expressive/Loud,73
-Pattaya,/Expressive/Loud,73
-Playfair Display SC,/Expressive/Loud,72
-Inknut Antiqua,/Expressive/Loud,72
-Metal Mania,/Expressive/Loud,72
-Fontdiner Swanky,/Expressive/Loud,72
-Sail,/Expressive/Loud,71
-Bodoni Moda,/Expressive/Loud,71
-Jomhuria,/Expressive/Loud,71
-Marko One,/Expressive/Loud,71
-The Nautigal,/Expressive/Loud,71
-Tiro Bangla,/Expressive/Loud,71
-Tiro Devanagari Hindi,/Expressive/Loud,71
-Tiro Devanagari Marathi,/Expressive/Loud,71
-Tiro Devanagari Sanskrit,/Expressive/Loud,71
-Tiro Gurmukhi,/Expressive/Loud,71
-Tiro Kannada,/Expressive/Loud,71
-Tiro Tamil,/Expressive/Loud,71
-Tiro Telugu,/Expressive/Loud,71
-Peralta,/Expressive/Loud,71
-PoetsenOne,/Expressive/Loud,71
-Sansita One,/Expressive/Loud,71
-Playfair Display,/Expressive/Loud,70
-Berkshire Swash,/Expressive/Loud,70
-Gloock,/Expressive/Loud,69
-ZCOOL XiaoWei,/Expressive/Loud,69
-Aguafina Script,/Expressive/Loud,65
-Uncial Antiqua,/Expressive/Loud,65
-Young Serif,/Expressive/Loud,65
-Texturina,/Expressive/Loud,63
-Petit Formal Script,/Expressive/Loud,62
-Source Serif 4,/Expressive/Loud,62
-Bakbak One,/Expressive/Loud,62
-Engagement,/Expressive/Loud,61
-Fahkwang,/Expressive/Loud,61
-Tenor Sans,/Expressive/Loud,61
-Bigshot One,/Expressive/Loud,59
-Pixelify Sans,/Expressive/Loud,59
-Vidaloka,/Expressive/Loud,59
-Philosopher,/Expressive/Loud,58
-Spectral,/Expressive/Loud,58
-Spectral SC,/Expressive/Loud,58
-Bentham,/Expressive/Loud,58
-Aclonica,/Expressive/Loud,57
-Fraunces,/Expressive/Loud,57
-Old Standard TT,/Expressive/Loud,57
-Vesper Libre,/Expressive/Loud,57
-Yatra One,/Expressive/Loud,57
-Libre Caslon Display,/Expressive/Loud,56
-Tienne,/Expressive/Loud,56
-Alkatra,/Expressive/Loud,55
-Original Surfer,/Expressive/Loud,55
-Otomanopee One,/Expressive/Loud,55
-Prosto One,/Expressive/Loud,55
-Trirong,/Expressive/Loud,55
-Alike,/Expressive/Loud,54
-Frank Ruhl Libre,/Expressive/Loud,54
-Italiana,/Expressive/Loud,54
-Pinyon Script,/Expressive/Loud,54
-Sofia,/Expressive/Loud,54
-Aboreto,/Expressive/Loud,53
-Rochester,/Expressive/Loud,53
-Alex Brush,/Expressive/Loud,52
-Cute Font,/Expressive/Loud,52
-Kirang Haerang,/Expressive/Loud,52
-Marcellus,/Expressive/Loud,52
-Marcellus SC,/Expressive/Loud,52
-Splash,/Expressive/Loud,52
-Antonio,/Expressive/Loud,52
-Digital Numbers,/Expressive/Loud,51
-Whisper,/Expressive/Loud,51
-Baskervville,/Expressive/Loud,50
-Sahitya,/Expressive/Loud,50
-Alegreya,/Expressive/Loud,49
-Alegreya SC,/Expressive/Loud,49
-Katibeh,/Expressive/Loud,49
-Akaya Kanadaka,/Expressive/Loud,48
-Akaya Telivigala,/Expressive/Loud,48
-Almendra SC,/Expressive/Loud,48
-Cantata One,/Expressive/Loud,48
-Gotu,/Expressive/Loud,48
-Orelega One,/Expressive/Loud,48
-Risque,/Expressive/Loud,48
-Acme,/Expressive/Loud,47
-Kaushan Script,/Expressive/Loud,47
-Marmelad,/Expressive/Loud,47
-Sevillana,/Expressive/Loud,47
-Macondo,/Expressive/Loud,46
-Macondo Swash Caps,/Expressive/Loud,46
-Mr Bedfort,/Expressive/Loud,46
-Salsa,/Expressive/Loud,46
-Yusei Magic,/Expressive/Loud,46
-Amarante,/Expressive/Loud,45
-Benne,/Expressive/Loud,45
-Bree Serif,/Expressive/Loud,45
-Rancho,/Expressive/Loud,45
-Taviraj,/Expressive/Loud,45
-Arapey,/Expressive/Loud,42
-Beau Rivage,/Expressive/Loud,42
-Shalimar,/Expressive/Loud,42
-Waterfall,/Expressive/Loud,42
-Bellefair,/Expressive/Loud,41
-Amita,/Expressive/Loud,40
-Geostar Fill,/Expressive/Loud,39
-Arsenal,/Expressive/Loud,38
-Inria Serif,/Expressive/Loud,38
-Arya,/Expressive/Loud,37
-Niconne,/Expressive/Loud,37
-Dokdo,/Expressive/Loud,34
-Nova Slim,/Expressive/Loud,33
-Puppies Play,/Expressive/Loud,33
-Besley,/Expressive/Loud,32
-Crushed,/Expressive/Loud,31
-Alkalami,/Expressive/Loud,28
-Nova Cut,/Expressive/Loud,28
-Song Myung,/Expressive/Loud,28
-Aladin,/Expressive/Loud,25
-Norican,/Expressive/Loud,25
-Noto Serif HK,/Expressive/Loud,25
-Noto Serif JP,/Expressive/Loud,25
-Noto Serif KR,/Expressive/Loud,25
-Noto Serif SC,/Expressive/Loud,25
-Noto Serif Tangut,/Expressive/Loud,25
-Noto Serif TC,/Expressive/Loud,25
-Style Script,/Expressive/Loud,23
-Gideon Roman,/Expressive/Loud,22
-Kavivanar,/Expressive/Loud,22
-Miama,/Expressive/Loud,22
-Tangerine,/Expressive/Loud,22
-Newsreader,/Expressive/Loud,20
-Sree Krushnadevaraya,/Expressive/Loud,20
-Alice,/Expressive/Loud,19
-Asul,/Expressive/Loud,17
-Syne Mono,/Expressive/Loud,5
-UnifrakturMaguntia,/Expressive/Vintage,100
-UnifrakturCook,/Expressive/Vintage,100
-Almendra SC,/Expressive/Vintage,99
-Pirata One,/Expressive/Vintage,99
-Quintessential,/Expressive/Vintage,99
-Bokor,/Expressive/Vintage,99
-Macondo,/Expressive/Vintage,99
-Macondo Swash Caps,/Expressive/Vintage,99
-Ballet,/Expressive/Vintage,99
-Caesar Dressing,/Expressive/Vintage,98.5
-Blaka,/Expressive/Vintage,98.5
-Kings,/Expressive/Vintage,98.5
-Almendra,/Expressive/Vintage,98
-Almendra Display,/Expressive/Vintage,98
-Uncial Antiqua,/Expressive/Vintage,98
-Eagle Lake,/Expressive/Vintage,98
-Grenze Gotisch,/Expressive/Vintage,98
-Texturina,/Expressive/Vintage,98
-Blaka Hollow,/Expressive/Vintage,98
-Lugrasimo,/Expressive/Vintage,97
-Kapakana,/Expressive/Vintage,96
-Jim Nightshade,/Expressive/Vintage,96
-New Rocker,/Expressive/Vintage,95
-Diplomata,/Expressive/Vintage,94
-Diplomata SC,/Expressive/Vintage,94
-Asset,/Expressive/Vintage,94
-Pinyon Script,/Expressive/Vintage,94
-Herr Von Muellerhoff,/Expressive/Vintage,94
-Ewert,/Expressive/Vintage,93.5
-Arbutus,/Expressive/Vintage,93
-Sancreek,/Expressive/Vintage,93
-Rye,/Expressive/Vintage,93
-Plaster,/Expressive/Vintage,93
-Great Vibes,/Expressive/Vintage,93
-Smokum,/Expressive/Vintage,92.5
-Aubrey,/Expressive/Vintage,92
-Monsieur La Doulaise,/Expressive/Vintage,92
-Meie Script,/Expressive/Vintage,92
-Aoboshi One,/Expressive/Vintage,92
-Limelight,/Expressive/Vintage,92
-Germania One,/Expressive/Vintage,92
-Mea Culpa,/Expressive/Vintage,92
-Balthazar,/Expressive/Vintage,92
-Porter Sans Block,/Expressive/Vintage,92
-Fascinate Inline,/Expressive/Vintage,92
-Fascinate,/Expressive/Vintage,92
-Italianno,/Expressive/Vintage,92
-Dynalight,/Expressive/Vintage,92
-Luxurious Script,/Expressive/Vintage,92
-Fondamento,/Expressive/Vintage,92
-Poller One,/Expressive/Vintage,91.5
-Modern Antiqua,/Expressive/Vintage,91.5
-Vast Shadow,/Expressive/Vintage,91.5
-Felipa,/Expressive/Vintage,91.5
-Astloch,/Expressive/Vintage,91
-Castoro Titling,/Expressive/Vintage,91
-Cinzel,/Expressive/Vintage,91
-Meddon,/Expressive/Vintage,91
-Bellefair,/Expressive/Vintage,91
-Cinzel Decorative,/Expressive/Vintage,91
-Engagement,/Expressive/Vintage,91
-Beau Rivage,/Expressive/Vintage,91
-IM FELL French Canon,/Expressive/Vintage,90.8
-Chicle,/Expressive/Vintage,90.5
-Stalinist One,/Expressive/Vintage,90.5
-Molle,/Expressive/Vintage,90.5
-Stalemate,/Expressive/Vintage,90.5
-Girassol,/Expressive/Vintage,90.5
-Spicy Rice,/Expressive/Vintage,90.5
-IM FELL English SC,/Expressive/Vintage,90
-Warnes,/Expressive/Vintage,90
-Aboreto,/Expressive/Vintage,89.5
-Trade Winds,/Expressive/Vintage,89.5
-Rosarivo,/Expressive/Vintage,89.5
-IM FELL Double Pica,/Expressive/Vintage,89
-IM FELL DW Pica,/Expressive/Vintage,89
-IM FELL DW Pica SC,/Expressive/Vintage,89
-IM FELL English,/Expressive/Vintage,89
-IM FELL French Canon SC,/Expressive/Vintage,89
-IM FELL Great Primer,/Expressive/Vintage,89
-IM FELL Great Primer SC,/Expressive/Vintage,89
-IM FELL Double Pica SC,/Expressive/Vintage,89
-Skranji,/Expressive/Vintage,89
-Grenze,/Expressive/Vintage,89
-Sacramento,/Expressive/Vintage,89
-Mr Bedfort,/Expressive/Vintage,89
-Grand Hotel,/Expressive/Vintage,89
-Wendy One,/Expressive/Vintage,89
-Della Respira,/Expressive/Vintage,88.5
-Sarina,/Expressive/Vintage,88
-Aladin,/Expressive/Vintage,88
-Yellowtail,/Expressive/Vintage,88
-Luxurious Roman,/Expressive/Vintage,87.5
-Croissant One,/Expressive/Vintage,87
-Redressed,/Expressive/Vintage,86
-Special Elite,/Expressive/Vintage,86
-GFS Neohellenic,/Expressive/Vintage,85.5
-Goudy Bookletter 1911,/Expressive/Vintage,85.5
-Farro,/Expressive/Vintage,85
-Baskervville,/Expressive/Vintage,85
-Libre Franklin,/Expressive/Vintage,84.5
-Playfair Display SC,/Expressive/Vintage,84.5
-Beth Ellen,/Expressive/Vintage,84.5
-Dancing Script,/Expressive/Vintage,84.5
-Cormorant Garamond,/Expressive/Vintage,84.5
-Chenla,/Expressive/Vintage,84.5
-Tilt Prism,/Expressive/Vintage,84.5
-Digital Numbers,/Expressive/Vintage,84.5
-Scheherazade New,/Expressive/Vintage,84.5
-Ysabeau,/Expressive/Vintage,84.5
-Ysabeau Infant,/Expressive/Vintage,84.5
-Ysabeau Office,/Expressive/Vintage,84.5
-Ysabeau SC,/Expressive/Vintage,84.5
-New Tegomin,/Expressive/Vintage,84.5
-Ultra,/Expressive/Vintage,84.5
-Gravitas One,/Expressive/Vintage,84.5
-Didact Gothic,/Expressive/Vintage,84.5
-Freehand,/Expressive/Vintage,84.5
-Tilt Warp,/Expressive/Vintage,84.5
-Petit Formal Script,/Expressive/Vintage,84.5
-Pixelify Sans,/Expressive/Vintage,84.5
-Vidaloka,/Expressive/Vintage,84.5
-Cutive Mono,/Expressive/Vintage,84.5
-Gilda Display,/Expressive/Vintage,84.5
-Cormorant SC,/Expressive/Vintage,84.5
-Prata,/Expressive/Vintage,84.5
-Ravi Prakash,/Expressive/Vintage,84.5
-Brygada 1918,/Expressive/Vintage,84.5
-Varela,/Expressive/Vintage,84.5
-Playfair Display,/Expressive/Vintage,84.5
-Fraunces,/Expressive/Vintage,84.5
-Arvo,/Expressive/Vintage,84.5
-Gideon Roman,/Expressive/Vintage,84.5
-Trocchi,/Expressive/Vintage,84.5
-Bodoni Moda,/Expressive/Vintage,84.5
-Caprasimo,/Expressive/Vintage,84.5
-Libre Baskerville,/Expressive/Vintage,84.5
-Simonetta,/Expressive/Vintage,84.5
-Cormorant Upright,/Expressive/Vintage,84.5
-Bruno Ace SC,/Expressive/Vintage,84
-Courier Prime,/Expressive/Vintage,84
-Bruno Ace,/Expressive/Vintage,84
-Montagu Slab,/Expressive/Vintage,84
-Mate,/Expressive/Vintage,83.5
-Mate SC,/Expressive/Vintage,83.5
-Schibsted Grotesk,/Expressive/Vintage,83.5
-PT Mono,/Expressive/Vintage,83.5
-Island Moments,/Expressive/Vintage,83.5
-Cormorant Infant,/Expressive/Vintage,83.5
-Xanh Mono,/Expressive/Vintage,83
-Radley,/Expressive/Vintage,83
-Playfair,/Expressive/Vintage,83
-Cousine,/Expressive/Vintage,83
-Stardos Stencil,/Expressive/Vintage,83
-Goblin One,/Expressive/Vintage,83
-David Libre,/Expressive/Vintage,83
-Tenor Sans,/Expressive/Vintage,83
-Sedan SC,/Expressive/Vintage,83
-Spectral,/Expressive/Vintage,82.5
-Spectral SC,/Expressive/Vintage,82.5
-EB Garamond,/Expressive/Vintage,82.5
-Sedan,/Expressive/Vintage,82.5
-Abyssinica SIL,/Expressive/Vintage,82.5
-Young Serif,/Expressive/Vintage,82.5
-Graduate,/Expressive/Vintage,82.5
-Shojumaru,/Expressive/Vintage,82.5
-Sulphur Point,/Expressive/Vintage,82.5
-Libre Bodoni,/Expressive/Vintage,82
-Esteban,/Expressive/Vintage,82
-Rakkas,/Expressive/Vintage,82
-Gelasio,/Expressive/Vintage,82
-Bai Jamjuree,/Expressive/Vintage,82
-Yeseva One,/Expressive/Vintage,82
-Carrois Gothic,/Expressive/Vintage,81.5
-Carrois Gothic SC,/Expressive/Vintage,81.5
-Newsreader,/Expressive/Vintage,81.5
-Stint Ultra Condensed,/Expressive/Vintage,81.5
-Katibeh,/Expressive/Vintage,81.5
-Pridi,/Expressive/Vintage,81
-Satisfy,/Expressive/Vintage,81
-Eczar,/Expressive/Vintage,81
-Odor Mean Chey,/Expressive/Vintage,81
-Caudex,/Expressive/Vintage,81
-Libre Caslon Display,/Expressive/Vintage,81
-Vollkorn,/Expressive/Vintage,81
-Vollkorn SC,/Expressive/Vintage,81
-Galdeano,/Expressive/Vintage,81
-Julius Sans One,/Expressive/Vintage,81
-Urbanist,/Expressive/Vintage,81
-Lancelot,/Expressive/Vintage,81
-NanumMyeongjo,/Expressive/Vintage,81
-STIX Two Text,/Expressive/Vintage,81
-Cormorant,/Expressive/Vintage,81
-Moul,/Expressive/Vintage,81
-Frank Ruhl Libre,/Expressive/Vintage,81
-Prociono,/Expressive/Vintage,81
-Hammersmith One,/Expressive/Vintage,81
-STIX Two Math,/Expressive/Vintage,81
-Bevan,/Expressive/Vintage,79.8
-Kotta One,/Expressive/Vintage,79.8
-Joan,/Expressive/Vintage,79.5
-Squada One,/Expressive/Vintage,79.4
-Josefin Sans,/Expressive/Vintage,79.4
-Peddana,/Expressive/Vintage,79.4
-Butcherman,/Expressive/Vintage,79.4
-GFS Didot,/Expressive/Vintage,79.3
-Alkalami,/Expressive/Vintage,79.3
-Belanosima,/Expressive/Vintage,79.2
-Metal,/Expressive/Vintage,79.2
-jsMath-cmbx10,/Expressive/Vintage,79
-jsMath-cmex10,/Expressive/Vintage,79
-jsMath-cmmi10,/Expressive/Vintage,79
-jsMath-cmr10,/Expressive/Vintage,79
-jsMath-cmsy10,/Expressive/Vintage,79
-jsMath-cmti10,/Expressive/Vintage,79
-Alegreya Sans,/Expressive/Vintage,79
-Alegreya Sans SC,/Expressive/Vintage,79
-Castoro,/Expressive/Vintage,78.9
-DM Serif Display,/Expressive/Vintage,78.9
-DM Serif Text,/Expressive/Vintage,78.9
-Sanchez,/Expressive/Vintage,78.9
-Tenali Ramakrishna,/Expressive/Vintage,78.9
-Buenard,/Expressive/Vintage,78.9
-Mrs Sheppards,/Expressive/Vintage,78.9
-Kurale,/Expressive/Vintage,78.8
-Sail,/Expressive/Vintage,78.8
-Gupter,/Expressive/Vintage,78.7
-Poly,/Expressive/Vintage,78.7
-Suranna,/Expressive/Vintage,78.7
-Suwannaphum,/Expressive/Vintage,78.7
-Trykker,/Expressive/Vintage,78.7
-Angkor,/Expressive/Vintage,78.7
-Miama,/Expressive/Vintage,78.7
-Mr Dafoe,/Expressive/Vintage,78.7
-Old Standard TT,/Expressive/Vintage,78.7
-Be Vietnam Pro,/Expressive/Vintage,78.4
-Donegal One,/Expressive/Vintage,78.4
-Damion,/Expressive/Vintage,78.4
-Bonheur Royale,/Expressive/Vintage,78.3
-Rokkitt,/Expressive/Vintage,78.3
-Thabit,/Expressive/Vintage,78.3
-Neuton,/Expressive/Vintage,78.3
-Alegreya,/Expressive/Vintage,78.2
-Alegreya SC,/Expressive/Vintage,78.2
-Sahitya,/Expressive/Vintage,78.2
-Style Script,/Expressive/Vintage,78.1
-Averia Serif Libre,/Expressive/Vintage,78
-VT323,/Expressive/Vintage,78
-Padauk,/Expressive/Vintage,78
-Ruwudu,/Expressive/Vintage,77.9
-Chonburi,/Expressive/Vintage,77.9
-Corinthia,/Expressive/Vintage,77.9
-Cardo,/Expressive/Vintage,77.8
-Poltawski Nowy,/Expressive/Vintage,77.8
-Updock,/Expressive/Vintage,77.8
-Lumanosimo,/Expressive/Vintage,77.6
-Kranky,/Expressive/Vintage,77.6
-Gentium Book Plus,/Expressive/Vintage,77.5
-Gentium Plus,/Expressive/Vintage,77.5
-Jacques Francois,/Expressive/Vintage,77.5
-Joti One,/Expressive/Vintage,77.5
-Benne,/Expressive/Vintage,77.4
-BIZ UDPMincho,/Expressive/Vintage,77.4
-Birthstone,/Expressive/Vintage,77.4
-Yeon Sung,/Expressive/Vintage,77.4
-Cutive,/Expressive/Vintage,77.3
-Habibi,/Expressive/Vintage,77.3
-Aguafina Script,/Expressive/Vintage,77.3
-Carattere,/Expressive/Vintage,77.3
-Arbutus Slab,/Expressive/Vintage,77.2
-Almarai,/Expressive/Vintage,77
-Press Start 2P,/Expressive/Vintage,77
-Cherry Cream Soda,/Expressive/Vintage,77
-Niconne,/Expressive/Vintage,77
-Ranchers,/Expressive/Vintage,76.9
-Reem Kufi,/Expressive/Vintage,76.8
-Reem Kufi Fun,/Expressive/Vintage,76.8
-Reem Kufi Ink,/Expressive/Vintage,76.8
-Yatra One,/Expressive/Vintage,76.8
-Caramel,/Expressive/Vintage,76.8
-Alice,/Expressive/Vintage,76.7
-Babylonica,/Expressive/Vintage,76.7
-Mountains of Christmas,/Expressive/Vintage,76.5
-Halant,/Expressive/Vintage,76.4
-Sumana,/Expressive/Vintage,76.3
-Tiro Bangla,/Expressive/Vintage,76.3
-Tiro Devanagari Hindi,/Expressive/Vintage,76.3
-Tiro Devanagari Marathi,/Expressive/Vintage,76.3
-Tiro Devanagari Sanskrit,/Expressive/Vintage,76.3
-Tiro Gurmukhi,/Expressive/Vintage,76.3
-Tiro Kannada,/Expressive/Vintage,76.3
-Tiro Tamil,/Expressive/Vintage,76.3
-Tiro Telugu,/Expressive/Vintage,76.3
-Atomic Age,/Expressive/Vintage,76
-Tai Heritage Pro,/Expressive/Vintage,76
-Dai Banna SIL,/Expressive/Vintage,75.4
-Sen,/Expressive/Vintage,75.4
-Diphylleia,/Expressive/Vintage,75.4
-Battambang,/Expressive/Vintage,75.4
-Slackey,/Expressive/Vintage,75.4
-Shippori Antique,/Expressive/Vintage,75.3
-DotGothic16,/Expressive/Vintage,75
-Instrument Serif,/Expressive/Vintage,75
-Julee,/Expressive/Vintage,75
-Linden Hill,/Expressive/Vintage,74.8
-Bentham,/Expressive/Vintage,74.6
-Rochester,/Expressive/Vintage,74.5
-Kameron,/Expressive/Vintage,74.5
-Arapey,/Expressive/Vintage,74.5
-Besley,/Expressive/Vintage,74.4
-NTR,/Expressive/Vintage,74.3
-Bona Nova,/Expressive/Vintage,74.3
-Smythe,/Expressive/Vintage,74.3
-Sree Krushnadevaraya,/Expressive/Vintage,74.2
-Abril Fatface,/Expressive/Vintage,74
-Zen Old Mincho,/Expressive/Vintage,74
-Metal Mania,/Expressive/Vintage,74
-Rozha One,/Expressive/Vintage,74
-Chela One,/Expressive/Vintage,73.9
-Patua One,/Expressive/Vintage,73.6
-Zen Tokyo Zoo,/Expressive/Vintage,73.6
-Sorts Mill Goudy,/Expressive/Vintage,73.5
-Zen Antique Soft,/Expressive/Vintage,73.4
-Libre Barcode 128,/Expressive/Vintage,73.4
-Libre Barcode 128 Text,/Expressive/Vintage,73.4
-Libre Barcode 39,/Expressive/Vintage,73.4
-Libre Barcode 39 Extended,/Expressive/Vintage,73.4
-Libre Barcode 39 Extended Text,/Expressive/Vintage,73.4
-Libre Barcode 39 Text,/Expressive/Vintage,73.4
-Libre Barcode EAN13 Text,/Expressive/Vintage,73.4
-Creepster,/Expressive/Vintage,73.4
-Creepster Caps,/Expressive/Vintage,73.4
-Amita,/Expressive/Vintage,73.4
-Alike Angular,/Expressive/Vintage,73
-Amarante,/Expressive/Vintage,73
-Imperial Script,/Expressive/Vintage,73
-Mystery Quest,/Expressive/Vintage,73
-Cantata One,/Expressive/Vintage,72.6
-OFL Sorts Mill Goudy TT,/Expressive/Vintage,72.5
-HeadlandOne,/Expressive/Vintage,72.4
-Bowlby One,/Expressive/Vintage,72.3
-Bowlby One SC,/Expressive/Vintage,72.3
-Bacasime Antique,/Expressive/Vintage,72.1
-Tinos,/Expressive/Vintage,72.1
-Gulzar,/Expressive/Vintage,71.8
-Original Surfer,/Expressive/Vintage,71.7
-Adamina,/Expressive/Vintage,71.7
-Unna,/Expressive/Vintage,71.5
-Federant,/Expressive/Vintage,71.2
-Bungee,/Expressive/Vintage,71.2
-Bungee Hairline,/Expressive/Vintage,71.2
-Bungee Inline,/Expressive/Vintage,71.2
-Bungee Outline,/Expressive/Vintage,71.2
-Bungee Shade,/Expressive/Vintage,71.2
-Bungee Spice,/Expressive/Vintage,71.2
-Anton,/Expressive/Vintage,71
-Libre Caslon Text,/Expressive/Vintage,70.8
-Cambo,/Expressive/Vintage,70.8
-Uchen,/Expressive/Vintage,70.7
-Crimson Pro,/Expressive/Vintage,70.6
-Crimson Text,/Expressive/Vintage,70.6
-Candal,/Expressive/Vintage,70.4
-Caladea,/Expressive/Vintage,70.4
-Solway,/Expressive/Vintage,70.3
-Stoke,/Expressive/Vintage,70.1
-Literata,/Expressive/Vintage,69.8
-Tilt Neon,/Expressive/Vintage,69.7
-Hurricane,/Expressive/Vintage,69.6
-League Script,/Expressive/Vintage,69.4
-Black Ops One,/Expressive/Vintage,69.3
-Staatliches,/Expressive/Vintage,69.3
-Suravaram,/Expressive/Vintage,69.3
-Dorsa,/Expressive/Vintage,69.3
-Fenix,/Expressive/Vintage,69.3
-Artifika,/Expressive/Vintage,69.2
-Sarpanch,/Expressive/Vintage,69
-Work Sans,/Expressive/Vintage,69
-Playball,/Expressive/Vintage,69
-Miss Fajardose,/Expressive/Vintage,69
-Qwitcher Grypen,/Expressive/Vintage,69
-Fuggles,/Expressive/Vintage,68.9
-Kaisei Tokumin,/Expressive/Vintage,68.9
-Passions Conflict,/Expressive/Vintage,68.7
-Lovers Quarrel,/Expressive/Vintage,68.7
-Arizonia,/Expressive/Vintage,68.7
-Chewy,/Expressive/Vintage,68.7
-Condiment,/Expressive/Vintage,68.7
-Covered By Your Grace,/Expressive/Vintage,68.7
-Moulpali,/Expressive/Vintage,68.7
-Vampiro One,/Expressive/Vintage,68.7
-Revalia,/Expressive/Vintage,68.6
-Volkhov,/Expressive/Vintage,68.4
-Ibarra Real Nova,/Expressive/Vintage,68.4
-Orbitron,/Expressive/Vintage,68.3
-Paytone One,/Expressive/Vintage,68.2
-Red Rose,/Expressive/Vintage,68
-Cantora One,/Expressive/Vintage,67.8
-Gwendolyn,/Expressive/Vintage,67.8
-Viaoda Libre,/Expressive/Vintage,67.8
-Eater,/Expressive/Vintage,67.8
-Cherish,/Expressive/Vintage,67.6
-Henny Penny,/Expressive/Vintage,67.6
-Sriracha,/Expressive/Vintage,67.5
-Atma,/Expressive/Vintage,67.5
-Praise,/Expressive/Vintage,67.5
-Boogaloo,/Expressive/Vintage,67.4
-Cabin Sketch,/Expressive/Vintage,67.4
-Elsie,/Expressive/Vintage,67.3
-Elsie Swash Caps,/Expressive/Vintage,67.3
-Gidugu,/Expressive/Vintage,67
-Mingzat,/Expressive/Vintage,67
-BioRhyme,/Expressive/Vintage,67
-Fruktur,/Expressive/Vintage,67
-Cherry Bomb One,/Expressive/Vintage,66.8
-Marck Script,/Expressive/Vintage,66.8
-Smooch,/Expressive/Vintage,66.5
-Charmonman,/Expressive/Vintage,66.4
-Fleur De Leah,/Expressive/Vintage,66.4
-Meow Script,/Expressive/Vintage,66.4
-Kaisei HarunoUmi,/Expressive/Vintage,66
-Bubblegum Sans,/Expressive/Vintage,65.8
-Kaisei Decol,/Expressive/Vintage,65
-Slabo 27px,/Expressive/Vintage,65
-Jomolhari,/Expressive/Vintage,65
-Mrs Saint Delafield,/Expressive/Vintage,64.7
-Calistoga,/Expressive/Vintage,64.7
-Niramit,/Expressive/Vintage,64.7
-Trispace,/Expressive/Vintage,64.7
-Qwigley,/Expressive/Vintage,64.5
-League Gothic,/Expressive/Vintage,64.5
-Rouge Script,/Expressive/Vintage,64.3
-Explora,/Expressive/Vintage,64.3
-Antonio,/Expressive/Vintage,64
-Kalam,/Expressive/Vintage,64
-Milonga,/Expressive/Vintage,63.5
-Charm,/Expressive/Vintage,63.4
-Grey Qo,/Expressive/Vintage,63.4
-Knewave,/Expressive/Vintage,63.4
-Labrada,/Expressive/Vintage,63.4
-Lustria,/Expressive/Vintage,63.4
-Montez,/Expressive/Vintage,63.4
-Romanesco,/Expressive/Vintage,63.4
-Schoolbell,/Expressive/Vintage,63.4
-Sonsie One,/Expressive/Vintage,63.4
-Petrona,/Expressive/Vintage,63.2
-Domine,/Expressive/Vintage,63.2
-Charis SIL,/Expressive/Vintage,63
-Comic Neue,/Expressive/Vintage,63
-Mr De Haviland,/Expressive/Vintage,63
-Permanent Marker,/Expressive/Vintage,63
-Coiny,/Expressive/Vintage,62.7
-Source Serif 4,/Expressive/Vintage,62.4
-Allura,/Expressive/Vintage,62.3
-Rethink Sans,/Expressive/Vintage,62
-Tuffy,/Expressive/Vintage,62
-Faster One,/Expressive/Vintage,62
-Love Light,/Expressive/Vintage,61.2
-Spirax,/Expressive/Vintage,60.2
-Shrikhand,/Expressive/Vintage,59.5
-Estonia,/Expressive/Vintage,59.4
-Hanalei Fill,/Expressive/Vintage,59.3
-Hanalei,/Expressive/Vintage,59
-Norican,/Expressive/Vintage,59
-Glass Antiqua,/Expressive/Vintage,58.9
-Allison,/Expressive/Vintage,58.9
-Asar,/Expressive/Vintage,58.9
-Dr Sugiyama,/Expressive/Vintage,58.9
-Kdam Thmor Pro,/Expressive/Vintage,58.9
-Tienne,/Expressive/Vintage,58.9
-Birthstone Bounce,/Expressive/Vintage,58.9
-Pacifico,/Expressive/Vintage,58.9
-Arya,/Expressive/Vintage,58.7
-Carter One,/Expressive/Vintage,58.7
-Markazi Text,/Expressive/Vintage,58.7
-Petemoss,/Expressive/Vintage,58.7
-Rosario,/Expressive/Vintage,58.7
-Waterfall,/Expressive/Vintage,58.7
-Koh Santepheap,/Expressive/Vintage,58.7
-Pathway Gothic One,/Expressive/Vintage,58.5
-Jolly Lodger,/Expressive/Vintage,58.5
-Sassy Frass,/Expressive/Vintage,58.4
-Fontdiner Swanky,/Expressive/Vintage,58.4
-Parisienne,/Expressive/Vintage,58.4
-Puppies Play,/Expressive/Vintage,58.4
-Averia Gruesa Libre,/Expressive/Vintage,58.3
-Averia Libre,/Expressive/Vintage,58.3
-Junge,/Expressive/Vintage,58.3
-Nova Square,/Expressive/Vintage,58
-Average,/Expressive/Vintage,58
-Jost,/Expressive/Vintage,58
-Song Myung,/Expressive/Vintage,58
-Michroma,/Expressive/Vintage,57.8
-Tektur,/Expressive/Vintage,57.8
-Abhaya Libre,/Expressive/Vintage,57.8
-Risque,/Expressive/Vintage,57.8
-Kolker Brush,/Expressive/Vintage,57.8
-Lavishly Yours,/Expressive/Vintage,57.8
-Proza Libre,/Expressive/Vintage,57.6
-Sevillana,/Expressive/Vintage,57.6
-Poppins,/Expressive/Vintage,57.5
-Oregano,/Expressive/Vintage,57.5
-Asul,/Expressive/Vintage,57.4
-Namdhinggo,/Expressive/Vintage,57.3
-Ruthie,/Expressive/Vintage,57.3
-The Nautigal,/Expressive/Vintage,57.3
-Average Sans,/Expressive/Vintage,57
-Kumar One,/Expressive/Vintage,56.7
-Comforter,/Expressive/Vintage,56.5
-Comforter Brush,/Expressive/Vintage,56.5
-Dawning of a New Day,/Expressive/Vintage,56.5
-Alfa Slab One,/Expressive/Vintage,56.4
-Ms Madi,/Expressive/Vintage,56.4
-Cute Font,/Expressive/Vintage,56.3
-Clicker Script,/Expressive/Vintage,55.6
-Lora,/Expressive/Vintage,55.4
-Lusitana,/Expressive/Vintage,55.4
-BhuTuka Expanded One,/Expressive/Vintage,55.3
-Zen Antique,/Expressive/Vintage,55
-Ephesis,/Expressive/Vintage,54.7
-Mina,/Expressive/Vintage,54
-Orbit,/Expressive/Vintage,54
-Sono,/Expressive/Vintage,54
-Freckle Face,/Expressive/Vintage,54
-Emblema One,/Expressive/Vintage,53.8
-Bilbo Swash Caps,/Expressive/Vintage,53.8
-Noto Nastaliq Urdu,/Expressive/Vintage,53.4
-Comfortaa,/Expressive/Vintage,53.4
-Shalimar,/Expressive/Vintage,53.4
-Lakki Reddy,/Expressive/Vintage,53.4
-Sofia,/Expressive/Vintage,53.4
-Seaweed Script,/Expressive/Vintage,53.3
-Hahmlet,/Expressive/Vintage,53
-Bilbo,/Expressive/Vintage,53
-Splash,/Expressive/Vintage,53
-Alex Brush,/Expressive/Vintage,53
-Sawarabi Mincho,/Expressive/Vintage,52
-Fredoka,/Expressive/Vintage,52
-Faustina,/Expressive/Vintage,49.8
-Mervale Script,/Expressive/Vintage,49.6
-Stylish,/Expressive/Vintage,49.5
-Rancho,/Expressive/Vintage,48.9
-Delicious Handrawn,/Expressive/Vintage,48.9
-Amaranth,/Expressive/Vintage,48.4
-Kablammo,/Expressive/Vintage,48.4
-Karla Tamil Inclined,/Expressive/Vintage,48
-Karla Tamil Upright,/Expressive/Vintage,48
-Lobster,/Expressive/Vintage,48
-Pattaya,/Expressive/Vintage,48
-DM Mono,/Expressive/Vintage,48
-Chango,/Expressive/Vintage,48
-Lobster Two,/Expressive/Vintage,48
-Ingrid Darling,/Expressive/Vintage,47.9
-Yesteryear,/Expressive/Vintage,47.6
-Public Sans,/Expressive/Vintage,47.3
-Gabriela,/Expressive/Vintage,47.3
-Russo One,/Expressive/Vintage,47.3
-Puritan,/Expressive/Vintage,47
-Cookie,/Expressive/Vintage,47
-Grechen Fuemen,/Expressive/Vintage,46.7
-Unkempt,/Expressive/Vintage,46.7
-BioRhyme Expanded,/Expressive/Vintage,46.5
-Alike,/Expressive/Vintage,46.5
-Ribeye,/Expressive/Vintage,46
-Ribeye Marrow,/Expressive/Vintage,46
-MonteCarlo,/Expressive/Vintage,45.4
-Lisu Bosa,/Expressive/Vintage,45
-Dela Gothic One,/Expressive/Vintage,44
-Calligraffitti,/Expressive/Vintage,44
-Trirong,/Expressive/Vintage,43.9
-Berkshire Swash,/Expressive/Vintage,43.9
-Euphoria Script,/Expressive/Vintage,43.9
-Crushed,/Expressive/Vintage,43.4
-Varela Round,/Expressive/Vintage,42.3
-Oswald,/Expressive/Vintage,41.2
-Dongle,/Expressive/Vintage,39.2
-Rufina,/Expressive/Vintage,38.9
-My Soul,/Expressive/Vintage,38.9
-Red Hat Mono,/Expressive/Vintage,38.9
-Rationale,/Expressive/Vintage,38.7
-Stint Ultra Expanded,/Expressive/Vintage,38.7
-Averia Sans Libre,/Expressive/Vintage,38.7
-Codystar,/Expressive/Vintage,38.7
-Monda,/Expressive/Vintage,38.2
-Rubik Dirt,/Expressive/Vintage,37.9
-Six Caps,/Expressive/Vintage,37.8
-Acme,/Expressive/Vintage,37.8
-Glegoo,/Expressive/Vintage,37.6
-Life Savers,/Expressive/Vintage,37.6
-Whisper,/Expressive/Vintage,37.6
-WindSong,/Expressive/Vintage,37.6
-Architects Daughter,/Expressive/Vintage,37.5
-Iceland,/Expressive/Vintage,37.4
-Roboto Slab,/Expressive/Vintage,37.3
-Blaka Ink,/Expressive/Vintage,37.3
-Kaushan Script,/Expressive/Vintage,37.3
-Anybody,/Expressive/Vintage,37
-Amatic SC,/Expressive/Vintage,36.4
-Konkhmer Sleokchher,/Expressive/Vintage,35.8
-Annie Use Your Telescope,/Expressive/Vintage,35.6
-Margarine,/Expressive/Vintage,35.6
-Licorice,/Expressive/Vintage,35.4
-Water Brush,/Expressive/Vintage,35.4
-Borel,/Expressive/Vintage,35
-MuseoModerno,/Expressive/Vintage,34.8
-Sigmar,/Expressive/Vintage,34.5
-Sigmar One,/Expressive/Vintage,34.5
-Kaisei Opti,/Expressive/Vintage,34
-MedievalSharp,/Expressive/Vintage,34
-Darumadrop One,/Expressive/Vintage,34
-Alkatra,/Expressive/Vintage,33.4
-Oooh Baby,/Expressive/Vintage,33.4
-Racing Sans One,/Expressive/Vintage,33.2
-Oxygen Mono,/Expressive/Vintage,33
-Inspiration,/Expressive/Vintage,33
-Gabarito,/Expressive/Vintage,32.9
-Suez One,/Expressive/Vintage,32.4
-Karma,/Expressive/Vintage,32.3
-Fugaz One,/Expressive/Vintage,32
-Sometype Mono,/Expressive/Vintage,28.9
-Devonshire,/Expressive/Vintage,28.9
-JetBrains Mono,/Expressive/Vintage,28.7
-Vesper Libre,/Expressive/Vintage,28.7
-Amethysta,/Expressive/Vintage,28.3
-Cormorant Unicase,/Expressive/Vintage,28
-Tauri,/Expressive/Vintage,28
-Zilla Slab,/Expressive/Vintage,28
-Akaya Kanadaka,/Expressive/Vintage,27.6
-Akaya Telivigala,/Expressive/Vintage,27.6
-Ole,/Expressive/Vintage,27.4
-Fredericka the Great,/Expressive/Vintage,27
-Bigelow Rules,/Expressive/Vintage,26.5
-Chilanka,/Expressive/Vintage,26.4
-Barriecito,/Expressive/Vintage,25.6
-Barrio,/Expressive/Vintage,25.6
-Scope One,/Expressive/Vintage,25.4
-Londrina Outline,/Expressive/Vintage,25.4
-Londrina Shadow,/Expressive/Vintage,25.4
-Londrina Sketch,/Expressive/Vintage,25.4
-Vujahday Script,/Expressive/Vintage,25.4
-Slabo 13px,/Expressive/Vintage,25
-Sedgwick Ave Display,/Expressive/Vintage,25
-Sedgwick Ave,/Expressive/Vintage,24.6
-Square Peg,/Expressive/Vintage,24.5
-Roboto Mono,/Expressive/Vintage,24.3
-Moon Dance,/Expressive/Vintage,22
-Over the Rainbow,/Expressive/Vintage,19
-Karla,/Expressive/Vintage,17
-Merge One,/Expressive/Vintage,16.5
-Signika,/Expressive/Vintage,14.5
-Signika Negative,/Expressive/Vintage,14.5
-Signika Negative SC,/Expressive/Vintage,14.5
-Signika SC,/Expressive/Vintage,14.5
-Princess Sofia,/Expressive/Vintage,14.3
-Source Code Pro,/Expressive/Vintage,14
-Kantumruy Pro,/Expressive/Vintage,13
-Frijole,/Expressive/Vintage,13
-Anta,/Expressive/Futuristic,100
-Anta,/Sans/Geometric,100
-Anta,/Expressive/Stiff,99
-Anta,/Theme/Techno,100
-Fustat,/Arabic/Kufi,90
-Honk,/Expressive/Innovative,100
-Honk,/Expressive/Loud,85
-Honk,/Expressive/Playful,50
-Honk,/Sans/Geometric,10
-Honk,/Theme/Shaded,100
-Micro 5,/Theme/Pixel,100
-Jaro,/Expressive/Loud,82
-Ojuju,/Expressive/Cute,20
-Ojuju,/Expressive/Awkward,60
+Zilla Slab Highlight,/Expressive/Stiff,72

--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -3248,9 +3248,9 @@ Happy Monkey,/Theme/Brush,100
 Harmattan,/Expressive/Calm,93
 Harmattan,/Sans/Grotesque,80
 Harmattan,/Sans/Neo Grotesque,40
-HeadlandOne,/Expressive/Sincere,75
-HeadlandOne,/Expressive/Vintage,72.4
-HeadlandOne,/Serif/Humanist Venetian,80
+Headland One,/Expressive/Sincere,75
+Headland One,/Expressive/Vintage,72.4
+Headland One,/Serif/Humanist Venetian,80
 Heebo,/Expressive/Calm,100
 Heebo,/Sans/Grotesque,90
 Henny Penny,/Expressive/Cute,72
@@ -3412,36 +3412,36 @@ Iceland,/Expressive/Innovative,53
 Iceland,/Expressive/Vintage,37.4
 Iceland,/Theme/Techno,100
 Iceland,/Expressive/Stiff,100
-IM FELL Double Pica,/Expressive/Business,28
-IM FELL Double Pica,/Expressive/Sincere,98
-IM FELL Double Pica,/Expressive/Vintage,89
-IM FELL Double Pica SC,/Expressive/Business,28
-IM FELL Double Pica SC,/Expressive/Sincere,98
-IM FELL Double Pica SC,/Expressive/Vintage,89
-IM FELL DW Pica,/Expressive/Business,28
-IM FELL DW Pica,/Expressive/Sincere,98
-IM FELL DW Pica,/Expressive/Vintage,89
-IM FELL DW Pica SC,/Expressive/Business,28
-IM FELL DW Pica SC,/Expressive/Sincere,98
-IM FELL DW Pica SC,/Expressive/Vintage,89
-IM FELL English,/Expressive/Business,28
-IM FELL English,/Expressive/Sincere,98
-IM FELL English,/Expressive/Vintage,89
-IM FELL English SC,/Expressive/Business,28
-IM FELL English SC,/Expressive/Sincere,98
-IM FELL English SC,/Expressive/Vintage,90
-IM FELL French Canon,/Expressive/Business,28
-IM FELL French Canon,/Expressive/Sincere,98
-IM FELL French Canon,/Expressive/Vintage,90.8
-IM FELL French Canon SC,/Expressive/Business,28
-IM FELL French Canon SC,/Expressive/Sincere,98
-IM FELL French Canon SC,/Expressive/Vintage,89
-IM FELL Great Primer,/Expressive/Business,28
-IM FELL Great Primer,/Expressive/Sincere,98
-IM FELL Great Primer,/Expressive/Vintage,89
-IM FELL Great Primer SC,/Expressive/Business,28
-IM FELL Great Primer SC,/Expressive/Sincere,98
-IM FELL Great Primer SC,/Expressive/Vintage,89
+IM Fell Double Pica,/Expressive/Business,28
+IM Fell Double Pica,/Expressive/Sincere,98
+IM Fell Double Pica,/Expressive/Vintage,89
+IM Fell Double Pica SC,/Expressive/Business,28
+IM Fell Double Pica SC,/Expressive/Sincere,98
+IM Fell Double Pica SC,/Expressive/Vintage,89
+IM Fell DW Pica,/Expressive/Business,28
+IM Fell DW Pica,/Expressive/Sincere,98
+IM Fell DW Pica,/Expressive/Vintage,89
+IM Fell DW Pica SC,/Expressive/Business,28
+IM Fell DW Pica SC,/Expressive/Sincere,98
+IM Fell DW Pica SC,/Expressive/Vintage,89
+IM Fell English,/Expressive/Business,28
+IM Fell English,/Expressive/Sincere,98
+IM Fell English,/Expressive/Vintage,89
+IM Fell English SC,/Expressive/Business,28
+IM Fell English SC,/Expressive/Sincere,98
+IM Fell English SC,/Expressive/Vintage,90
+IM Fell French Canon,/Expressive/Business,28
+IM Fell French Canon,/Expressive/Sincere,98
+IM Fell French Canon,/Expressive/Vintage,90.8
+IM Fell French Canon SC,/Expressive/Business,28
+IM Fell French Canon SC,/Expressive/Sincere,98
+IM Fell French Canon SC,/Expressive/Vintage,89
+IM Fell Great Primer,/Expressive/Business,28
+IM Fell Great Primer,/Expressive/Sincere,98
+IM Fell Great Primer,/Expressive/Vintage,89
+IM Fell Great Primer SC,/Expressive/Business,28
+IM Fell Great Primer SC,/Expressive/Sincere,98
+IM Fell Great Primer SC,/Expressive/Vintage,89
 Imbue,/Expressive/Competent,96.5
 Imbue,/Serif/Didone,100
 Imperial Script,/Expressive/Artistic,100
@@ -3984,10 +3984,7 @@ Kolker Brush,/Expressive/Rugged,19
 Kolker Brush,/Expressive/Vintage,57.8
 Kolker Brush,/Script/Informal,100
 Kolker Brush,/Theme/Brush,100
-Konkhmer Sleokchher,/Expressive/Calm,100
 Konkhmer Sleokchher,/Expressive/Vintage,35.8
-Konkhmer Sleokchher,/Sans/Neo Grotesque,100
-Konkhmer Sleokchher,/Expressive/Stiff,71
 Kosugi,/Expressive/Calm,82
 Kosugi,/Expressive/Competent,19
 Kosugi,/Sans/Grotesque,60
@@ -4046,14 +4043,14 @@ Kumar One,/Serif/Fat Face,30
 Kumar One,/Serif/Modern,100
 Kumar One,/Slab/Geometric,10
 Kumar One,/Expressive/Stiff,93
-Kumar One Inline,/Expressive/Futuristic,91
-Kumar One Inline,/Expressive/Innovative,92
-Kumar One Inline,/Sans/Geometric,10
-Kumar One Inline,/Serif/Fat Face,30
-Kumar One Inline,/Serif/Modern,100
-Kumar One Inline,/Slab/Geometric,10
-Kumar One Inline,/Theme/Inline,50
-Kumar One Inline,/Expressive/Stiff,97
+Kumar One Outline,/Expressive/Futuristic,91
+Kumar One Outline,/Expressive/Innovative,92
+Kumar One Outline,/Sans/Geometric,10
+Kumar One Outline,/Serif/Fat Face,30
+Kumar One Outline,/Serif/Modern,100
+Kumar One Outline,/Slab/Geometric,10
+Kumar One Outline,/Theme/Inline,50
+Kumar One Outline,/Expressive/Stiff,97
 Kumbh Sans,/Expressive/Calm,99
 Kumbh Sans,/Sans/Geometric,100
 Kurale,/Expressive/Calm,73
@@ -4746,7 +4743,6 @@ Metal Mania,/Expressive/Sincere,10.5
 Metal Mania,/Expressive/Vintage,74
 Metal Mania,/Theme/Distressed,100
 Metal Mania,/Theme/Wacky,10
-Metal Mania,/Expressive/Stiff,91
 Metamorphous,/Expressive/Artistic,93
 Metamorphous,/Expressive/Sincere,23
 Metamorphous,/Theme/Medieval,100
@@ -5113,22 +5109,22 @@ Nanum Pen,/Expressive/Happy,47
 Nanum Pen,/Script/Handwritten,100
 Nanum Pen,/Script/Informal,100
 Nanum Pen,/Theme/Brush,100
-NanumGothic,/Expressive/Calm,99
-NanumGothic,/Sans/Grotesque,70
-NanumGothic,/Sans/Humanist,30
-NanumGothicCoding,/Expressive/Calm,78
-NanumGothicCoding,/Expressive/Competent,78.1
-NanumGothicCoding,/Expressive/Futuristic,32
-NanumGothicCoding,/Sans/Geometric,40
-NanumGothicCoding,/Sans/Grotesque,20
-NanumGothicCoding,/Sans/Humanist,20
-NanumGothicCoding,/Slab/Geometric,20
-NanumGothicCoding,/Expressive/Stiff,10
-NanumMyeongjo,/Expressive/Business,98.7
-NanumMyeongjo,/Expressive/Calm,98
-NanumMyeongjo,/Expressive/Vintage,81
-NanumMyeongjo,/Serif/Old Style Garalde,100
-NanumMyeongjo,/Expressive/Stiff,40
+Nanum Gothic,/Expressive/Calm,99
+Nanum Gothic,/Sans/Grotesque,70
+Nanum Gothic,/Sans/Humanist,30
+Nanum Gothic Coding,/Expressive/Calm,78
+Nanum Gothic Coding,/Expressive/Competent,78.1
+Nanum Gothic Coding,/Expressive/Futuristic,32
+Nanum Gothic Coding,/Sans/Geometric,40
+Nanum Gothic Coding,/Sans/Grotesque,20
+Nanum Gothic Coding,/Sans/Humanist,20
+Nanum Gothic Coding,/Slab/Geometric,20
+Nanum Gothic Coding,/Expressive/Stiff,10
+Nanum Myeongjo,/Expressive/Business,98.7
+Nanum Myeongjo,/Expressive/Calm,98
+Nanum Myeongjo,/Expressive/Vintage,81
+Nanum Myeongjo,/Serif/Old Style Garalde,100
+Nanum Myeongjo,/Expressive/Stiff,40
 Narnoor,/Expressive/Calm,99
 Narnoor,/Sans/Humanist,100
 NATS,/Expressive/Business,80.2
@@ -5163,7 +5159,6 @@ New Rocker,/Expressive/Loud,88
 New Rocker,/Expressive/Rugged,98
 New Rocker,/Expressive/Vintage,95
 New Rocker,/Theme/Blackletter,100
-New Rocker,/Expressive/Stiff,91
 New Tegomin,/Expressive/Excited,15
 New Tegomin,/Expressive/Innovative,12
 New Tegomin,/Expressive/Playful,20
@@ -6260,7 +6255,7 @@ Pixelify Sans,/Expressive/Innovative,47
 Pixelify Sans,/Expressive/Loud,59
 Pixelify Sans,/Expressive/Vintage,84.5
 Pixelify Sans,/Theme/Techno,100
-Pixelify Sans,/Expressive/Stiff,76
+Pixelify Sans,/Expressive/Stiff,95
 Plaster,/Expressive/Artistic,91
 Plaster,/Expressive/Loud,99
 Plaster,/Expressive/Rugged,100
@@ -7457,13 +7452,11 @@ Ruwudu,/Expressive/Vintage,77.9
 Ruwudu,/Serif/Old Style Garalde,80
 Ruwudu,/Expressive/Stiff,50
 Rye,/Expressive/Artistic,82
-Rye,/Expressive/Calm,95
 Rye,/Expressive/Innovative,76
 Rye,/Expressive/Vintage,93
 Rye,/Theme/Inline,20
 Rye,/Theme/Tuscan,100
 Rye,/Theme/Woodtype,100
-Rye,/Expressive/Stiff,81
 Sacramento,/Expressive/Artistic,62
 Sacramento,/Expressive/Cute,75
 Sacramento,/Expressive/Fancy,65
@@ -7492,18 +7485,18 @@ Saira Condensed,/Expressive/Competent,99.5
 Saira Condensed,/Expressive/Futuristic,97
 Saira Condensed,/Sans/Superellipse,80
 Saira Condensed,/Expressive/Stiff,98
-Saira ExtraCondensed,/Expressive/Business,68
-Saira ExtraCondensed,/Expressive/Calm,78
-Saira ExtraCondensed,/Expressive/Competent,99.5
-Saira ExtraCondensed,/Expressive/Futuristic,97
-Saira ExtraCondensed,/Sans/Superellipse,80
-Saira ExtraCondensed,/Expressive/Stiff,98
-Saira SemiCondensed,/Expressive/Business,69
-Saira SemiCondensed,/Expressive/Calm,78
-Saira SemiCondensed,/Expressive/Competent,99.5
-Saira SemiCondensed,/Expressive/Futuristic,97
-Saira SemiCondensed,/Sans/Superellipse,80
-Saira SemiCondensed,/Expressive/Stiff,98
+Saira Extra Condensed,/Expressive/Business,68
+Saira Extra Condensed,/Expressive/Calm,78
+Saira Extra Condensed,/Expressive/Competent,99.5
+Saira Extra Condensed,/Expressive/Futuristic,97
+Saira Extra Condensed,/Sans/Superellipse,80
+Saira Extra Condensed,/Expressive/Stiff,98
+Saira Semi Condensed,/Expressive/Business,69
+Saira Semi Condensed,/Expressive/Calm,78
+Saira Semi Condensed,/Expressive/Competent,99.5
+Saira Semi Condensed,/Expressive/Futuristic,97
+Saira Semi Condensed,/Sans/Superellipse,80
+Saira Semi Condensed,/Expressive/Stiff,98
 Saira Stencil One,/Expressive/Calm,31
 Saira Stencil One,/Expressive/Futuristic,99
 Saira Stencil One,/Expressive/Innovative,32


### PR DESCRIPTION
@evanwadams @m4rc1e 

### The following families show no preview on the tagging tool:

_Note: Some of the families are in multiple categories but I'm only listing one instance per category._

#### Sincere:
`IM Fell`: entire family; 'FELL' needs to be spelled 'Fell'; I've updated this in the data
`Molle`
`Hermeneus One` Not available on fonts.google.com
`Headland One` Was 'HeadlandOne' updated to 'Headland One' in the .csv

#### Business:
`Nanum Myeongjo` Was 'NanumMyeongjo' updated to 'Nanum Myeongjo' in the .csv
`Karla Tamil Inclined` Not available on fonts.google.com
`Karla Tamil Upright` Not available on fonts.google.com
`Saira Extra Condensed` Was 'Saira ExtraCondensed' updated to 'Saira Extra Condensed' in the .csv
`Saira Semi Condensed` Was 'Saira SemiCondensed' updated to 'Saira Semi Condensed' in the .csv
`Sunflower` Require this code `<link href="https://fonts.googleapis.com/css2?family=Sunflower:wght@300&display=swap" rel="stylesheet`>
`Signika Negative SC` Not available on fonts.google.com
`Signika SC` Not available on fonts.google.com
`Tuffy` Not available on fonts.google.com
`Porter Sans Block` Not available on fonts.google.com

#### Competent:
`Nanum Gothic Coding` Was 'NanumGothicCoding' updated to 'Nanum Gothic Coding' in the .csv
`Merge One` Not available on fonts.google.com
`NATS` Not available on fonts.google.com

#### Stiff:
`Strong` Not available on fonts.google.com
`Kumar One Outline` Was 'Kumar One Inline' updated to 'Kumar One Outline' in the .csv
`Post No Bills Colombo Medium` Not available on fonts.google.com
`Post No Bills Jaffna` Not available on fonts.google.com
`Sansation` Not available on fonts.google.com
