### PR TITLE
Run designer profile checks in its own worflow

### DIFF
--- a/.ci/run.py
+++ b/.ci/run.py
@@ -66,7 +66,7 @@ def main():
 
         elif check_type == CheckType.DESIGNER:
             print(f"Checking designer profile: {directory}")
-            subprocess.run(["pytest", profile_test_file, directory])
+            subprocess.run(["pytest", profile_test_file, directory], check=True)
 
         else:
             print(f"Skipping directory {directory}")

--- a/.ci/test_profiles.py
+++ b/.ci/test_profiles.py
@@ -61,13 +61,6 @@ def test_profile_dir_has_info(profile_dir):
     assert "info.pb" in os.listdir(profile_dir), "info.pb is missing"
 
 
-def test_profile_has_correct_img(profile_dir):
-    assert not any(f for f in os.listdir(profile_dir) if f.endswith((".jpg", ".jpeg")))
-    assert any(
-        f for f in os.listdir(profile_dir) if f.endswith(".png")
-    ), "Profile is missing png image"
-
-
 def test_profile_info_image_link_is_correct(profile_dir, proto_info):
     img_path = proto_info.avatar.file_name
     assert img_path in os.listdir(profile_dir), "info.pb: image path is incorrect"

--- a/.github/workflows/designers.yaml
+++ b/.github/workflows/designers.yaml
@@ -1,0 +1,27 @@
+name: Check Designer profiles
+
+on:
+  pull_request:
+    paths:
+    - 'catalog/designers/*/*'
+
+jobs:
+  test_designer_profiles:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+      
+    - name: Install dependencies
+      run: pip install gftools[qa] pytest
+    - name: Check designer profiles
+      run: |
+        python3 .ci/run.py --pr-number $PR_NUMBER --pr-url-body https://www.github.com/google/fonts/pull/
+      env:
+        PYTHONIOENCODING: 'utf-8'
+        PYTHONUTF8: '1'
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,8 @@
 name: Google Fonts QA
 on:
   pull_request:
-    branches:
-    - main
+    paths:
+    - '{ofl,ufl,apache}/*/*'
 
 jobs:
 


### PR DESCRIPTION
Currently, designer profiles are checked by test.yaml. This workflow also checks fonts so it install a load of dependencies that aren't relevant to checking simple design profiles.