### PR TITLE
ci: install cairo on ubuntu latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,7 @@ jobs:
       with:
         python-version: "3.10"
     - name: Install Cairo (Ubuntu)
-      if: matrix.platform == 'ubuntu-latest'
       run: sudo apt-get install libcairo2-dev
-
     # Check to_sandbox.txt and to_production.txt do not contain typos
     - name: Install gftools
       run: pip install gftools[qa]
@@ -46,7 +44,6 @@ jobs:
       with:
         python-version: "3.10"
     - name: Install Cairo (Ubuntu)
-      if: matrix.platform == 'ubuntu-latest'
       run: sudo apt-get install libcairo2-dev
 
     # Check Knowledge link graph

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+    - name: Install Cairo (Ubuntu)
+      if: matrix.platform == 'ubuntu-latest'
+      run: sudo apt-get install libcairo2-dev
 
     # Check to_sandbox.txt and to_production.txt do not contain typos
     - name: Install gftools
@@ -42,6 +45,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+    - name: Install Cairo (Ubuntu)
+      if: matrix.platform == 'ubuntu-latest'
+      run: sudo apt-get install libcairo2-dev
 
     # Check Knowledge link graph
     - name: Install dependencies

--- a/.github/workflows/knowledge_graph.py
+++ b/.github/workflows/knowledge_graph.py
@@ -219,6 +219,7 @@ def _check_outbound_link(url: str):
         'webmd.com',
         "jessicahische.is",
         "type.method.ac",
+        "dev.epicgames.com", # Returns a 403 response when using requests
     ])
     # Following urls will be fixed at a later date. If the CI is failing and a suitable
     # replacement url cannot be found, please add them to this set.

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -20,6 +20,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+    - name: Install Cairo (Ubuntu)
+      if: matrix.platform == 'ubuntu-latest'
+      run: sudo apt-get install libcairo2-dev
     - name: Install dependencies
       run: pip install gftools[qa]
     - name: Generate report

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -21,7 +21,6 @@ jobs:
       with:
         python-version: "3.10"
     - name: Install Cairo (Ubuntu)
-      if: matrix.platform == 'ubuntu-latest'
       run: sudo apt-get install libcairo2-dev
     - name: Install dependencies
       run: pip install gftools[qa]


### PR DESCRIPTION
Latest Ubuntu doesn't come with Cairo preinstalled so we have to do it manually.