### PR TITLE
Give artefacts individual names

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,9 +61,9 @@ jobs:
 
       - name: Upload check results
         if: steps.check_files.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
-          name: diffbrowsers-${{matrix.os}}
+          name: qa
           path: out/
 
   diffenator:
@@ -110,9 +110,9 @@ jobs:
 
       - name: Upload check results
         if: steps.check_files.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
-          name: diffenator-fontbakery
+          name: qa
           path: out/
 
   ftxvalidator:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,7 +63,7 @@ jobs:
         if: steps.check_files.outputs.files_exists == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: qa
+          name: diffbrowsers-${{matrix.os}}
           path: out/
 
   diffenator:
@@ -112,7 +112,7 @@ jobs:
         if: steps.check_files.outputs.files_exists == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: qa
+          name: diffenator-fontbakery
           path: out/
 
   ftxvalidator:


### PR DESCRIPTION
CI is currently failing because four jobs are all trying to upload an artifact called "qa", and whichever gets there first wins and causes the others to error. This makes sure all artifacts have distinct names.