### PR TITLE
Update tags_metadata.csv

### DIFF
--- a/tags/tags_metadata.csv
+++ b/tags/tags_metadata.csv
@@ -12,7 +12,6 @@
 /Expressive/Vintage,/Expressive/Vintage
 /Serif/Modern,/Serif/Modern
 /Serif/Transitional,/Serif/Transitional
-/Sinhala/Traditional,/Sinhala/Traditional
 /Expressive/Loud,/Expressive/Loud
 /Sans/Glyphic,/Sans/Glyphic
 /Serif/Fat Face,/Serif/FatFace
@@ -28,47 +27,32 @@
 /Script/Informal,/Script/Informal
 /Expressive/Awkward,/Expressive/Awkward
 /Expressive/Childlike,/Expressive/Childlike
-/Indic/Sign Painting,/Indic/Sign Painting
 /Script/Upright Script,/Script/Upright
 /Theme/Blobby,/Theme/Blobby
 /Expressive/Innovative,/Expressive/Innovative
 /Theme/Shaded,/Theme/Shaded
-/Indic/Low contrast,/Indic/Low contrast
 /Expressive/Happy,/Expressive/Happy
 /Theme/Art Nouveau,/Theme/Art Nouveau
 /Sans/Grotesque,/Sans/Grotesque
 /Sans/Superelipse,/Sans/Superellipse
 /Serif/Humanist Venetian,/Serif/Humanist
 /Slab/Humanist,/Slab/Humanist
-/Arabic/Kufi,/Arabic/Kufi
 /Expressive/Rugged,/Expressive/Rugged
 /Slab/Geometric,/Slab/Geometric
-/Arabic/West African,/Arabic/West African
 /Expressive/Active,/Expressive/Active
 /Theme/Stencil,/Theme/Stencil
 /Theme/Blackletter,/Theme/Blackletter
 /Expressive/Calm,/Expressive/Calm
-/Arabic/Naskh,/Arabic/Naskh
-"/South East Asian (Thai, Khmer, Lao)/Looped","/South East Asian (Thai, Khmer, Lao)/Looped"
-"/South East Asian (Thai, Khmer, Lao)/Loopless","/South East Asian (Thai, Khmer, Lao)/Loopless"
 /Theme/Woodtype,/Theme/Woodtype
 /Slab/Clarendon,/Slab/Clarendon
-/Arabic/Ruqah,/Arabic/Ruqah
-/Indic/Contemporary,/Indic/Contemporary
-/Indic/Reverse-contrast,/Indic/Reverse-contrast
-/Indic/Traditional,/Indic/Traditional
 /Theme/Distressed,/Theme/Distressed
-/Hebrew/Normal,/Hebrew/Normal
 /Theme/Inline,/Theme/Inline
 /Serif/Scotch,/Serif/Scotch
 /Theme/Brush,/Theme/Brush
-"/South East Asian (Thai, Khmer, Lao)/Chrieng (Khmer)","/South East Asian (Thai, Khmer, Lao)/Chrieng (Khmer)"
 /Theme/Medieval,/Theme/Medieval
 /Serif/Didone,/Serif/Didone
 /Theme/Art Deco,/Theme/Art Deco
 /Theme/Pixel,/Theme/Pixel
-/Arabic/Nastaliq,/Arabic/Nastaliq
-/Hebrew/Rashi,/Hebrew/Rashi
 /Theme/Tuscan,/Theme/Tuscan
 /Monospace/Monospace,/Monospace/Monospace
 /Not text/Symbols,/Not text/Symbols/


### PR DESCRIPTION
Removed partially-completed tags:
/South East Asian
/Arabic
/Hebrew
/Indic
/Sinhala

All references to them have already been removed from families.csv