### PR TITLE
Edu families: Dots + Guides fix

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -2284,34 +2284,34 @@ Economica,/Sans/Humanist,80
 Economica,/Sans/Superellipse,100
 Eczar,/Expressive/Vintage,81
 Eczar,/Serif/Old Style Garalde,60
-Edu AU VIC WA NT Arrows Guide,/Expressive/Childlike,90
-Edu AU VIC WA NT Arrows Guide,/Expressive/Cute,15
-Edu AU VIC WA NT Arrows Guide,/Script/Handwritten,100
-Edu AU VIC WA NT Arrows Guide,/Script/Informal,60
+Edu AU VIC WA NT Arrows Guides,/Expressive/Childlike,90
+Edu AU VIC WA NT Arrows Guides,/Expressive/Cute,15
+Edu AU VIC WA NT Arrows Guides,/Script/Handwritten,100
+Edu AU VIC WA NT Arrows Guides,/Script/Informal,60
 Edu AU VIC WA NT Arrows,/Expressive/Childlike,90
 Edu AU VIC WA NT Arrows,/Expressive/Cute,15
 Edu AU VIC WA NT Arrows,/Script/Handwritten,100
 Edu AU VIC WA NT Arrows,/Script/Informal,60
-Edu AU VIC WA NT Cursive Guide,/Expressive/Childlike,90
-Edu AU VIC WA NT Cursive Guide,/Expressive/Cute,15
-Edu AU VIC WA NT Cursive Guide,/Script/Handwritten,100
-Edu AU VIC WA NT Cursive Guide,/Script/Informal,60
+Edu AU VIC WA NT Cursive Guides,/Expressive/Childlike,90
+Edu AU VIC WA NT Cursive Guides,/Expressive/Cute,15
+Edu AU VIC WA NT Cursive Guides,/Script/Handwritten,100
+Edu AU VIC WA NT Cursive Guides,/Script/Informal,60
 Edu AU VIC WA NT Cursive,/Expressive/Childlike,90
 Edu AU VIC WA NT Cursive,/Expressive/Cute,15
 Edu AU VIC WA NT Cursive,/Script/Handwritten,100
 Edu AU VIC WA NT Cursive,/Script/Informal,60
-Edu AU VIC WA NT Dotted Guide,/Expressive/Active,60
-Edu AU VIC WA NT Dotted Guide,/Expressive/Childlike,90
-Edu AU VIC WA NT Dotted Guide,/Script/Handwritten,100
-Edu AU VIC WA NT Dotted Guide,/Script/Informal,60
-Edu AU VIC WA NT Dotted,/Expressive/Active,60
-Edu AU VIC WA NT Dotted,/Expressive/Childlike,90
-Edu AU VIC WA NT Dotted,/Script/Handwritten,100
-Edu AU VIC WA NT Dotted,/Script/Informal,60
-Edu AU VIC WA NT Guide,/Expressive/Active,60
-Edu AU VIC WA NT Guide,/Expressive/Childlike,90
-Edu AU VIC WA NT Guide,/Script/Handwritten,100
-Edu AU VIC WA NT Guide,/Script/Informal,60
+Edu AU VIC WA NT Dots Guides,/Expressive/Active,60
+Edu AU VIC WA NT Dots Guides,/Expressive/Childlike,90
+Edu AU VIC WA NT Dots Guides,/Script/Handwritten,100
+Edu AU VIC WA NT Dots Guides,/Script/Informal,60
+Edu AU VIC WA NT Dots,/Expressive/Active,60
+Edu AU VIC WA NT Dots,/Expressive/Childlike,90
+Edu AU VIC WA NT Dots,/Script/Handwritten,100
+Edu AU VIC WA NT Dots,/Script/Informal,60
+Edu AU VIC WA NT Guides,/Expressive/Active,60
+Edu AU VIC WA NT Guides,/Expressive/Childlike,90
+Edu AU VIC WA NT Guides,/Script/Handwritten,100
+Edu AU VIC WA NT Guides,/Script/Informal,60
 Edu AU VIC WA NT Hand Pre,/Expressive/Active,60
 Edu AU VIC WA NT Hand Pre,/Expressive/Childlike,90
 Edu AU VIC WA NT Hand Pre,/Script/Handwritten,100
@@ -2320,29 +2320,26 @@ Edu AU VIC WA NT Hand,/Expressive/Childlike,90
 Edu AU VIC WA NT Hand,/Expressive/Cute,15
 Edu AU VIC WA NT Hand,/Script/Handwritten,100
 Edu AU VIC WA NT Hand,/Script/Informal,60
-Edu AU VIC WA NT Outline Guide,/Expressive/Active,60
-Edu AU VIC WA NT Outline Guide,/Expressive/Childlike,90
-Edu AU VIC WA NT Outline Guide,/Script/Handwritten,100
-Edu AU VIC WA NT Outline Guide,/Script/Informal,60
+Edu AU VIC WA NT Outline Guides,/Expressive/Active,60
+Edu AU VIC WA NT Outline Guides,/Expressive/Childlike,90
+Edu AU VIC WA NT Outline Guides,/Script/Handwritten,100
+Edu AU VIC WA NT Outline Guides,/Script/Informal,60
 Edu AU VIC WA NT Outline,/Expressive/Active,60
 Edu AU VIC WA NT Outline,/Expressive/Childlike,90
 Edu AU VIC WA NT Outline,/Script/Handwritten,100
 Edu AU VIC WA NT Outline,/Script/Informal,60
-Edu AU VIC WA NT Pre Guide,/Expressive/Active,60
-Edu AU VIC WA NT Pre Guide,/Expressive/Childlike,90
-Edu AU VIC WA NT Pre Guide,/Script/Handwritten,100
-Edu AU VIC WA NT Pre Guide,/Script/Informal,60
-Edu AU VIC WA NT Starters Guide,/Expressive/Active,60
-Edu AU VIC WA NT Starters Guide,/Expressive/Childlike,90
-Edu AU VIC WA NT Starters Guide,/Script/Handwritten,100
-Edu AU VIC WA NT Starters Guide,/Script/Informal,60
+Edu AU VIC WA NT Pre Guides,/Expressive/Active,60
+Edu AU VIC WA NT Pre Guides,/Expressive/Childlike,90
+Edu AU VIC WA NT Pre Guides,/Script/Handwritten,100
+Edu AU VIC WA NT Pre Guides,/Script/Informal,60
+Edu AU VIC WA NT Starters Guides,/Expressive/Active,60
+Edu AU VIC WA NT Starters Guides,/Expressive/Childlike,90
+Edu AU VIC WA NT Starters Guides,/Script/Handwritten,100
+Edu AU VIC WA NT Starters Guides,/Script/Informal,60
 Edu AU VIC WA NT Starters,/Expressive/Active,60
 Edu AU VIC WA NT Starters,/Expressive/Childlike,90
 Edu AU VIC WA NT Starters,/Script/Handwritten,100
 Edu AU VIC WA NT Starters,/Script/Informal,60
-Edu Australia VIC WA NT Hand Dots,/Expressive/Active,100
-Edu Australia VIC WA NT Hand Dots,/Expressive/Childlike,12
-Edu Australia VIC WA NT Hand Dots,/Script/Handwritten,100
 Edu NSW ACT Foundation,/Expressive/Active,59
 Edu NSW ACT Foundation,/Expressive/Childlike,90
 Edu NSW ACT Foundation,/Expressive/Sincere,100


### PR DESCRIPTION
 @m4rc1e this PR fixes:

- [x]  #8153 – the Edu families need to use the Family name `AU` instead of "Australia"
- [x] Changes the former `Dotted` and `Guide` to `Dots` and `Guides` for all the Edu families, as these are the agreed names for these variants in the educational handwriting fonts in the Catalog e.g. #8021


cc @emmamarichal, so we are all in sync for these PRs revision.