### PR TITLE
Upgrade upload-artifact

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload check results
         if: steps.check_files.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: qa
           path: out/
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload check results
         if: steps.check_files.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: qa
           path: out/


### PR DESCRIPTION
CI runs are currently cancelled due to using a deprecated version of upload-artifacts; upgrades it.