### PR TITLE
Add sample_text to  Libre Barcode 39 Text METADATA

### DIFF
--- a/ofl/librebarcode39text/METADATA.pb
+++ b/ofl/librebarcode39text/METADATA.pb
@@ -26,5 +26,11 @@ source {
   }
   branch: "master"
 }
+sample_text {
+  masthead_full: “1234”
+  masthead_partial: “12”
+  styles: "0123456789abdefghijklmnopqrstx"
+  tester: "0123456789abdefghijklmnopqrstx"
+}
 classifications: "DISPLAY"
 classifications: "SYMBOLS"


### PR DESCRIPTION
Libre Barcode 39 Text only supports a limited set of characters, "0123456789abdefghijklmnopqrstx". So having a pre-defined sample_text is more suitable for Libre Barcode 39 Text.