### PR TITLE
Ponomar: Version 1.301; ttfautohint (v1.8.4.7-5d5b) added



### DIFF
--- a/ofl/ponomar/METADATA.pb
+++ b/ofl/ponomar/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "cyrillic-ext"
 subsets: "latin"
 subsets: "menu"
 source {
-  repository_url: "https://github.com/slavonic/Ponomar"
+  repository_url: "https://github.com/slavonic/ponomar"
   commit: "a45d4cc09e37e1f7fff266e98a3245dad73c9ac9"
   files {
     source_file: "OFL.txt"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/slavonic/ponomar at commit https://github.com/slavonic/ponomar/commit/a45d4cc09e37e1f7fff266e98a3245dad73c9ac9.

Resolves #8156
## PR Checklist:

- [X] `tags` are added for NEW FONTS
- [X] `primary_script` definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [X] `subsets` definitions in the METADATA.pb reflect the actual subsets and languages present in the font files (in alphabetic order). For **CJK fonts**, only include one of the following subsets `chinese-hongkong`, `chinese-simplified`, `chinese-traditional`, `korean`, `japanese`.
- [X] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [X] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
