### PR TITLE
Fix broken link in figcaption

### DIFF
--- a/cc-by-sa/knowledge/modules/designing_hangeul/lessons/an_introduction_to_hangeul/content.md
+++ b/cc-by-sa/knowledge/modules/designing_hangeul/lessons/an_introduction_to_hangeul/content.md
@@ -22,7 +22,11 @@ Since the invention of writing in Mesopotamia more than 5000 years ago, there ha
 
 ![Texts in four scripts.](images/thumbnail.svg)
 
-<figcaption>A montage of texts written in Sumerian, Egyptian, Chinese, and Meso-American [scripts](/glossary/script), intended to show the our species’ creativity and ingenuity in devising alphabets.</figcaption>
+<figcaption>
+
+A montage of texts written in Sumerian, Egyptian, Chinese, and Meso-American [scripts](/glossary/script), intended to show the our species’ creativity and ingenuity in devising alphabets.
+
+</figcaption>
 
 </figure>
 


### PR DESCRIPTION
![Broken link](https://github.com/user-attachments/assets/fdc3eb2e-fe1e-42aa-b6e6-9343bdccce5d)

at https://fonts.google.com/knowledge/designing_hangeul/an_introduction_to_hangeul

(I'm not familiar with the site's build system or style and haven't tested these changes outside of Pandoc, but editing the source of the site and adding correct `<p>` and `<a>` tags

![Old figcaption](https://github.com/user-attachments/assets/a46bd815-f813-4472-a175-c18429fee775)

![The new figcaption wrapped in a paragraph](https://github.com/user-attachments/assets/f3294801-49ec-4ab8-99c3-0fbe8d113ebf)

does not break margins so I assume that this change will work.)