### PR TITLE
Update families.csv: Host Grotesk

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -2960,6 +2960,11 @@ Honk,/Expressive/Loud,85
 Honk,/Expressive/Playful,50
 Honk,/Sans/Geometric,10
 Honk,/Theme/Shaded,100
+Host Grotesk,/Expressive/Business,96
+Host Grotesk,/Expressive/Calm,95
+Host Grotesk,/Expressive/Competent,23.5
+Host Grotesk,/Sans/Geometric,80
+Host Grotesk,/Sans/Grotesque,100
 Hubballi,/Expressive/Calm,68.8
 Hubballi,/Expressive/Childlike,70
 Hubballi,/Expressive/Cute,35


### PR DESCRIPTION
These are the tags for Host Grotesk family #8247.

- Host Grotesk,/Expressive/Business,96
- Host Grotesk,/Expressive/Calm,95
- Host Grotesk,/Expressive/Competent,23.5
- Host Grotesk,/Sans/Geometric,80
- Host Grotesk,/Sans/Grotesque,100

![image](https://github.com/user-attachments/assets/ba6f7e25-0bd0-4b38-9c92-49203449b31d)d)
