### PR TITLE
PW subsets fix

### DIFF
--- a/ofl/playwritearguides/METADATA.pb
+++ b/ofl/playwritearguides/METADATA.pb
@@ -12,10 +12,7 @@ fonts {
   full_name: "Playwrite AR Guides Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-subsets: "latin"
-subsets: "latin-ext"
 subsets: "menu"
-subsets: "vietnamese"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
   commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"

--- a/ofl/playwritecoguides/METADATA.pb
+++ b/ofl/playwritecoguides/METADATA.pb
@@ -12,10 +12,7 @@ fonts {
   full_name: "Playwrite CO Guides Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-subsets: "latin"
-subsets: "latin-ext"
 subsets: "menu"
-subsets: "vietnamese"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
   commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"


### PR DESCRIPTION
HI @emmamarichal, this PR fixes the subsets for the CO and AR families to make them only `menu` as expected for these fonts.
