### PR TITLE
PW Guides Links fixes

### DIFF
--- a/ofl/playwritearguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritearguides/article/ARTICLE.en_us.html
@@ -23,7 +23,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+AR/about#playwrite-argentina-Guides_characteristics">Playwrite Argentina.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+AR/about#playwrite-argentina-characteristics">Playwrite Argentina.</a>
 </p>
 <img src="Playwrite-Argentina-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteaunswguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteaunswguides/article/ARTICLE.en_us.html
@@ -34,7 +34,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+AU+NSW/about#playwrite-australia-nsw-Guides_characteristics">Playwrite Australia NSW.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+AU+NSW/about#playwrite-australia-nsw-characteristics">Playwrite Australia NSW.</a>
 </p>
 <img src="Playwrite-Australia-NSW-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteauqldguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteauqldguides/article/ARTICLE.en_us.html
@@ -34,7 +34,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+AU+QLD/about#playwrite-australia-qld-Guides_characteristics">Playwrite Australia QLD.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+AU+QLD/about#playwrite-australia-qld-characteristics">Playwrite Australia QLD.</a>
 </p>
 <img src="Playwrite-Australia-QLD-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteausaguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteausaguides/article/ARTICLE.en_us.html
@@ -34,7 +34,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+AU+SA/about#playwrite-australia-sa-Guides_characteristics">Playwrite Australia SA.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+AU+SA/about#playwrite-australia-sa-characteristics">Playwrite Australia SA.</a>
 </p>
 <img src="Playwrite-Australia-SA-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritebevlgguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritebevlgguides/article/ARTICLE.en_us.html
@@ -1,5 +1,5 @@
 <p>
-    Playwrite België Vlaams Gewest Guides is a single-weight font designed to harmonize seamlessly with its companion, <a href="https://fonts.google.com/specimen/Playwrite+BE+WAL">Playwrite België Vlaams Gewest</a>. This font includes guideline markers on the baseline, x-height, ascenders, and descenders, providing a visual aid for primary school children. These guides help young learners grasp the proportions of letterforms and assist them in drawing letters with confidence and accuracy.
+    Playwrite België Vlaanderen Guides is a single-weight font designed to harmonize seamlessly with its companion, <a href="https://fonts.google.com/specimen/Playwrite+BE+WAL">Playwrite België Vlaanderen</a>. This font includes guideline markers on the baseline, x-height, ascenders, and descenders, providing a visual aid for primary school children. These guides help young learners grasp the proportions of letterforms and assist them in drawing letters with confidence and accuracy.
 </p>
 <p>
 	The Dutch-French language divide in Belgium, a phenomenon with roots stretching
@@ -23,18 +23,18 @@
 <hr />
 <img src="Playwrite-Belgie-Vlaanderen-Guides_1.png" />
 
-<h4>Playwrite België Vlaams Gewest characteristics</h4>
+<h4>Playwrite België Vlaanderen characteristics</h4>
 
 <p>
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+BE+VLG/about?query=VLG#playwrite-belgi-vlaams-gewest-characteristics">Playwrite België Vlaams Gewest.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+BE+VLG/about?query=VLG#playwrite-belgi-vlaams-gewest-characteristics">Playwrite België Vlaanderen.</a>
 </p>
 <img src="Playwrite-Belgie-Vlaanderen-Guides_3.png" />
 <h4>Family name in font menus</h4>
 <p>
-	Playwrite België Vlaams Gewest Guides appears in font menus with a two-letter country
+	Playwrite België Vlaanderen Guides appears in font menus with a two-letter country
 	code ‘BE’ and a the ‘VLG’ abbreviation <strong>Playwrite BE VLG Guides</strong>, and features a single Regular weight.
 	<br />
 	The download .zip file includes the static font for this guided version.

--- a/ofl/playwritebewalguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritebewalguides/article/ARTICLE.en_us.html
@@ -1,5 +1,5 @@
 <p>
-    Playwrite België Walloon Guides is a single-weight font designed to harmonize seamlessly with its companion, <a href="https://fonts.google.com/specimen/Playwrite+BE+WAL">Playwrite België Walloon</a>. This font includes guideline markers on the baseline, x-height, ascenders, and descenders, providing a visual aid for primary school children. These guides help young learners grasp the proportions of letterforms and assist them in drawing letters with confidence and accuracy.
+    Playwrite Belgique Wallonie-Bruxelles Guides is a single-weight font designed to harmonize seamlessly with its companion, <a href="https://fonts.google.com/specimen/Playwrite+BE+WAL">Playwrite Belgique Wallonie-Bruxelles</a>. This font includes guideline markers on the baseline, x-height, ascenders, and descenders, providing a visual aid for primary school children. These guides help young learners grasp the proportions of letterforms and assist them in drawing letters with confidence and accuracy.
 </p>
 <p>
 	The Dutch-French language divide in Belgium, a phenomenon with roots stretching
@@ -24,18 +24,18 @@
 <hr />
 <img src="Playwrite-Belgique-Wallonie-Bruxelles-Guides_1.png" />
 
-<h4>Playwrite België Walloon Guides characteristics</h4>
+<h4>Playwrite Belgique Wallonie-Bruxelles Guides characteristics</h4>
 
 <p>
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+BE+WAL/about#playwrite-belgi-walloon-characteristics">Playwrite België Walloon.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+BE+WAL/about#playwrite-belgi-walloon-characteristics">Playwrite Belgique Wallonie-Bruxelles.</a>
 </p>
 <img src="Playwrite-Belgique-Wallonie-Bruxelles-Guides_3.png" />
 <h4>Family name in font menus</h4>
 <p>
-	Playwrite België Walloon Guides appears in font menus with a two-letter country code
+	Playwrite Belgique Wallonie-Bruxelles Guides appears in font menus with a two-letter country code
 	‘BE’ and a the ‘WAL’ abbreviation <strong>Playwrite BE WAL Guides</strong>, and features a single Regular weight.
 	<br />
 	The download .zip file includes the static font for this guided version.

--- a/ofl/playwritebrguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritebrguides/article/ARTICLE.en_us.html
@@ -32,7 +32,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+BR/about#playwrite-brasil-Guides_characteristics">Playwrite Brasil.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+BR/about#playwrite-brasil-characteristics">Playwrite Brasil.</a>
 </p>
 <img src="Playwrite-Brasil-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritecaguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritecaguides/article/ARTICLE.en_us.html
@@ -1,5 +1,5 @@
 <p>
-    Playwrite Canada Guides is a single-weight font designed to harmonize seamlessly with its companion, <a href="https://fonts.google.com/specimen/Playwrite+AR">Playwrite Canada</a>. This font includes guideline markers on the baseline, x-height, ascenders, and descenders, providing a visual aid for primary school children. These guides help young learners grasp the proportions of letterforms and assist them in drawing letters with confidence and accuracy.
+    Playwrite Canada Guides is a single-weight font designed to harmonize seamlessly with its companion, <a href="https://fonts.google.com/specimen/Playwrite+CA">Playwrite Canada</a>. This font includes guideline markers on the baseline, x-height, ascenders, and descenders, providing a visual aid for primary school children. These guides help young learners grasp the proportions of letterforms and assist them in drawing letters with confidence and accuracy.
 </p>
 <p>
 	The traditional method of handwriting instruction in Canada is called
@@ -27,7 +27,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+CA/about#playwrite-canada-Guides_characteristics">Playwrite Canada.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+CA/about#playwrite-canada-characteristics">Playwrite Canada.</a>
 </p>
 <img src="Playwrite-Canada-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritecuguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritecuguides/article/ARTICLE.en_us.html
@@ -27,7 +27,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+CU/about#playwrite-cuba-Guides_characteristics">Playwrite Cuba.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+CU/about#playwrite-cuba-characteristics">Playwrite Cuba.</a>
 </p>
 <img src="Playwrite-Cuba-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritedegrundguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritedegrundguides/article/ARTICLE.en_us.html
@@ -38,7 +38,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+DE+Grund/about#playwrite-deutschland-grundschrift-Guides_characteristics">Playwrite Deutschland Grundschrift.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+DE+Grund/about#playwrite-deutschland-grundschrift-characteristics">Playwrite Deutschland Grundschrift.</a>
 </p>
 <img src="Playwrite-Deutschland-Grundschrift-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritedkloopetguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritedkloopetguides/article/ARTICLE.en_us.html
@@ -28,7 +28,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+DK+Loopet/about#playwrite-danmark-loopet-Guides_characteristics">Playwrite Danmark Loopet.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+DK+Loopet/about#playwrite-danmark-loopet-characteristics">Playwrite Danmark Loopet.</a>
 </p>
 <img src="Playwrite-Danmark-Loopet-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritedkuloopetguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritedkuloopetguides/article/ARTICLE.en_us.html
@@ -29,7 +29,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+DK+Uloopet/about?query=Danm#playwrite-danmark-uloopet-Guides_characteristics">Playwrite Danmark Uloopet.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+DK+Uloopet/about?query=Danm#playwrite-danmark-uloopet-characteristics">Playwrite Danmark Uloopet.</a>
 </p>
 <img src="Playwrite-Danmark-Uloopet-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritefrmoderneguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritefrmoderneguides/article/ARTICLE.en_us.html
@@ -35,7 +35,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+FR+Moderne/about#playwrite-france-moderne-Guides_characteristics">Playwrite France Moderne.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+FR+Moderne/about#playwrite-france-moderne-characteristics">Playwrite France Moderne.</a>
 </p>
 <img src="Playwrite-France-Moderne-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritefrtradguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritefrtradguides/article/ARTICLE.en_us.html
@@ -37,7 +37,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+FR+Trad/about#playwrite-france-traditionnelle-Guides_characteristics">Playwrite France Traditionnelle.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+FR+Trad/about#playwrite-france-traditionnelle-characteristics">Playwrite France Traditionnelle.</a>
 </p>
 <img src="Playwrite-France-Traditionnelle-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritehrguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritehrguides/article/ARTICLE.en_us.html
@@ -27,7 +27,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+HR/about#playwrite-hrvatska-Guides_characteristics">Playwrite Hrvatska.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+HR/about#playwrite-hrvatska-characteristics">Playwrite Hrvatska.</a>
 </p>
 <img src="Playwrite-Hrvatska-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritehrlijevaguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritehrlijevaguides/article/ARTICLE.en_us.html
@@ -27,7 +27,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+HR+Lijeva/about#playwrite-hrvatska-lijeva-Guides_characteristics">Playwrite Playwrite Hrvatska Lijeva.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+HR+Lijeva/about#playwrite-hrvatska-lijeva-characteristics">Playwrite Playwrite Hrvatska Lijeva.</a>
 </p>
 <img src="Playwrite-Hrvatska-Lijeva-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteidguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteidguides/article/ARTICLE.en_us.html
@@ -24,7 +24,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+ID/about#playwrite-indonesia-Guides_characteristics">Playwrite Indonesia.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+ID/about#playwrite-indonesia-characteristics">Playwrite Indonesia.</a>
 </p>
 <img src="Playwrite-Indonesia-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteieguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteieguides/article/ARTICLE.en_us.html
@@ -32,7 +32,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+IE/about?query=Irel#playwrite-ireland-Guides_characteristics">Playwrite Ireland.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+ID/about#playwrite-indonesia-characteristics">Playwrite Ireland.</a>
 </p>
 <img src="Playwrite-Ireland-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteieguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteieguides/article/ARTICLE.en_us.html
@@ -32,7 +32,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+ID/about#playwrite-indonesia-characteristics">Playwrite Ireland.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+IE/about?query=Irel#playwrite-ireland-characteristics">Playwrite Ireland.</a>
 </p>
 <img src="Playwrite-Ireland-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteinguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteinguides/article/ARTICLE.en_us.html
@@ -31,7 +31,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+IN/about#playwrite-india-Guides_characteristics">Playwrite India.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+IN/about#playwrite-india-characteristics">Playwrite India.</a>
 </p>
 <img src="Playwrite-India-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteitmodernaguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteitmodernaguides/article/ARTICLE.en_us.html
@@ -35,7 +35,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+IT+Moderna/about#playwrite-italia-moderna-Guides_characteristics">Playwrite Italia Moderna.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+IT+Moderna/about#playwrite-italia-moderna-characteristics">Playwrite Italia Moderna.</a>
 </p>
 <img src="Playwrite-Italia-Moderna-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteittradguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteittradguides/article/ARTICLE.en_us.html
@@ -1,4 +1,7 @@
 <p>
+    Playwrite Italia Tradizionale Guides is a single-weight font designed to harmonize seamlessly with its companion, <a href="https://fonts.google.com/specimen/Playwrite+IT+Trad">Playwrite Italia Tradizionale</a>. This font includes guideline markers on the baseline, x-height, ascenders, and descenders, providing a visual aid for primary school children. These guides help young learners grasp the proportions of letterforms and assist them in drawing letters with confidence and accuracy.
+</p>
+<p>
 	Italy holds an important place in the historical development of handwriting
 	styles. Handwriting produced in the Latin script finds its roots in the models
 	produced during the Italian Renaissance. The most prevalent form of handwriting
@@ -19,10 +22,6 @@
 	recognition among the latter.
 </p>
 <p>
-	Playwrite Italia Tradizionale is a variable font with a weight range from Thin
-	(100) to Regular (400), and supports over 150 Latin-based languages.
-</p>
-<p>
 	To contribute, see
 	<a href="https://github.com/TypeTogether/Playwrite/">
     github.com/TypeTogether/Playwrite</a>.
@@ -33,19 +32,16 @@
 <h4>Playwrite Italia Tradizionale characteristics</h4>
 
 <p>
-	This upright, fully joined, modern cursive features short ascenders and
-	descenders. It utilizes simplified print-style capital letters. Distinctive
-	identity traits include a serifed 'I' and an 'M' with splain legs. Lowercase
-	letters 'f', 'g', 'j', and 'y' employ descender loops to connect to the next
-	letter seamlessly. Both 'p' and 'b' are designed with closed bowls, 'k' is
-	constructed with two strokes, and 'f' is notable for the absence of its top
-	loop, creating a recognizable handwriting model.
+	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
+</p>
+<p>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+IT+Trad/about#playwrite-italia-tradizionale-characteristics">Playwrite Italia Tradizionale.</a>
 </p>
 <img src="Playwrite-Italia-Tradizionale-Guides_3.png" />
 <h4>Family name in font menus</h4>
 <p>
 	Playwrite Italia Tradizionale appears in font menus with a two-letter country
-	code, ‘IT’ and a the ‘Trad’ abbreviation, <strong>Playwrite IT Trad</strong>. It
+	code, ‘IT’ and a the ‘Trad’ abbreviation, <strong>Playwrite IT Trad Guides</strong>. It
 	features four styles: Thin, ExtraLight, Light, and Regular.
 	<br />
 	The download .zip file includes the variable font and standard static ttf fonts
@@ -102,7 +98,7 @@
 </p>
 <p>
     <strong>Google Docs and Slides:</strong> From the font selector drop-down, go to "More Fonts" 
-    and search for the desired font name, in this case, "Playwrite IT Trad", and click OK. 
+    and search for the desired font name, in this case, "Playwrite IT Trad Guides", and click OK. 
     If some text is already selected, the font choice will apply.
 </p>
 <p>

--- a/ofl/playwritengmodernguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritengmodernguides/article/ARTICLE.en_us.html
@@ -33,7 +33,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+NG+Modern/about#playwrite-nigeria-modern-Guides_characteristics">Playwrite Nigeria Modern.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+NG+Modern/about#playwrite-nigeria-modern-characteristics">Playwrite Nigeria Modern.</a>
 </p>
 <img src="Playwrite-Nigeria-Modern-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritenlguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritenlguides/article/ARTICLE.en_us.html
@@ -24,7 +24,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+NL/about?query=Neth#playwrite-netherland-Guides_characteristics">Playwrite Netherland.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+NL/about?query=Neth#playwrite-netherland-characteristics">Playwrite Netherland.</a>
 </p>
 <img src="Playwrite-Netherland-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritenoguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritenoguides/article/ARTICLE.en_us.html
@@ -26,7 +26,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+NO/about#playwrite-norge-Guides_characteristics">Playwrite Norge.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+NO/about#playwrite-norge-characteristics">Playwrite Norge.</a>
 </p>
 <img src="Playwrite-Norge-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritenzguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritenzguides/article/ARTICLE.en_us.html
@@ -27,7 +27,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+NZ/about#playwrite-new-zealand-Guides_characteristics">Playwrite New Zealand.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+NZ/about#playwrite-new-zealand-characteristics">Playwrite New Zealand.</a>
 </p>
 <img src="Playwrite-New-Zealand-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteplguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteplguides/article/ARTICLE.en_us.html
@@ -29,7 +29,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+PL/about#playwrite-polska-Guides_characteristics">Playwrite Polska.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+PL/about#playwrite-polska-characteristics">Playwrite Polska.</a>
 </p>
 <img src="Playwrite-Polska-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteptguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteptguides/article/ARTICLE.en_us.html
@@ -27,7 +27,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+PT/about#playwrite-portugal-Guides_characteristics">Playwrite Portugal.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+PT/about#playwrite-portugal-characteristics">Playwrite Portugal.</a>
 </p>
 <img src="Playwrite-Portugal-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteskguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteskguides/article/ARTICLE.en_us.html
@@ -22,7 +22,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+SK/about#playwrite-slovensko-Guides_characteristics">Playwrite Slovensko.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+SK/about#playwrite-slovensko-characteristics">Playwrite Slovensko.</a>
 </p>
 <img src="Playwrite-Slovensko-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritetzguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritetzguides/article/ARTICLE.en_us.html
@@ -31,7 +31,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+TZ/about?query=Tanza#playwrite-tanzania-Guides_characteristics">Playwrite Tanzania.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+TZ/about?query=Tanza#playwrite-tanzania-characteristics">Playwrite Tanzania.</a>
 </p>
 <img src="Playwrite-Tanzania-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteusmodernguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteusmodernguides/article/ARTICLE.en_us.html
@@ -28,7 +28,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+US+Modern/about#playwrite-usa-modern-characteristics">Playwrite USA Modern.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+US+Trad/about#playwrite-usa-traditional-characteristics">Playwrite USA Modern.</a>
 </p>
 <img src="Playwrite-USA-Modern-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteusmodernguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteusmodernguides/article/ARTICLE.en_us.html
@@ -28,7 +28,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+US+Modern/about#playwrite-usa-modern-Guides_characteristics">Playwrite USA Modern.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+US+Modern/about#playwrite-usa-modern-characteristics">Playwrite USA Modern.</a>
 </p>
 <img src="Playwrite-USA-Modern-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteusmodernguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteusmodernguides/article/ARTICLE.en_us.html
@@ -28,7 +28,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+US+Trad/about#playwrite-usa-traditional-characteristics">Playwrite USA Modern.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+US+Modern/about#playwrite-usa-modern-characteristics">Playwrite USA Modern.</a>
 </p>
 <img src="Playwrite-USA-Modern-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwriteustradguides/article/ARTICLE.en_us.html
+++ b/ofl/playwriteustradguides/article/ARTICLE.en_us.html
@@ -29,7 +29,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+US+Trad/about#playwrite-usa-traditional-Guides_characteristics">Playwrite USA Traditional.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+US+Trad/about#playwrite-usa-traditional-characteristics">Playwrite USA Traditional.</a>
 </p>
 <img src="Playwrite-USA-Traditional-Guides_3.png" />
 <h4>Family name in font menus</h4>

--- a/ofl/playwritezaguides/article/ARTICLE.en_us.html
+++ b/ofl/playwritezaguides/article/ARTICLE.en_us.html
@@ -32,7 +32,7 @@
 	Guidelines are present in all characters except for those used for letter spacing. To create a versatile font for teachers designing practice sheets that feature guidelines without corresponding letters, the underscore is used as a key character. It replaces the glyph shape with the guidelines and matches the width of the letter space.
 </p>
 <p>
-    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+ZA/about#playwrite-south-africa-Guides_characteristics">Playwrite South Africa.</a>
+    Find the detailed characteristics of this country's Model in <a href="https://fonts.google.com/specimen/Playwrite+ZA/about#playwrite-south-africa-characteristics">Playwrite South Africa.</a>
 </p>
 <img src="Playwrite-South-Africa-Guides_3.png" />
 <h4>Family name in font menus</h4>


### PR DESCRIPTION
Hi @m4rc1e, This PR fixes some issues spotted in Dev Server on the About section of the Playwrite Guides.

Mainly, links to the matching font characteristics that were broken after inserting the path to the images in the articles.
Also, when reviewing the above, a couple of added issues were caught. The fonts were not touched, though, so this is safe to merge.

I'm not adding this to the board; each font `of` dir will track all these changes.