### PR TITLE
Update METADATA.pb

### DIFF
--- a/ofl/librebarcodeean13text/METADATA.pb
+++ b/ofl/librebarcodeean13text/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Libre Barcode EAN13 Text Regular"
   copyright: "Copyright 2017-2020 The Libre Barcode Project Authors (https://github.com/graphicore/librebarcode)"
 }
-subsets: "latin"
 subsets: "menu"
 source {
   repository_url: "https://github.com/graphicore/librebarcode"


### PR DESCRIPTION
Removing `subsets: "latin"` as `Libre Barcode EAN13 Text` is a barcode font that only supports numbers and some alphabets. 

Using the pre-defined `sample_text` should be enough to showcase what this font is capable of doing.