### PR TITLE
42 Dots Sans: primary script update

### DIFF
--- a/ofl/42dotsans/METADATA.pb
+++ b/ofl/42dotsans/METADATA.pb
@@ -20,7 +20,7 @@ axes {
   min_value: 300.0
   max_value: 800.0
 }
-primary_script: "Hang"
+primary_script: "Kore"
 source {
   repository_url: "https://github.com/42dot/42dot-Sans"
   branch: "main"


### PR DESCRIPTION
cc @aaronbell @m4rc1e 

I changed the `primary_script` `hang` to `kore` because korean doesn't appear in the dev-sandbox, see: https://github.com/google/fonts/pull/8185 

<img width="892" alt="Screenshot 2025-01-15 at 13 41 00" src="https://github.com/user-attachments/assets/267e4acc-2a8c-4211-b98d-29fb17c7397c" />


