### PR TITLE
Cyrillic subset delisted from Gesit fonts

### DIFF
--- a/ofl/geist/METADATA.pb
+++ b/ofl/geist/METADATA.pb
@@ -12,8 +12,6 @@ fonts {
   full_name: "Geist Regular"
   copyright: "Copyright 2024 The Geist Project Authors (https://github.com/vercel/geist-font.git)"
 }
-subsets: "cyrillic"
-subsets: "cyrillic-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"

--- a/ofl/geistmono/METADATA.pb
+++ b/ofl/geistmono/METADATA.pb
@@ -12,8 +12,6 @@ fonts {
   full_name: "Geist Mono Regular"
   copyright: "Copyright 2024 The Geist Project Authors (https://github.com/vercel/geist-font.git)"
 }
-subsets: "cyrillic"
-subsets: "cyrillic-ext"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"


### PR DESCRIPTION
@emmamarichal this PR delist Cyrillic for Geist and Geist Mono.

This change will continue to be tracked by the original font PR's #8246 #8264, so I'm not adding this PR to the traffic board.