### PR TITLE
Adding 119 automatically generated `config.yaml` files, for font repos that have `.glyphs` files in their `sources/` directory.

### DIFF
--- a/ofl/aboreto/config.yaml
+++ b/ofl/aboreto/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Aboreto.glyphs

--- a/ofl/akshar/config.yaml
+++ b/ofl/akshar/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Akshar.glyphs

--- a/ofl/anekbangla/config.yaml
+++ b/ofl/anekbangla/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - AnekGurmukhi.glyphs

--- a/ofl/anekdevanagari/config.yaml
+++ b/ofl/anekdevanagari/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - AnekGurmukhi.glyphs

--- a/ofl/anekgujarati/config.yaml
+++ b/ofl/anekgujarati/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - AnekGurmukhi.glyphs

--- a/ofl/anekgurmukhi/config.yaml
+++ b/ofl/anekgurmukhi/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - AnekGurmukhi.glyphs

--- a/ofl/anekkannada/config.yaml
+++ b/ofl/anekkannada/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - AnekGurmukhi.glyphs

--- a/ofl/aneklatin/config.yaml
+++ b/ofl/aneklatin/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - AnekGurmukhi.glyphs

--- a/ofl/anekmalayalam/config.yaml
+++ b/ofl/anekmalayalam/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - AnekGurmukhi.glyphs

--- a/ofl/anekodia/config.yaml
+++ b/ofl/anekodia/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - AnekGurmukhi.glyphs

--- a/ofl/anektamil/config.yaml
+++ b/ofl/anektamil/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - AnekGurmukhi.glyphs

--- a/ofl/anektelugu/config.yaml
+++ b/ofl/anektelugu/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - AnekGurmukhi.glyphs

--- a/ofl/arima/config.yaml
+++ b/ofl/arima/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Arima.glyphs

--- a/ofl/artifika/config.yaml
+++ b/ofl/artifika/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Artifika.glyphs

--- a/ofl/average/config.yaml
+++ b/ofl/average/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Average.glyphs

--- a/ofl/baloobhaijaan2/config.yaml
+++ b/ofl/baloobhaijaan2/config.yaml
@@ -1,0 +1,11 @@
+sources:
+  - Baloo2.glyphs
+  - BalooBhai2.glyphs
+  - BalooBhaijaan2.glyphs
+  - BalooBhaina2.glyphs
+  - BalooChettan2.glyphs
+  - BalooDa2.glyphs
+  - BalooPaaji2.glyphs
+  - BalooTamma2.glyphs
+  - BalooTammudu2.glyphs
+  - BalooThambi2.glyphs

--- a/ofl/belleza/config.yaml
+++ b/ofl/belleza/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Belleza.glyphs

--- a/ofl/bizudgothic/config.yaml
+++ b/ofl/bizudgothic/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - BIZ-UDGothic-BoldExt.glyphs
+  - BIZ-UDGothicExt.glyphs
+  - BIZ-UDPGothic-BoldExt.glyphs
+  - BIZ-UDPGothicExt.glyphs

--- a/ofl/bizudmincho/config.yaml
+++ b/ofl/bizudmincho/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - BIZ-UDMincho-HeavyExt.glyphs
+  - BIZ-UDMinchoExt.glyphs
+  - BIZ-UDPMincho-HeavyExt.glyphs
+  - BIZ-UDPMinchoExt.glyphs

--- a/ofl/bizudpgothic/config.yaml
+++ b/ofl/bizudpgothic/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - BIZ-UDGothic-BoldExt.glyphs
+  - BIZ-UDGothicExt.glyphs
+  - BIZ-UDPGothic-BoldExt.glyphs
+  - BIZ-UDPGothicExt.glyphs

--- a/ofl/bizudpmincho/config.yaml
+++ b/ofl/bizudpmincho/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - BIZ-UDMincho-HeavyExt.glyphs
+  - BIZ-UDMinchoExt.glyphs
+  - BIZ-UDPMincho-HeavyExt.glyphs
+  - BIZ-UDPMinchoExt.glyphs

--- a/ofl/blackopsone/config.yaml
+++ b/ofl/blackopsone/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - BlackOpsOne.glyphs

--- a/ofl/blaka/config.yaml
+++ b/ofl/blaka/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - Blaka-Ink.glyphs
+  - Blaka.glyphs

--- a/ofl/blakahollow/config.yaml
+++ b/ofl/blakahollow/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - Blaka-Ink.glyphs
+  - Blaka.glyphs

--- a/ofl/blakaink/config.yaml
+++ b/ofl/blakaink/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - Blaka-Ink.glyphs
+  - Blaka.glyphs

--- a/ofl/braahone/config.yaml
+++ b/ofl/braahone/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - BraahOne.glyphs

--- a/ofl/brunoace/config.yaml
+++ b/ofl/brunoace/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - BrunoAce-Regular.glyphs
+  - BrunoAceSC-Regular.glyphs

--- a/ofl/brunoacesc/config.yaml
+++ b/ofl/brunoacesc/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - BrunoAce-Regular.glyphs
+  - BrunoAceSC-Regular.glyphs

--- a/ofl/cairo/config.yaml
+++ b/ofl/cairo/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Cairo.glyphs

--- a/ofl/cairoplay/config.yaml
+++ b/ofl/cairoplay/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Cairo.glyphs

--- a/ofl/cormorant/config.yaml
+++ b/ofl/cormorant/config.yaml
@@ -1,0 +1,4 @@
+sources:
+  - Cormorant-Italic.glyphs
+  - Cormorant.glyphs
+  - CormorantUpright.glyphs

--- a/ofl/cormorantgaramond/config.yaml
+++ b/ofl/cormorantgaramond/config.yaml
@@ -1,0 +1,4 @@
+sources:
+  - Cormorant-Italic.glyphs
+  - Cormorant.glyphs
+  - CormorantUpright.glyphs

--- a/ofl/cormorantinfant/config.yaml
+++ b/ofl/cormorantinfant/config.yaml
@@ -1,0 +1,4 @@
+sources:
+  - Cormorant-Italic.glyphs
+  - Cormorant.glyphs
+  - CormorantUpright.glyphs

--- a/ofl/cormorantsc/config.yaml
+++ b/ofl/cormorantsc/config.yaml
@@ -1,0 +1,4 @@
+sources:
+  - Cormorant-Italic.glyphs
+  - Cormorant.glyphs
+  - CormorantUpright.glyphs

--- a/ofl/cormorantunicase/config.yaml
+++ b/ofl/cormorantunicase/config.yaml
@@ -1,0 +1,4 @@
+sources:
+  - Cormorant-Italic.glyphs
+  - Cormorant.glyphs
+  - CormorantUpright.glyphs

--- a/ofl/diplomata/config.yaml
+++ b/ofl/diplomata/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - Diplomata.glyphs
+  - DiplomataSC.glyphs

--- a/ofl/diplomatasc/config.yaml
+++ b/ofl/diplomatasc/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - Diplomata.glyphs
+  - DiplomataSC.glyphs

--- a/ofl/eczar/config.yaml
+++ b/ofl/eczar/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Eczar.glyphs

--- a/ofl/fasterone/config.yaml
+++ b/ofl/fasterone/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - FasterOne.glyphs

--- a/ofl/faunaone/config.yaml
+++ b/ofl/faunaone/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - FaunaOne.glyphs

--- a/ofl/fjallaone/config.yaml
+++ b/ofl/fjallaone/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - FjallaOne.glyphs

--- a/ofl/gildadisplay/config.yaml
+++ b/ofl/gildadisplay/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - GildaDisplay.glyphs

--- a/ofl/gruppo/config.yaml
+++ b/ofl/gruppo/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Gruppo.glyphs

--- a/ofl/gulzar/config.yaml
+++ b/ofl/gulzar/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Gulzar.glyphs

--- a/ofl/handjet/config.yaml
+++ b/ofl/handjet/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Handjet.glyphs

--- a/ofl/hedvigletterssans/config.yaml
+++ b/ofl/hedvigletterssans/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - HedvigLettersSans.glyphs
+  - HedvigLettersSerif.glyphs

--- a/ofl/hedviglettersserif/config.yaml
+++ b/ofl/hedviglettersserif/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - HedvigLettersSans.glyphs
+  - HedvigLettersSerif.glyphs

--- a/ofl/imprima/config.yaml
+++ b/ofl/imprima/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Imprima.glyphs

--- a/ofl/jacquard12/config.yaml
+++ b/ofl/jacquard12/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - Jacquard12.glyphs
+  - Jacquard12Charted.glyphs
+  - Jacquard24.glyphs
+  - Jacquard24Charted.glyphs

--- a/ofl/jacquard12charted/config.yaml
+++ b/ofl/jacquard12charted/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - Jacquard12.glyphs
+  - Jacquard12Charted.glyphs
+  - Jacquard24.glyphs
+  - Jacquard24Charted.glyphs

--- a/ofl/jacquard24/config.yaml
+++ b/ofl/jacquard24/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - Jacquard12.glyphs
+  - Jacquard12Charted.glyphs
+  - Jacquard24.glyphs
+  - Jacquard24Charted.glyphs

--- a/ofl/jacquard24charted/config.yaml
+++ b/ofl/jacquard24charted/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - Jacquard12.glyphs
+  - Jacquard12Charted.glyphs
+  - Jacquard24.glyphs
+  - Jacquard24Charted.glyphs

--- a/ofl/jersey10/config.yaml
+++ b/ofl/jersey10/config.yaml
@@ -1,0 +1,9 @@
+sources:
+  - Jersey10.glyphs
+  - Jersey10Charted.glyphs
+  - Jersey15.glyphs
+  - Jersey15Charted.glyphs
+  - Jersey20.glyphs
+  - Jersey20Charted.glyphs
+  - Jersey25.glyphs
+  - Jersey25Charted.glyphs

--- a/ofl/jersey10charted/config.yaml
+++ b/ofl/jersey10charted/config.yaml
@@ -1,0 +1,9 @@
+sources:
+  - Jersey10.glyphs
+  - Jersey10Charted.glyphs
+  - Jersey15.glyphs
+  - Jersey15Charted.glyphs
+  - Jersey20.glyphs
+  - Jersey20Charted.glyphs
+  - Jersey25.glyphs
+  - Jersey25Charted.glyphs

--- a/ofl/jersey15/config.yaml
+++ b/ofl/jersey15/config.yaml
@@ -1,0 +1,9 @@
+sources:
+  - Jersey10.glyphs
+  - Jersey10Charted.glyphs
+  - Jersey15.glyphs
+  - Jersey15Charted.glyphs
+  - Jersey20.glyphs
+  - Jersey20Charted.glyphs
+  - Jersey25.glyphs
+  - Jersey25Charted.glyphs

--- a/ofl/jersey15charted/config.yaml
+++ b/ofl/jersey15charted/config.yaml
@@ -1,0 +1,9 @@
+sources:
+  - Jersey10.glyphs
+  - Jersey10Charted.glyphs
+  - Jersey15.glyphs
+  - Jersey15Charted.glyphs
+  - Jersey20.glyphs
+  - Jersey20Charted.glyphs
+  - Jersey25.glyphs
+  - Jersey25Charted.glyphs

--- a/ofl/jersey20/config.yaml
+++ b/ofl/jersey20/config.yaml
@@ -1,0 +1,9 @@
+sources:
+  - Jersey10.glyphs
+  - Jersey10Charted.glyphs
+  - Jersey15.glyphs
+  - Jersey15Charted.glyphs
+  - Jersey20.glyphs
+  - Jersey20Charted.glyphs
+  - Jersey25.glyphs
+  - Jersey25Charted.glyphs

--- a/ofl/jersey20charted/config.yaml
+++ b/ofl/jersey20charted/config.yaml
@@ -1,0 +1,9 @@
+sources:
+  - Jersey10.glyphs
+  - Jersey10Charted.glyphs
+  - Jersey15.glyphs
+  - Jersey15Charted.glyphs
+  - Jersey20.glyphs
+  - Jersey20Charted.glyphs
+  - Jersey25.glyphs
+  - Jersey25Charted.glyphs

--- a/ofl/jersey25/config.yaml
+++ b/ofl/jersey25/config.yaml
@@ -1,0 +1,9 @@
+sources:
+  - Jersey10.glyphs
+  - Jersey10Charted.glyphs
+  - Jersey15.glyphs
+  - Jersey15Charted.glyphs
+  - Jersey20.glyphs
+  - Jersey20Charted.glyphs
+  - Jersey25.glyphs
+  - Jersey25Charted.glyphs

--- a/ofl/jersey25charted/config.yaml
+++ b/ofl/jersey25charted/config.yaml
@@ -1,0 +1,9 @@
+sources:
+  - Jersey10.glyphs
+  - Jersey10Charted.glyphs
+  - Jersey15.glyphs
+  - Jersey15Charted.glyphs
+  - Jersey20.glyphs
+  - Jersey20Charted.glyphs
+  - Jersey25.glyphs
+  - Jersey25Charted.glyphs

--- a/ofl/jotione/config.yaml
+++ b/ofl/jotione/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Joti.glyphs

--- a/ofl/julee/config.yaml
+++ b/ofl/julee/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Julee.glyphs

--- a/ofl/kiteone/config.yaml
+++ b/ofl/kiteone/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Kite One.glyphs

--- a/ofl/lemon/config.yaml
+++ b/ofl/lemon/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Lemon.glyphs

--- a/ofl/mate/config.yaml
+++ b/ofl/mate/config.yaml
@@ -1,0 +1,4 @@
+sources:
+  - Mate-Italic.glyphs
+  - Mate.glyphs
+  - MateSC.glyphs

--- a/ofl/matesc/config.yaml
+++ b/ofl/matesc/config.yaml
@@ -1,0 +1,4 @@
+sources:
+  - Mate-Italic.glyphs
+  - Mate.glyphs
+  - MateSC.glyphs

--- a/ofl/monofett/config.yaml
+++ b/ofl/monofett/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Monofett.glyphs

--- a/ofl/notonaskharabic/config.yaml
+++ b/ofl/notonaskharabic/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSansArabicUI.glyphs

--- a/ofl/notorashihebrew/config.yaml
+++ b/ofl/notorashihebrew/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - NotoRashiHebrew.glyphs
+  - NotoSansHebrew.glyphs
+  - NotoSansHebrewDroid.glyphs
+  - NotoSerifHebrew.glyphs

--- a/ofl/notosansadlamunjoined/config.yaml
+++ b/ofl/notosansadlamunjoined/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - NotoSansAdlam.glyphs
+  - NotoSansAdlamUnjoined.glyphs

--- a/ofl/notosansbalinese/config.yaml
+++ b/ofl/notosansbalinese/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - NotoSansBalinese.glyphs
+  - NotoSerifBalinese.glyphs

--- a/ofl/notosanscham/config.yaml
+++ b/ofl/notosanscham/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSansCham.glyphs

--- a/ofl/notosansgrantha/config.yaml
+++ b/ofl/notosansgrantha/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - NotoSansGrantha.glyphs
+  - NotoSerifGrantha.glyphs

--- a/ofl/notosanshebrew/config.yaml
+++ b/ofl/notosanshebrew/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - NotoRashiHebrew.glyphs
+  - NotoSansHebrew.glyphs
+  - NotoSansHebrewDroid.glyphs
+  - NotoSerifHebrew.glyphs

--- a/ofl/notosansinscriptionalpahlavi/config.yaml
+++ b/ofl/notosansinscriptionalpahlavi/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSansInscriptionalPahlavi.glyphs

--- a/ofl/notosansinscriptionalparthian/config.yaml
+++ b/ofl/notosansinscriptionalparthian/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSansInscriptionalParthian.glyphs

--- a/ofl/notosanskaithi/config.yaml
+++ b/ofl/notosanskaithi/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSansKaithi.glyphs

--- a/ofl/notosanskhudawadi/config.yaml
+++ b/ofl/notosanskhudawadi/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSansKhudawadi.glyphs

--- a/ofl/notosanslimbu/config.yaml
+++ b/ofl/notosanslimbu/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSansLimbu.glyphs

--- a/ofl/notosansmasaramgondi/config.yaml
+++ b/ofl/notosansmasaramgondi/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSansMasaramGondi.glyphs

--- a/ofl/notosansnandinagari/config.yaml
+++ b/ofl/notosansnandinagari/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSansNandinagari.glyphs

--- a/ofl/notosansoldsogdian/config.yaml
+++ b/ofl/notosansoldsogdian/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSansOldSogdian.glyphs

--- a/ofl/notosanspsalterpahlavi/config.yaml
+++ b/ofl/notosanspsalterpahlavi/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSansPsalterPahlavi.glyphs

--- a/ofl/notosansthailooped/config.yaml
+++ b/ofl/notosansthailooped/config.yaml
@@ -1,0 +1,4 @@
+sources:
+  - NotoSansThaiLooped.glyphs
+  - NotoSansThaiLoopedUI.glyphs
+  - NotoSerifThai.glyphs

--- a/ofl/notoserifbalinese/config.yaml
+++ b/ofl/notoserifbalinese/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - NotoSansBalinese.glyphs
+  - NotoSerifBalinese.glyphs

--- a/ofl/notoserifgrantha/config.yaml
+++ b/ofl/notoserifgrantha/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - NotoSansGrantha.glyphs
+  - NotoSerifGrantha.glyphs

--- a/ofl/notoserifhebrew/config.yaml
+++ b/ofl/notoserifhebrew/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - NotoRashiHebrew.glyphs
+  - NotoSansHebrew.glyphs
+  - NotoSansHebrewDroid.glyphs
+  - NotoSerifHebrew.glyphs

--- a/ofl/notoserifolduyghur/config.yaml
+++ b/ofl/notoserifolduyghur/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSerifOldUyghur.glyphs

--- a/ofl/notoseriftodhri/config.yaml
+++ b/ofl/notoseriftodhri/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSerifTodhri.glyphs

--- a/ofl/notoseriftoto/config.yaml
+++ b/ofl/notoseriftoto/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - NotoSerifToto.glyphs

--- a/ofl/offside/config.yaml
+++ b/ofl/offside/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Offside.glyphs

--- a/ofl/orienta/config.yaml
+++ b/ofl/orienta/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Orienta.glyphs

--- a/ofl/pathwaygothicone/config.yaml
+++ b/ofl/pathwaygothicone/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - PathwayGothicOne.glyphs

--- a/ofl/piazzolla/config.yaml
+++ b/ofl/piazzolla/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - Piazzolla-Italic.glyphs
+  - Piazzolla.glyphs

--- a/ofl/protestguerrilla/config.yaml
+++ b/ofl/protestguerrilla/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - ProtestGuerrilla.glyphs
+  - ProtestRevolution.glyphs
+  - ProtestRiot.glyphs
+  - ProtestStrike.glyphs

--- a/ofl/protestrevolution/config.yaml
+++ b/ofl/protestrevolution/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - ProtestGuerrilla.glyphs
+  - ProtestRevolution.glyphs
+  - ProtestRiot.glyphs
+  - ProtestStrike.glyphs

--- a/ofl/protestriot/config.yaml
+++ b/ofl/protestriot/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - ProtestGuerrilla.glyphs
+  - ProtestRevolution.glyphs
+  - ProtestRiot.glyphs
+  - ProtestStrike.glyphs

--- a/ofl/proteststrike/config.yaml
+++ b/ofl/proteststrike/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - ProtestGuerrilla.glyphs
+  - ProtestRevolution.glyphs
+  - ProtestRiot.glyphs
+  - ProtestStrike.glyphs

--- a/ofl/publicsans/config.yaml
+++ b/ofl/publicsans/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - PublicSans-Italic.glyphs
+  - PublicSans.glyphs

--- a/ofl/redditmono/config.yaml
+++ b/ofl/redditmono/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - RedditMono.glyphs
+  - RedditSans.glyphs
+  - RedditSansCondensed.glyphs
+  - RedditSansItalics.glyphs

--- a/ofl/redditsans/config.yaml
+++ b/ofl/redditsans/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - RedditMono.glyphs
+  - RedditSans.glyphs
+  - RedditSansCondensed.glyphs
+  - RedditSansItalics.glyphs

--- a/ofl/redditsanscondensed/config.yaml
+++ b/ofl/redditsanscondensed/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - RedditMono.glyphs
+  - RedditSans.glyphs
+  - RedditSansCondensed.glyphs
+  - RedditSansItalics.glyphs

--- a/ofl/sen/config.yaml
+++ b/ofl/sen/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sen.glyphs

--- a/ofl/shantellsans/config.yaml
+++ b/ofl/shantellsans/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - shantell-marker.glyphs
+  - shantell.glyphs

--- a/ofl/sigmar/config.yaml
+++ b/ofl/sigmar/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Sigmar.glyphs

--- a/ofl/sofiasans/config.yaml
+++ b/ofl/sofiasans/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - SofiaSansCondensed-Italic.glyphs
+  - SofiaSansCondensed.glyphs

--- a/ofl/sofiasanscondensed/config.yaml
+++ b/ofl/sofiasanscondensed/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - SofiaSansCondensed-Italic.glyphs
+  - SofiaSansCondensed.glyphs

--- a/ofl/sofiasansextracondensed/config.yaml
+++ b/ofl/sofiasansextracondensed/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - SofiaSansCondensed-Italic.glyphs
+  - SofiaSansCondensed.glyphs

--- a/ofl/sofiasanssemicondensed/config.yaml
+++ b/ofl/sofiasanssemicondensed/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - SofiaSansCondensed-Italic.glyphs
+  - SofiaSansCondensed.glyphs

--- a/ofl/strait/config.yaml
+++ b/ofl/strait/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Strait.glyphs

--- a/ofl/trocchi/config.yaml
+++ b/ofl/trocchi/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Trocchi.glyphs

--- a/ofl/unicaone/config.yaml
+++ b/ofl/unicaone/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - UnicaOne.glyphs

--- a/ofl/unlock/config.yaml
+++ b/ofl/unlock/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Unlock.glyphs

--- a/ofl/varelaround/config.yaml
+++ b/ofl/varelaround/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - VarelaRound.glyphs

--- a/ofl/warnes/config.yaml
+++ b/ofl/warnes/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Warnes.glyphs

--- a/ofl/yarndings12/config.yaml
+++ b/ofl/yarndings12/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - Yarndings12.glyphs
+  - Yarndings12Charted.glyphs
+  - Yarndings20.glyphs
+  - Yarndings20Charted.glyphs

--- a/ofl/yarndings12charted/config.yaml
+++ b/ofl/yarndings12charted/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - Yarndings12.glyphs
+  - Yarndings12Charted.glyphs
+  - Yarndings20.glyphs
+  - Yarndings20Charted.glyphs

--- a/ofl/yarndings20/config.yaml
+++ b/ofl/yarndings20/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - Yarndings12.glyphs
+  - Yarndings12Charted.glyphs
+  - Yarndings20.glyphs
+  - Yarndings20Charted.glyphs

--- a/ofl/yarndings20charted/config.yaml
+++ b/ofl/yarndings20charted/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - Yarndings12.glyphs
+  - Yarndings12Charted.glyphs
+  - Yarndings20.glyphs
+  - Yarndings20Charted.glyphs


### PR DESCRIPTION
These files were auto-generated by the python script below, working on the git repo cache dir that results from running the [google-fonts-sources](https://github.com/googlefonts/google-fonts-sources) tool.

```python
import os
import sys

if len(sys.argv) != 3:
	sys.exit(f"usage: {sys.argv[0]} gfonts_dir cache_dir")
	
gfonts_repo = sys.argv[1]
cache_dir = sys.argv[2]

SOURCE_EXT = ".glyphs"
#SOURCE_EXT = ".ufo"
#SOURCE_EXT = ".vfb"
#SOURCE_EXT = ".designspace"

count = 0

for subdir, _, files in os.walk(f'{gfonts_repo}/ofl'):
	commit = None
	repo_url = None
	if "METADATA.pb" in files:
		for line in open(subdir+"/METADATA.pb",'r').readlines():
			if "commit" in line:
				commit = line.split("\"")[1].strip()
			elif "repository_url" in line:
				repo_url = line.split("\"")[1].strip()

	if commit and repo_url and "github.com/" in repo_url:
		repo_checkout = cache_dir + "/" + repo_url.split("github.com/")[1]
		if os.path.isdir(repo_checkout) and os.path.isdir(repo_checkout + "/sources") and not os.path.exists(repo_checkout + "/sources/config.yaml"):
			for repo_subdir, _, repo_files in os.walk(repo_checkout + "/sources"):
				source_files = [f for f in repo_files if f.endswith(SOURCE_EXT)]
				if not source_files:
					continue

				config_yaml_content = "sources:\n" + "\n".join([f"  - {sf}" for sf in sorted(source_files)])
				
#				print(subdir + "/config.yaml")
				open(subdir + "/config.yaml", "w+").write(config_yaml_content)
				print(f"[{repo_checkout}] {repo_url} {commit} {repo_subdir}\n")
				count += 1
				break

print(count)
```