### PR TITLE
ci: update `upload-artifact` and `download-artifact` actions to v4

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@184d73b71b93c222403b2e7f1ffebe4508014249 # v4.4.3
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,9 +61,9 @@ jobs:
 
       - name: Upload check results
         if: steps.check_files.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: qa
+          name: qa-diffbrowsers-${{ matrix.os }}
           path: out/
 
   diffenator:
@@ -111,9 +111,9 @@ jobs:
 
       - name: Upload check results
         if: steps.check_files.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: qa
+          name: qa-diffenator
           path: out/
 
   ftxvalidator:

--- a/axisregistry/.github/workflows/publish-release.yml
+++ b/axisregistry/.github/workflows/publish-release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -69,7 +69,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
v3 of `actions/upload-artifact` and `actions/download-artifact` will be fully deprecated by 5 December 2024. Jobs that are scheduled to run during the brownout periods will also fail. See:

1. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
2. https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/

An attempt was made to update the artifact actions in PR https://github.com/google/fonts/pull/8159, but the version was eventually downgraded from `v4` to `v3` due to artifact name conficts in PR https://github.com/google/fonts/pull/8210. This is because v4 of `actions/upload-artifact` does not allow uploading to the same artifact name anymore and we need to give each artifact a unique name. See:

1. https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact
2. https://github.com/actions/upload-artifact?tab=readme-ov-file#not-uploading-to-the-same-artifact
3. https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

/cc @simoncozens @m4rc1e 