### PR TITLE
New Tag: `/Purpose/Educational`

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -1086,6 +1086,7 @@ Borel,/Expressive/Cute,100
 Borel,/Expressive/Playful,53
 Borel,/Expressive/Stiff,10
 Borel,/Expressive/Vintage,35
+Borel,/Purpose/Educational,100
 Borel,/Script/Formal,50
 Borel,/Script/Upright Script,100
 Bowlby One SC,/Expressive/Loud,99
@@ -3880,6 +3881,11 @@ Kulim Park,/Expressive/Rugged,2
 Kulim Park,/Expressive/Stiff,52
 Kulim Park,/Sans/Geometric,30
 Kulim Park,/Sans/Humanist,30
+<<<<<<< HEAD
+=======
+"Kumar One ",/Seasonal/Diwali,90
+Kumar One Inline,/Expressive/Stiff,97
+>>>>>>> f07df7f84 (New Tag: /Purpose/Educational)
 Kumar One Outline,/Expressive/Innovative,92
 Kumar One Outline,/Expressive/Stiff,97
 Kumar One Outline,/Quality/SpecialUse,0

--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -3892,11 +3892,6 @@ Kulim Park,/Expressive/Rugged,2
 Kulim Park,/Expressive/Stiff,52
 Kulim Park,/Sans/Geometric,30
 Kulim Park,/Sans/Humanist,30
-<<<<<<< HEAD
-=======
-"Kumar One ",/Seasonal/Diwali,90
-Kumar One Inline,/Expressive/Stiff,97
->>>>>>> f07df7f84 (New Tag: /Purpose/Educational)
 Kumar One Outline,/Expressive/Innovative,92
 Kumar One Outline,/Expressive/Stiff,97
 Kumar One Outline,/Quality/SpecialUse,0

--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -1,4 +1,5 @@
 ABeeZee,/Expressive/Calm,91.6
+ABeeZee,/Purpose/Educational,100
 ABeeZee,/Sans/Geometric,10
 ABeeZee,/Sans/Humanist,75
 ADLaM Display,/Sans/Humanist,70

--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -2176,31 +2176,37 @@ Eczar,/Expressive/Vintage,81
 Eczar,/Serif/Old Style Garalde,60
 Edu AU VIC WA NT Arrows,/Expressive/Childlike,90
 Edu AU VIC WA NT Arrows,/Expressive/Cute,15
+Edu AU VIC WA NT Arrows,/Purpose/Educational,100
 Edu AU VIC WA NT Arrows,/Quality/SpecialUse,100
 Edu AU VIC WA NT Arrows,/Script/Handwritten,100
 Edu AU VIC WA NT Arrows,/Script/Informal,60
 Edu AU VIC WA NT Dots,/Expressive/Active,60
 Edu AU VIC WA NT Dots,/Expressive/Childlike,90
+Edu AU VIC WA NT Dots,/Purpose/Educational,100
 Edu AU VIC WA NT Dots,/Quality/SpecialUse,100
 Edu AU VIC WA NT Dots,/Script/Handwritten,100
 Edu AU VIC WA NT Dots,/Script/Informal,60
 Edu AU VIC WA NT Guides,/Expressive/Active,60
 Edu AU VIC WA NT Guides,/Expressive/Childlike,90
+Edu AU VIC WA NT Guides,/Purpose/Educational,100
 Edu AU VIC WA NT Guides,/Quality/SpecialUse,100
 Edu AU VIC WA NT Guides,/Script/Handwritten,100
 Edu AU VIC WA NT Guides,/Script/Informal,60
 Edu AU VIC WA NT Hand,/Expressive/Childlike,90
 Edu AU VIC WA NT Hand,/Expressive/Cute,15
+Edu AU VIC WA NT Hand,/Purpose/Educational,100
 Edu AU VIC WA NT Hand,/Quality/SpecialUse,100
 Edu AU VIC WA NT Hand,/Script/Handwritten,100
 Edu AU VIC WA NT Hand,/Script/Informal,60
 Edu AU VIC WA NT Pre,/Expressive/Childlike,90
 Edu AU VIC WA NT Pre,/Expressive/Cute,20
+Edu AU VIC WA NT Pre,/Purpose/Educational,100
 Edu AU VIC WA NT Pre,/Quality/SpecialUse,100
 Edu AU VIC WA NT Pre,/Script/Handwritten,100
 Edu NSW ACT Foundation,/Expressive/Active,59
 Edu NSW ACT Foundation,/Expressive/Childlike,90
 Edu NSW ACT Foundation,/Expressive/Sincere,100
+Edu NSW ACT Foundation,/Purpose/Educational,100
 Edu NSW ACT Foundation,/Quality/SpecialUse,100
 Edu NSW ACT Foundation,/Script/Handwritten,100
 Edu NSW ACT Foundation,/Script/Informal,60
@@ -2208,6 +2214,7 @@ Edu QLD Beginner,/Expressive/Active,95
 Edu QLD Beginner,/Expressive/Childlike,90
 Edu QLD Beginner,/Expressive/Cute,15
 Edu QLD Beginner,/Expressive/Sincere,100
+Edu QLD Beginner,/Purpose/Educational,100
 Edu QLD Beginner,/Quality/SpecialUse,100
 Edu QLD Beginner,/Script/Handwritten,100
 Edu QLD Beginner,/Script/Informal,60
@@ -2215,6 +2222,7 @@ Edu SA Beginner,/Expressive/Active,94
 Edu SA Beginner,/Expressive/Childlike,90
 Edu SA Beginner,/Expressive/Cute,20
 Edu SA Beginner,/Expressive/Sincere,100
+Edu SA Beginner,/Purpose/Educational,100
 Edu SA Beginner,/Quality/SpecialUse,100
 Edu SA Beginner,/Script/Handwritten,100
 Edu SA Beginner,/Script/Informal,60
@@ -2222,11 +2230,13 @@ Edu TAS Beginner,/Expressive/Active,95
 Edu TAS Beginner,/Expressive/Childlike,90
 Edu TAS Beginner,/Expressive/Cute,15
 Edu TAS Beginner,/Expressive/Sincere,100
+Edu TAS Beginner,/Purpose/Educational,100
 Edu TAS Beginner,/Quality/SpecialUse,100
 Edu TAS Beginner,/Script/Handwritten,100
 Edu TAS Beginner,/Script/Informal,60
 Edu VIC WA NT Beginner,/Expressive/Active,96
 Edu VIC WA NT Beginner,/Expressive/Sincere,100
+Edu VIC WA NT Beginner,/Purpose/Educational,100
 Edu VIC WA NT Beginner,/Quality/SpecialUse,100
 Edu VIC WA NT Beginner,/Script/Handwritten,100
 Edu VIC WA NT Beginner,/Script/Informal,60
@@ -6056,389 +6066,491 @@ Playpen Sans,/Expressive/Playful,22
 Playpen Sans,/Expressive/Sincere,99
 Playpen Sans,/Script/Handwritten,100
 Playpen Sans,/Script/Informal,100
+Playwrite AR Guides,/Purpose/Educational,100
 Playwrite AR Guides,/Quality/SpecialUse,100
 Playwrite AR Guides,/Script/Handwritten,100
 Playwrite AR Guides,/Script/Upright Script,100
 Playwrite AR,/Expressive/Calm,50
 Playwrite AR,/Expressive/Cute,50
+Playwrite AR,/Purpose/Educational,100
 Playwrite AR,/Quality/SpecialUse,100
 Playwrite AR,/Script/Handwritten,100
 Playwrite AR,/Script/Informal,80
 Playwrite AR,/Script/Upright Script,100
+Playwrite AT Guides,/Purpose/Educational,100
 Playwrite AT Guides,/Quality/SpecialUse,100
 Playwrite AT Guides,/Script/Handwritten,100
 Playwrite AT Guides,/Script/Upright Script,50
 Playwrite AT,/Expressive/Calm,50
 Playwrite AT,/Expressive/Cute,50
+Playwrite AT,/Purpose/Educational,100
 Playwrite AT,/Quality/SpecialUse,100
 Playwrite AT,/Script/Handwritten,100
 Playwrite AT,/Script/Informal,80
 Playwrite AT,/Script/Upright Script,50
 Playwrite AT,/Seasonal/Kwanzaa,72
+Playwrite AU NSW Guides,/Purpose/Educational,100
 Playwrite AU NSW Guides,/Quality/SpecialUse,100
 Playwrite AU NSW Guides,/Script/Handwritten,100
 Playwrite AU NSW,/Expressive/Active,81
 Playwrite AU NSW,/Expressive/Cute,50
+Playwrite AU NSW,/Purpose/Educational,100
 Playwrite AU NSW,/Quality/SpecialUse,100
 Playwrite AU NSW,/Script/Handwritten,100
 Playwrite AU NSW,/Script/Informal,80
+Playwrite AU QLD Guides,/Purpose/Educational,100
 Playwrite AU QLD Guides,/Quality/SpecialUse,100
 Playwrite AU QLD Guides,/Script/Handwritten,100
 Playwrite AU QLD,/Expressive/Cute,50
+Playwrite AU QLD,/Purpose/Educational,100
 Playwrite AU QLD,/Quality/SpecialUse,100
 Playwrite AU QLD,/Script/Handwritten,100
 Playwrite AU QLD,/Script/Informal,80
+Playwrite AU SA Guides,/Purpose/Educational,100
 Playwrite AU SA Guides,/Quality/SpecialUse,100
 Playwrite AU SA Guides,/Script/Handwritten,100
 Playwrite AU SA,/Expressive/Cute,50
+Playwrite AU SA,/Purpose/Educational,100
 Playwrite AU SA,/Quality/SpecialUse,100
 Playwrite AU SA,/Script/Handwritten,100
 Playwrite AU SA,/Script/Informal,80
 Playwrite AU SA,/Seasonal/Kwanzaa,74
+Playwrite AU TAS Guides,/Purpose/Educational,100
 Playwrite AU TAS Guides,/Quality/SpecialUse,100
 Playwrite AU TAS Guides,/Script/Handwritten,100
 Playwrite AU TAS,/Expressive/Cute,50
+Playwrite AU TAS,/Purpose/Educational,100
 Playwrite AU TAS,/Quality/SpecialUse,100
 Playwrite AU TAS,/Script/Handwritten,100
 Playwrite AU TAS,/Script/Informal,80
+Playwrite AU VIC Guides,/Purpose/Educational,100
 Playwrite AU VIC Guides,/Quality/SpecialUse,100
 Playwrite AU VIC Guides,/Script/Handwritten,100
 Playwrite AU VIC,/Expressive/Cute,50
+Playwrite AU VIC,/Purpose/Educational,100
 Playwrite AU VIC,/Quality/SpecialUse,100
 Playwrite AU VIC,/Script/Handwritten,100
 Playwrite AU VIC,/Script/Informal,80
+Playwrite BE VLG Guides,/Purpose/Educational,100
 Playwrite BE VLG Guides,/Quality/SpecialUse,100
 Playwrite BE VLG Guides,/Script/Handwritten,100
 Playwrite BE VLG,/Expressive/Cute,50
+Playwrite BE VLG,/Purpose/Educational,100
 Playwrite BE VLG,/Quality/SpecialUse,100
 Playwrite BE VLG,/Script/Handwritten,100
 Playwrite BE VLG,/Script/Informal,80
+Playwrite BE WAL Guides,/Purpose/Educational,100
 Playwrite BE WAL Guides,/Quality/SpecialUse,100
 Playwrite BE WAL Guides,/Script/Handwritten,100
 Playwrite BE WAL Guides,/Script/Upright Script,100
 Playwrite BE WAL,/Expressive/Calm,50
 Playwrite BE WAL,/Expressive/Cute,50
+Playwrite BE WAL,/Purpose/Educational,100
 Playwrite BE WAL,/Quality/SpecialUse,100
 Playwrite BE WAL,/Script/Handwritten,100
 Playwrite BE WAL,/Script/Informal,80
 Playwrite BE WAL,/Script/Upright Script,100
+Playwrite BR Guides,/Purpose/Educational,100
 Playwrite BR Guides,/Quality/SpecialUse,100
 Playwrite BR Guides,/Script/Handwritten,100
 Playwrite BR Guides,/Script/Upright Script,100
 Playwrite BR,/Expressive/Calm,50
 Playwrite BR,/Expressive/Cute,50
+Playwrite BR,/Purpose/Educational,100
 Playwrite BR,/Quality/SpecialUse,100
 Playwrite BR,/Script/Handwritten,100
 Playwrite BR,/Script/Informal,80
 Playwrite BR,/Script/Upright Script,100
+Playwrite CA Guides,/Purpose/Educational,100
 Playwrite CA Guides,/Quality/SpecialUse,100
 Playwrite CA Guides,/Script/Handwritten,100
 Playwrite CA,/Expressive/Cute,50
+Playwrite CA,/Purpose/Educational,100
 Playwrite CA,/Quality/SpecialUse,100
 Playwrite CA,/Script/Handwritten,100
 Playwrite CA,/Script/Informal,80
+Playwrite CL Guides,/Purpose/Educational,100
 Playwrite CL Guides,/Quality/SpecialUse,100
 Playwrite CL Guides,/Script/Handwritten,100
 Playwrite CL Guides,/Script/Upright Script,100
 Playwrite CL,/Expressive/Calm,50
 Playwrite CL,/Expressive/Cute,50
+Playwrite CL,/Purpose/Educational,100
 Playwrite CL,/Quality/SpecialUse,100
 Playwrite CL,/Script/Handwritten,100
 Playwrite CL,/Script/Informal,80
 Playwrite CL,/Script/Upright Script,100
+Playwrite CO Guides,/Purpose/Educational,100
 Playwrite CO Guides,/Quality/SpecialUse,100
 Playwrite CO Guides,/Script/Handwritten,100
 Playwrite CO,/Expressive/Active,80
 Playwrite CO,/Expressive/Cute,50
+Playwrite CO,/Purpose/Educational,100
 Playwrite CO,/Quality/SpecialUse,100
 Playwrite CO,/Script/Handwritten,100
 Playwrite CO,/Script/Informal,80
+Playwrite CU Guides,/Purpose/Educational,100
 Playwrite CU Guides,/Quality/SpecialUse,100
 Playwrite CU Guides,/Script/Handwritten,100
 Playwrite CU,/Expressive/Cute,50
+Playwrite CU,/Purpose/Educational,100
 Playwrite CU,/Quality/SpecialUse,100
 Playwrite CU,/Script/Handwritten,100
 Playwrite CU,/Script/Informal,80
+Playwrite CZ Guides,/Purpose/Educational,100
 Playwrite CZ Guides,/Quality/SpecialUse,100
 Playwrite CZ Guides,/Script/Handwritten,100
 Playwrite CZ,/Expressive/Active,80
 Playwrite CZ,/Expressive/Cute,50
+Playwrite CZ,/Purpose/Educational,100
 Playwrite CZ,/Quality/SpecialUse,100
 Playwrite CZ,/Script/Handwritten,100
 Playwrite CZ,/Script/Informal,80
 Playwrite CZ,/Seasonal/Kwanzaa,78
+Playwrite DE Grund Guides,/Purpose/Educational,100
 Playwrite DE Grund Guides,/Quality/SpecialUse,100
 Playwrite DE Grund Guides,/Script/Handwritten,100
 Playwrite DE Grund Guides,/Script/Upright Script,100
 Playwrite DE Grund,/Expressive/Calm,50
 Playwrite DE Grund,/Expressive/Cute,50
+Playwrite DE Grund,/Purpose/Educational,100
 Playwrite DE Grund,/Quality/SpecialUse,100
 Playwrite DE Grund,/Script/Handwritten,100
 Playwrite DE Grund,/Script/Informal,80
 Playwrite DE Grund,/Script/Upright Script,100
+Playwrite DE LA Guides,/Purpose/Educational,100
 Playwrite DE LA Guides,/Quality/SpecialUse,100
 Playwrite DE LA Guides,/Script/Handwritten,100
 Playwrite DE LA,/Expressive/Active,80
 Playwrite DE LA,/Expressive/Cute,50
+Playwrite DE LA,/Purpose/Educational,100
 Playwrite DE LA,/Quality/SpecialUse,100
 Playwrite DE LA,/Script/Handwritten,100
 Playwrite DE LA,/Script/Informal,80
+Playwrite DE SAS Guides,/Purpose/Educational,100
 Playwrite DE SAS Guides,/Quality/SpecialUse,100
 Playwrite DE SAS Guides,/Script/Handwritten,100
 Playwrite DE SAS,/Expressive/Active,80
 Playwrite DE SAS,/Expressive/Cute,50
+Playwrite DE SAS,/Purpose/Educational,100
 Playwrite DE SAS,/Quality/SpecialUse,100
 Playwrite DE SAS,/Script/Handwritten,100
 Playwrite DE SAS,/Script/Informal,80
+Playwrite DE VA Guides,/Purpose/Educational,100
 Playwrite DE VA Guides,/Quality/SpecialUse,100
 Playwrite DE VA Guides,/Script/Handwritten,100
 Playwrite DE VA,/Expressive/Active,70
 Playwrite DE VA,/Expressive/Cute,50
+Playwrite DE VA,/Purpose/Educational,100
 Playwrite DE VA,/Quality/SpecialUse,100
 Playwrite DE VA,/Script/Handwritten,100
 Playwrite DE VA,/Script/Informal,80
+Playwrite DK Loopet Guides,/Purpose/Educational,100
 Playwrite DK Loopet Guides,/Quality/SpecialUse,100
 Playwrite DK Loopet Guides,/Script/Handwritten,100
 Playwrite DK Loopet,/Expressive/Cute,50
+Playwrite DK Loopet,/Purpose/Educational,100
 Playwrite DK Loopet,/Quality/SpecialUse,100
 Playwrite DK Loopet,/Script/Handwritten,100
 Playwrite DK Loopet,/Script/Informal,80
 Playwrite DK Loopet,/Seasonal/Kwanzaa,81
+Playwrite DK Uloopet Guides,/Purpose/Educational,100
 Playwrite DK Uloopet Guides,/Quality/SpecialUse,100
 Playwrite DK Uloopet Guides,/Script/Handwritten,100
 Playwrite DK Uloopet,/Expressive/Cute,50
+Playwrite DK Uloopet,/Purpose/Educational,100
 Playwrite DK Uloopet,/Quality/SpecialUse,100
 Playwrite DK Uloopet,/Script/Handwritten,100
 Playwrite DK Uloopet,/Script/Informal,80
+Playwrite ES Deco Guides,/Purpose/Educational,100
 Playwrite ES Deco Guides,/Quality/SpecialUse,100
 Playwrite ES Deco Guides,/Script/Handwritten,100
 Playwrite ES Deco Guides,/Script/Upright Script,100
 Playwrite ES Deco,/Expressive/Calm,50
 Playwrite ES Deco,/Expressive/Cute,50
+Playwrite ES Deco,/Purpose/Educational,100
 Playwrite ES Deco,/Quality/SpecialUse,100
 Playwrite ES Deco,/Script/Handwritten,100
 Playwrite ES Deco,/Script/Informal,80
 Playwrite ES Deco,/Script/Upright Script,100
+Playwrite ES Guides,/Purpose/Educational,100
 Playwrite ES Guides,/Quality/SpecialUse,100
 Playwrite ES Guides,/Script/Handwritten,100
 Playwrite ES Guides,/Script/Upright Script,100
 Playwrite ES,/Expressive/Calm,50
 Playwrite ES,/Expressive/Cute,50
+Playwrite ES,/Purpose/Educational,100
 Playwrite ES,/Quality/SpecialUse,100
 Playwrite ES,/Script/Handwritten,100
 Playwrite ES,/Script/Informal,80
 Playwrite ES,/Script/Upright Script,100
+Playwrite FR Moderne Guides,/Purpose/Educational,100
 Playwrite FR Moderne Guides,/Quality/SpecialUse,100
 Playwrite FR Moderne Guides,/Script/Handwritten,100
 Playwrite FR Moderne Guides,/Script/Upright Script,100
 Playwrite FR Moderne,/Expressive/Calm,50
 Playwrite FR Moderne,/Expressive/Cute,50
+Playwrite FR Moderne,/Purpose/Educational,100
 Playwrite FR Moderne,/Quality/SpecialUse,100
 Playwrite FR Moderne,/Script/Handwritten,100
 Playwrite FR Moderne,/Script/Informal,80
 Playwrite FR Moderne,/Script/Upright Script,100
+Playwrite FR Trad Guides,/Purpose/Educational,100
 Playwrite FR Trad Guides,/Quality/SpecialUse,100
 Playwrite FR Trad Guides,/Script/Handwritten,100
 Playwrite FR Trad Guides,/Script/Upright Script,100
 Playwrite FR Trad,/Expressive/Cute,50
+Playwrite FR Trad,/Purpose/Educational,100
 Playwrite FR Trad,/Quality/SpecialUse,100
 Playwrite FR Trad,/Script/Handwritten,100
 Playwrite FR Trad,/Script/Informal,80
 Playwrite FR Trad,/Script/Upright Script,100
+Playwrite GB J Guides,/Purpose/Educational,100
 Playwrite GB J Guides,/Quality/SpecialUse,100
 Playwrite GB J Guides,/Script/Handwritten,100
 Playwrite GB J Guides,/Script/Upright Script,50
 Playwrite GB J,/Expressive/Calm,50
 Playwrite GB J,/Expressive/Cute,50
+Playwrite GB J,/Purpose/Educational,100
 Playwrite GB J,/Quality/SpecialUse,100
 Playwrite GB J,/Script/Handwritten,100
 Playwrite GB J,/Script/Informal,80
 Playwrite GB J,/Script/Upright Script,50
+Playwrite GB S Guides,/Purpose/Educational,100
 Playwrite GB S Guides,/Quality/SpecialUse,100
 Playwrite GB S Guides,/Script/Handwritten,100
 Playwrite GB S Guides,/Script/Upright Script,50
 Playwrite GB S,/Expressive/Calm,50
 Playwrite GB S,/Expressive/Cute,50
+Playwrite GB S,/Purpose/Educational,100
 Playwrite GB S,/Quality/SpecialUse,100
 Playwrite GB S,/Script/Handwritten,100
 Playwrite GB S,/Script/Informal,80
 Playwrite GB S,/Script/Upright Script,50
+Playwrite HR Guides,/Purpose/Educational,100
 Playwrite HR Guides,/Quality/SpecialUse,100
 Playwrite HR Guides,/Script/Handwritten,100
+Playwrite HR Lijeva Guides,/Purpose/Educational,100
 Playwrite HR Lijeva Guides,/Quality/SpecialUse,100
 Playwrite HR Lijeva Guides,/Script/Handwritten,100
 Playwrite HR Lijeva Guides,/Script/Upright Script,100
 Playwrite HR Lijeva,/Expressive/Calm,50
 Playwrite HR Lijeva,/Expressive/Cute,50
+Playwrite HR Lijeva,/Purpose/Educational,100
 Playwrite HR Lijeva,/Quality/SpecialUse,100
 Playwrite HR Lijeva,/Script/Handwritten,100
 Playwrite HR Lijeva,/Script/Informal,80
 Playwrite HR Lijeva,/Script/Upright Script,100
 Playwrite HR,/Expressive/Cute,50
+Playwrite HR,/Purpose/Educational,100
 Playwrite HR,/Quality/SpecialUse,100
 Playwrite HR,/Script/Handwritten,100
 Playwrite HR,/Script/Informal,80
+Playwrite HU Guides,/Purpose/Educational,100
 Playwrite HU Guides,/Quality/SpecialUse,100
 Playwrite HU Guides,/Script/Handwritten,100
 Playwrite HU Guides,/Script/Upright Script,100
 Playwrite HU,/Expressive/Calm,50
 Playwrite HU,/Expressive/Cute,50
+Playwrite HU,/Purpose/Educational,100
 Playwrite HU,/Quality/SpecialUse,100
 Playwrite HU,/Script/Handwritten,100
 Playwrite HU,/Script/Informal,80
 Playwrite HU,/Script/Upright Script,100
+Playwrite ID Guides,/Purpose/Educational,100
 Playwrite ID Guides,/Quality/SpecialUse,100
 Playwrite ID Guides,/Script/Handwritten,100
 Playwrite ID Guides,/Script/Upright Script,100
 Playwrite ID,/Expressive/Calm,50
 Playwrite ID,/Expressive/Cute,50
+Playwrite ID,/Purpose/Educational,100
 Playwrite ID,/Quality/SpecialUse,100
 Playwrite ID,/Script/Handwritten,100
 Playwrite ID,/Script/Informal,80
 Playwrite ID,/Script/Upright Script,100
+Playwrite IE Guides,/Purpose/Educational,100
 Playwrite IE Guides,/Quality/SpecialUse,100
 Playwrite IE Guides,/Script/Handwritten,100
 Playwrite IE,/Expressive/Active,82
 Playwrite IE,/Expressive/Cute,50
+Playwrite IE,/Purpose/Educational,100
 Playwrite IE,/Quality/SpecialUse,100
 Playwrite IE,/Script/Handwritten,100
 Playwrite IE,/Script/Informal,80
+Playwrite IN Guides,/Purpose/Educational,100
 Playwrite IN Guides,/Quality/SpecialUse,100
 Playwrite IN Guides,/Script/Handwritten,100
 Playwrite IN,/Expressive/Cute,50
+Playwrite IN,/Purpose/Educational,100
 Playwrite IN,/Quality/SpecialUse,100
 Playwrite IN,/Script/Handwritten,100
 Playwrite IN,/Script/Informal,80
+Playwrite IS Guides,/Purpose/Educational,100
 Playwrite IS Guides,/Quality/SpecialUse,100
 Playwrite IS Guides,/Script/Handwritten,100
 Playwrite IS,/Expressive/Cute,50
+Playwrite IS,/Purpose/Educational,100
 Playwrite IS,/Quality/SpecialUse,100
 Playwrite IS,/Script/Handwritten,100
 Playwrite IS,/Script/Informal,80
+Playwrite IT Moderna Guides,/Purpose/Educational,100
 Playwrite IT Moderna Guides,/Quality/SpecialUse,100
 Playwrite IT Moderna Guides,/Script/Handwritten,100
 Playwrite IT Moderna Guides,/Script/Upright Script,100
 Playwrite IT Moderna,/Expressive/Calm,50
 Playwrite IT Moderna,/Expressive/Cute,50
+Playwrite IT Moderna,/Purpose/Educational,100
 Playwrite IT Moderna,/Quality/SpecialUse,100
 Playwrite IT Moderna,/Script/Handwritten,100
 Playwrite IT Moderna,/Script/Informal,80
 Playwrite IT Moderna,/Script/Upright Script,100
+Playwrite IT Trad Guides,/Purpose/Educational,100
 Playwrite IT Trad Guides,/Quality/SpecialUse,100
 Playwrite IT Trad Guides,/Script/Handwritten,100
 Playwrite IT Trad Guides,/Script/Upright Script,100
 Playwrite IT Trad,/Expressive/Calm,50
 Playwrite IT Trad,/Expressive/Cute,50
+Playwrite IT Trad,/Purpose/Educational,100
 Playwrite IT Trad,/Quality/SpecialUse,100
 Playwrite IT Trad,/Script/Handwritten,100
 Playwrite IT Trad,/Script/Informal,80
 Playwrite IT Trad,/Script/Upright Script,100
+Playwrite MX Guides,/Purpose/Educational,100
 Playwrite MX Guides,/Quality/SpecialUse,100
 Playwrite MX Guides,/Script/Handwritten,100
 Playwrite MX,/Expressive/Active,82
 Playwrite MX,/Expressive/Cute,50
+Playwrite MX,/Purpose/Educational,100
 Playwrite MX,/Quality/SpecialUse,100
 Playwrite MX,/Script/Handwritten,100
 Playwrite MX,/Script/Informal,80
+Playwrite NG Modern Guides,/Purpose/Educational,100
 Playwrite NG Modern Guides,/Quality/SpecialUse,100
 Playwrite NG Modern Guides,/Script/Handwritten,100
 Playwrite NG Modern,/Expressive/Calm,50
 Playwrite NG Modern,/Expressive/Cute,50
+Playwrite NG Modern,/Purpose/Educational,100
 Playwrite NG Modern,/Quality/SpecialUse,100
 Playwrite NG Modern,/Script/Handwritten,100
 Playwrite NG Modern,/Script/Informal,80
+Playwrite NL Guides,/Purpose/Educational,100
 Playwrite NL Guides,/Quality/SpecialUse,100
 Playwrite NL Guides,/Script/Handwritten,100
 Playwrite NL,/Expressive/Active,82
 Playwrite NL,/Expressive/Cute,50
+Playwrite NL,/Purpose/Educational,100
 Playwrite NL,/Quality/SpecialUse,100
 Playwrite NL,/Script/Handwritten,100
 Playwrite NL,/Script/Informal,80
+Playwrite NO Guides,/Purpose/Educational,100
 Playwrite NO Guides,/Quality/SpecialUse,100
 Playwrite NO Guides,/Script/Handwritten,100
 Playwrite NO,/Expressive/Cute,50
+Playwrite NO,/Purpose/Educational,100
 Playwrite NO,/Quality/SpecialUse,100
 Playwrite NO,/Script/Handwritten,100
 Playwrite NO,/Script/Informal,80
+Playwrite NZ Guides,/Purpose/Educational,100
 Playwrite NZ Guides,/Quality/SpecialUse,100
 Playwrite NZ Guides,/Script/Handwritten,100
 Playwrite NZ,/Expressive/Cute,50
+Playwrite NZ,/Purpose/Educational,100
 Playwrite NZ,/Quality/SpecialUse,100
 Playwrite NZ,/Script/Handwritten,100
 Playwrite NZ,/Script/Informal,80
+Playwrite PE Guides,/Purpose/Educational,100
 Playwrite PE Guides,/Quality/SpecialUse,100
 Playwrite PE Guides,/Script/Handwritten,100
 Playwrite PE Guides,/Script/Upright Script,100
 Playwrite PE,/Expressive/Calm,50
 Playwrite PE,/Expressive/Cute,50
+Playwrite PE,/Purpose/Educational,100
 Playwrite PE,/Quality/SpecialUse,100
 Playwrite PE,/Script/Handwritten,100
 Playwrite PE,/Script/Informal,80
 Playwrite PE,/Script/Upright Script,100
+Playwrite PL Guides,/Purpose/Educational,100
 Playwrite PL Guides,/Quality/SpecialUse,100
 Playwrite PL Guides,/Script/Handwritten,100
 Playwrite PL Guides,/Script/Upright Script,100
 Playwrite PL,/Expressive/Calm,50
 Playwrite PL,/Expressive/Cute,50
+Playwrite PL,/Purpose/Educational,100
 Playwrite PL,/Quality/SpecialUse,100
 Playwrite PL,/Script/Handwritten,100
 Playwrite PL,/Script/Informal,80
 Playwrite PL,/Script/Upright Script,100
+Playwrite PT Guides,/Purpose/Educational,100
 Playwrite PT Guides,/Quality/SpecialUse,100
 Playwrite PT Guides,/Script/Handwritten,100
 Playwrite PT Guides,/Script/Upright Script,100
 Playwrite PT,/Expressive/Calm,50
 Playwrite PT,/Expressive/Cute,50
+Playwrite PT,/Purpose/Educational,100
 Playwrite PT,/Quality/SpecialUse,100
 Playwrite PT,/Script/Handwritten,100
 Playwrite PT,/Script/Informal,80
 Playwrite PT,/Script/Upright Script,100
+Playwrite RO Guides,/Purpose/Educational,100
 Playwrite RO Guides,/Quality/SpecialUse,100
 Playwrite RO Guides,/Script/Handwritten,100
 Playwrite RO,/Expressive/Cute,50
+Playwrite RO,/Purpose/Educational,100
 Playwrite RO,/Quality/SpecialUse,100
 Playwrite RO,/Script/Handwritten,100
 Playwrite RO,/Script/Informal,80
+Playwrite SK Guides,/Purpose/Educational,100
 Playwrite SK Guides,/Quality/SpecialUse,100
 Playwrite SK Guides,/Script/Handwritten,100
 Playwrite SK,/Expressive/Cute,50
+Playwrite SK,/Purpose/Educational,100
 Playwrite SK,/Quality/SpecialUse,100
 Playwrite SK,/Script/Handwritten,100
 Playwrite SK,/Script/Informal,80
+Playwrite TZ Guides,/Purpose/Educational,100
 Playwrite TZ Guides,/Quality/SpecialUse,100
 Playwrite TZ Guides,/Script/Handwritten,100
 Playwrite TZ,/Expressive/Cute,50
+Playwrite TZ,/Purpose/Educational,100
 Playwrite TZ,/Quality/SpecialUse,100
 Playwrite TZ,/Script/Handwritten,100
 Playwrite TZ,/Script/Informal,80
+Playwrite US Modern Guides,/Purpose/Educational,100
 Playwrite US Modern Guides,/Quality/SpecialUse,100
 Playwrite US Modern Guides,/Script/Handwritten,100
 Playwrite US Modern Guides,/Script/Upright Script,100
 Playwrite US Modern,/Expressive/Calm,50
 Playwrite US Modern,/Expressive/Cute,50
+Playwrite US Modern,/Purpose/Educational,100
 Playwrite US Modern,/Quality/SpecialUse,100
 Playwrite US Modern,/Script/Handwritten,100
 Playwrite US Modern,/Script/Informal,80
 Playwrite US Modern,/Script/Upright Script,100
+Playwrite US Trad Guides,/Purpose/Educational,100
 Playwrite US Trad Guides,/Quality/SpecialUse,100
 Playwrite US Trad Guides,/Script/Handwritten,100
 Playwrite US Trad,/Expressive/Active,70
 Playwrite US Trad,/Expressive/Cute,50
+Playwrite US Trad,/Purpose/Educational,100
 Playwrite US Trad,/Quality/SpecialUse,100
 Playwrite US Trad,/Script/Handwritten,100
 Playwrite US Trad,/Script/Informal,80
+Playwrite VN Guides,/Purpose/Educational,100
 Playwrite VN Guides,/Quality/SpecialUse,100
 Playwrite VN Guides,/Script/Handwritten,100
 Playwrite VN Guides,/Script/Upright Script,100
 Playwrite VN,/Expressive/Calm,50
 Playwrite VN,/Expressive/Cute,50
+Playwrite VN,/Purpose/Educational,100
 Playwrite VN,/Quality/SpecialUse,100
 Playwrite VN,/Script/Handwritten,100
 Playwrite VN,/Script/Informal,80
 Playwrite VN,/Script/Upright Script,100
+Playwrite ZA Guides,/Purpose/Educational,100
 Playwrite ZA Guides,/Quality/SpecialUse,100
 Playwrite ZA Guides,/Script/Handwritten,100
 Playwrite ZA,/Expressive/Cute,50
+Playwrite ZA,/Purpose/Educational,100
 Playwrite ZA,/Quality/SpecialUse,100
 Playwrite ZA,/Script/Handwritten,100
 Playwrite ZA,/Script/Informal,80


### PR DESCRIPTION
Hi @davelab6, @evanwadams 

Following the conversation in the chat about this new tag

> Evans agreement is good to go :)

This PR introduces a new `Purpose/Educational` category to filter projects like the Australian Edu families, Playwrite, and other fonts specifically intended for teaching writing.