### PR TITLE
Update families.csv: Inknut Antiqua

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -3477,15 +3477,12 @@ Ingrid Darling,/Theme/Wacky,40
 Inika,/Expressive/Awkward,12
 Inika,/Expressive/Sincere,58
 Inika,/Serif/Old Style Garalde,10
-Inknut Antiqua,/Expressive/Business,80.1
-Inknut Antiqua,/Expressive/Calm,89
-Inknut Antiqua,/Expressive/Futuristic,63
-Inknut Antiqua,/Expressive/Innovative,12
-Inknut Antiqua,/Expressive/Loud,72
-Inknut Antiqua,/Expressive/Sincere,44.5
-Inknut Antiqua,/Expressive/Stiff,81
-Inknut Antiqua,/Script/Formal,20
-Inknut Antiqua,/Serif/Humanist Venetian,80
+Inknut Antiqua,/Expressive/Business,70
+Inknut Antiqua,/Expressive/Calm,90
+Inknut Antiqua,/Expressive/Loud,70
+Inknut Antiqua,/Expressive/Sincere,50
+Inknut Antiqua,/Expressive/Stiff,80
+Inknut Antiqua,/Serif/Humanist Venetian,90
 Inria Sans,/Expressive/Business,92
 Inria Sans,/Expressive/Calm,96
 Inria Sans,/Expressive/Competent,12


### PR DESCRIPTION
Following Evan's comment, the following tags have been removed from Inknut Antiqua:

- [x] Expressive/Futuristic
- [x] Expressive/Innovate
- [x] Script/Formal

