### PR TITLE
Jersey 25 Charted: Version 1.002; ttfautohint (v1.8.4.7-5d5b) added



### DIFF
--- a/ofl/jersey25charted/DESCRIPTION.en_us.html
+++ b/ofl/jersey25charted/DESCRIPTION.en_us.html
@@ -1,7 +1,7 @@
-<p>The Soft Type Collection is designed for knitters to chart out their typographic projects. Jersey is a sporty, versatile sans-serif typeface, knittable in various sizes.</p>
+<p>
+    The Soft Type Collection is designed for knitters to chart out their typographic projects. Jersey is a sporty, versitile sans-serif typeface, knittable at various sizes.
+</p>
 
-<p>Each typeface has a “Regular” and “Charted” version, and some include multiple scales so you can fit type on your knits, no matter the project's size. Check out the non-charted version <a href="https://fonts.google.com/specimen/Jersey+25">Jersey 25</a>.</p>
-
-<p>In this collection, the number following the typeface's name indicates the height of the capital letters for that typeface. For this particular style, it's best to use a minimum of 30pt font size to ensure that it's clear, legible, and visually appealing across different platforms and mediums.</p>
-
-<p>To contribute, please see <a href="https://github.com/scfried/soft-type-jersey">github.com/scfried/soft-type-jersey</a>.</p>
+<p>
+    To contribute, see <a href="https://github.com/scfried/soft-type-jersey">github.com/scfried/soft-type-jersey</a>.
+</p>

--- a/ofl/jersey25charted/METADATA.pb
+++ b/ofl/jersey25charted/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/scfried/soft-type-jersey"
-  commit: "afc20d521110d3ba6d6614d226896c74d62f8f2f"
+  commit: "d8446c4c9c2ba14cf408c295be35213c006e19ff"
   files {
     source_file: "fonts/ttf/Jersey25Charted-Regular.ttf"
     dest_file: "Jersey25Charted-Regular.ttf"


### PR DESCRIPTION
Taken from the upstream repo https://github.com/scfried/soft-type-jersey at commit https://github.com/scfried/soft-type-jersey/commit/d8446c4c9c2ba14cf408c295be35213c006e19ff.
## PR Checklist:

- [ ] `minisite_url` definition in the METADATA.pb file for commissioned projects
- [ ] `tags` are added for NEW FONTS
- [ ] `primary_script` definition in the METADATA.pb file for all projects that have a primary non-Latin based language support target
- [ ] `subsets` definitions in the METADATA.pb reflect the actual subsets and languages present in the font files (in alphabetic order). For **CJK fonts**, only include one of the following subsets `chinese-hongkong`, `chinese-simplified`, `chinese-traditional`, `korean`, `japanese`.
- [ ] Fontbakery checks are reviewed and failing checks are resolved in collaboration with the upstream font development team
- [ ] Diffenator2 regression checks for revisions on all projects that are currently in production
- [ ] Designers bio info have to be present in the designer catalog (at least an issue should be opened for tracking this, if they are not)
- [ ] Check designers order in metadata.pb, since the first one of the list appears as “principal designer”
- [ ] Social media formatted visual assets for all new commissioned projects in the Drive directory, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
- [ ] Social media content draft for all new commissioned projects in the Drive directory and Social Media tracker spreadsheet, communicate with the repository Maintainer so that they can push this content to the Social Media tracker spreadsheet
