### PR TITLE
Fix incorrect metadata for several Korean families.

### DIFF
--- a/ofl/blackandwhitepicture/METADATA.pb
+++ b/ofl/blackandwhitepicture/METADATA.pb
@@ -13,5 +13,6 @@ fonts {
   copyright: "Copyright (c) 1992-2018 AsiaSoft Inc. Seoul Korea All Rights Reserved."
 }
 subsets: "korean"
+subsets: "latin"
 subsets: "menu"
 primary_script: "Kore"

--- a/ofl/blackhansans/METADATA.pb
+++ b/ofl/blackhansans/METADATA.pb
@@ -13,6 +13,7 @@ fonts {
   copyright: "Copyright 2015 The Black Han Sans Authors"
 }
 subsets: "korean"
+subsets: "latin"
 subsets: "menu"
 primary_script: "Kore"
 stroke: "SANS_SERIF"

--- a/ofl/cutefont/METADATA.pb
+++ b/ofl/cutefont/METADATA.pb
@@ -13,6 +13,7 @@ fonts {
   copyright: "COPYRIGHT  2004-2017 by TypoDesign Lab. Inc. All rights reserved. Font designed by TypoDesign Lab. Inc."
 }
 subsets: "korean"
+subsets: "latin"
 subsets: "menu"
 primary_script: "Kore"
 stroke: "SANS_SERIF"

--- a/ofl/dokdo/METADATA.pb
+++ b/ofl/dokdo/METADATA.pb
@@ -13,5 +13,6 @@ fonts {
   copyright: "Copyright (c) 2005-2017 FONTRIX. All Rights Reserved."
 }
 subsets: "korean"
+subsets: "latin"
 subsets: "menu"
 primary_script: "Kore"

--- a/ofl/gaegu/METADATA.pb
+++ b/ofl/gaegu/METADATA.pb
@@ -31,6 +31,7 @@ fonts {
   copyright: "Copyright 2018 The Gaegu Project Authors"
 }
 subsets: "korean"
+subsets: "latin"
 subsets: "menu"
 primary_script: "Kore"
 stroke: "SANS_SERIF"

--- a/ofl/gugi/METADATA.pb
+++ b/ofl/gugi/METADATA.pb
@@ -13,6 +13,7 @@ fonts {
   copyright: "Copyright (c) 2017 by TAE System & Typefaces Co.. All rights reserved."
 }
 subsets: "korean"
+subsets: "latin"
 subsets: "menu"
 primary_script: "Kore"
 stroke: "SANS_SERIF"

--- a/ofl/nanumgothic/METADATA.pb
+++ b/ofl/nanumgothic/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 fonts {
   name: "Nanum Gothic"
   style: "normal"
-  weight: 600
+  weight: 700
   filename: "NanumGothic-Bold.ttf"
   post_script_name: "NanumGothicBold"
   full_name: "NanumGothicBold"
@@ -24,7 +24,7 @@ fonts {
 fonts {
   name: "Nanum Gothic"
   style: "normal"
-  weight: 700
+  weight: 800
   filename: "NanumGothic-ExtraBold.ttf"
   post_script_name: "NanumGothicExtraBold"
   full_name: "NanumGothicExtraBold"

--- a/ofl/nanumgothiccoding/METADATA.pb
+++ b/ofl/nanumgothiccoding/METADATA.pb
@@ -22,6 +22,7 @@ fonts {
   copyright: "Copyright © 2009 NHN Corporation. All rights reserved. Font designed by Sandoll Communications Inc."
 }
 subsets: "menu"
+subsets: "latin"
 subsets: "korean"
 primary_script: "Kore"
 stroke: "SANS_SERIF"

--- a/ofl/nanummyeongjo/METADATA.pb
+++ b/ofl/nanummyeongjo/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 fonts {
   name: "Nanum Myeongjo"
   style: "normal"
-  weight: 600
+  weight: 700
   filename: "NanumMyeongjo-Bold.ttf"
   post_script_name: "NanumMyeongjoBold"
   full_name: "NanumMyeongjoBold"
@@ -24,7 +24,7 @@ fonts {
 fonts {
   name: "Nanum Myeongjo"
   style: "normal"
-  weight: 700
+  weight: 800
   filename: "NanumMyeongjo-ExtraBold.ttf"
   post_script_name: "NanumMyeongjoExtraBold"
   full_name: "NanumMyeongjoExtraBold"

--- a/ofl/nanumpenscript/METADATA.pb
+++ b/ofl/nanumpenscript/METADATA.pb
@@ -13,5 +13,6 @@ fonts {
   copyright: "Copyright © 2010 NHN Corporation. All rights reserved. Font designed by Sandoll Communications Inc."
 }
 subsets: "menu"
+subsets: "latin"
 subsets: "korean"
 primary_script: "Kore"


### PR DESCRIPTION
- Nanum Gothic and Nanum Myeongjo had incorrectly specified weights.
- The remaining families don't list a latin subset but do have basic latin support.