### PR TITLE
revert removal of `branch` values on METADATA.pb files

### DIFF
--- a/ofl/arima/METADATA.pb
+++ b/ofl/arima/METADATA.pb
@@ -41,4 +41,5 @@ source {
     source_file: "DESCRIPTION.en_us.html"
     dest_file: "DESCRIPTION.en_us.html"
   }
+  branch: "master"
 }

--- a/ofl/artifika/METADATA.pb
+++ b/ofl/artifika/METADATA.pb
@@ -30,4 +30,5 @@ source {
     source_file: "fonts/ttf/Artifika-Regular.ttf"
     dest_file: "Artifika-Regular.ttf"
   }
+  branch: "master"
 }

--- a/ofl/aubrey/METADATA.pb
+++ b/ofl/aubrey/METADATA.pb
@@ -30,4 +30,5 @@ source {
     source_file: "fonts/TTF/Aubrey-Regular.ttf"
     dest_file: "Aubrey-Regular.ttf"
   }
+  branch: "master"
 }

--- a/ofl/bhutukaexpandedone/METADATA.pb
+++ b/ofl/bhutukaexpandedone/METADATA.pb
@@ -32,6 +32,7 @@ source {
     source_file: "fonts/ttf/BhuTukaExpandedOne-Regular.ttf"
     dest_file: "BhuTukaExpandedOne-Regular.ttf"
   }
+  branch: "master"
 }
 stroke: "SLAB_SERIF"
 classifications: "DISPLAY"

--- a/ofl/blaka/METADATA.pb
+++ b/ofl/blaka/METADATA.pb
@@ -32,5 +32,6 @@ source {
     source_file: "DESCRIPTION.en_us.html"
     dest_file: "DESCRIPTION.en_us.html"
   }
+  branch: "master"
 }
 primary_script: "Arab"

--- a/ofl/blakahollow/METADATA.pb
+++ b/ofl/blakahollow/METADATA.pb
@@ -32,5 +32,6 @@ source {
     source_file: "DESCRIPTION.en_us.html"
     dest_file: "DESCRIPTION.en_us.html"
   }
+  branch: "master"
 }
 primary_script: "Arab"

--- a/ofl/blakaink/METADATA.pb
+++ b/ofl/blakaink/METADATA.pb
@@ -32,5 +32,6 @@ source {
     source_file: "DESCRIPTION.en_us.html"
     dest_file: "DESCRIPTION.en_us.html"
   }
+  branch: "master"
 }
 primary_script: "Arab"

--- a/ofl/cactusclassicalserif/METADATA.pb
+++ b/ofl/cactusclassicalserif/METADATA.pb
@@ -30,6 +30,7 @@ source {
     source_file: "fonts/ttf/CactusClassicalSerif-Regular.ttf"
     dest_file: "CactusClassicalSerif-Regular.ttf"
   }
+  branch: "main"
 }
 primary_script: "Hant"
 primary_language: "yue_Hant"

--- a/ofl/cairo/METADATA.pb
+++ b/ofl/cairo/METADATA.pb
@@ -39,5 +39,6 @@ source {
     source_file: "fonts/Cairo/variable/Cairo[slnt,wght].ttf"
     dest_file: "Cairo[slnt,wght].ttf"
   }
+  branch: "master"
 }
 primary_script: "Arab"

--- a/ofl/cairoplay/METADATA.pb
+++ b/ofl/cairoplay/METADATA.pb
@@ -39,5 +39,6 @@ source {
     source_file: "fonts/CairoPlay/variable/CairoPlay[slnt,wght].ttf"
     dest_file: "CairoPlay[slnt,wght].ttf"
   }
+  branch: "master"
 }
 primary_script: "Arab"

--- a/ofl/chocolateclassicalsans/METADATA.pb
+++ b/ofl/chocolateclassicalsans/METADATA.pb
@@ -30,6 +30,7 @@ source {
     source_file: "fonts/ttf/ChocolateClassicalSans-Regular.ttf"
     dest_file: "ChocolateClassicalSans-Regular.ttf"
   }
+  branch: "main"
 }
 primary_script: "Hant"
 primary_language: "yue_Hant"

--- a/ofl/diplomata/METADATA.pb
+++ b/ofl/diplomata/METADATA.pb
@@ -27,6 +27,7 @@ source {
     source_file: "fonts/diplomata/ttf/Diplomata-Regular.ttf"
     dest_file: "Diplomata-Regular.ttf"
   }
+  branch: "master"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/diplomatasc/METADATA.pb
+++ b/ofl/diplomatasc/METADATA.pb
@@ -27,6 +27,7 @@ source {
     source_file: "fonts/diplomatasc/ttf/DiplomataSC-Regular.ttf"
     dest_file: "DiplomataSC-Regular.ttf"
   }
+  branch: "master"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/hedvigletterssans/METADATA.pb
+++ b/ofl/hedvigletterssans/METADATA.pb
@@ -29,5 +29,6 @@ source {
     source_file: "fonts/HedvigLettersSans/ttf/HedvigLettersSans-Regular.ttf"
     dest_file: "HedvigLettersSans-Regular.ttf"
   }
+  branch: "main"
 }
 stroke: "SANS_SERIF"

--- a/ofl/hedviglettersserif/METADATA.pb
+++ b/ofl/hedviglettersserif/METADATA.pb
@@ -38,5 +38,6 @@ source {
     source_file: "fonts/HedvigLettersSerif/variable/HedvigLettersSerif[opsz].ttf"
     dest_file: "HedvigLettersSerif[opsz].ttf"
   }
+  branch: "main"
 }
 stroke: "SERIF"

--- a/ofl/lxgwwenkaimonotc/METADATA.pb
+++ b/ofl/lxgwwenkaimonotc/METADATA.pb
@@ -60,6 +60,7 @@ source {
     source_file: "fonts/TTF/LXGWWenKaiMonoTC-Bold.ttf"
     dest_file: "LXGWWenKaiMonoTC-Bold.ttf"
   }
+  branch: "main"
 }
 primary_script: "Hant"
 primary_language: "zh_Hant"

--- a/ofl/lxgwwenkaitc/METADATA.pb
+++ b/ofl/lxgwwenkaitc/METADATA.pb
@@ -60,6 +60,7 @@ source {
     source_file: "fonts/TTF/LXGWWenKaiTC-Bold.ttf"
     dest_file: "LXGWWenKaiTC-Bold.ttf"
   }
+  branch: "main"
 }
 primary_script: "Hant"
 primary_language: "zh_Hant"

--- a/ofl/mate/METADATA.pb
+++ b/ofl/mate/METADATA.pb
@@ -40,6 +40,7 @@ source {
     source_file: "fonts/mate/ttf/Mate-Italic.ttf"
     dest_file: "Mate-Italic.ttf"
   }
+  branch: "master"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/matesc/METADATA.pb
+++ b/ofl/matesc/METADATA.pb
@@ -27,4 +27,5 @@ source {
     source_file: "fonts/matesc/ttf/MateSC-Regular.ttf"
     dest_file: "MateSC-Regular.ttf"
   }
+  branch: "master"
 }

--- a/ofl/playpensansarabic/METADATA.pb
+++ b/ofl/playpensansarabic/METADATA.pb
@@ -35,6 +35,7 @@ source {
     source_file: "fonts/variable/PlaypenSansArabic[wght].ttf"
     dest_file: "PlaypenSansArabic[wght].ttf"
   }
+  branch: "main"
 }
 minisite_url: "https://www.type-together.com/making-playpen-sans"
 primary_script: "Arab"

--- a/ofl/playpensanshebrew/METADATA.pb
+++ b/ofl/playpensanshebrew/METADATA.pb
@@ -35,6 +35,7 @@ source {
     source_file: "fonts/variable/PlaypenSansHebrew[wght].ttf"
     dest_file: "PlaypenSansHebrew[wght].ttf"
   }
+  branch: "main"
 }
 minisite_url: "https://www.type-together.com/making-playpen-sans"
 primary_script: "Hebr"

--- a/ofl/playpensansthai/METADATA.pb
+++ b/ofl/playpensansthai/METADATA.pb
@@ -35,6 +35,7 @@ source {
     source_file: "fonts/variable/PlaypenSansThai[wght].ttf"
     dest_file: "PlaypenSansThai[wght].ttf"
   }
+  branch: "main"
 }
 minisite_url: "https://www.type-together.com/making-playpen-sans"
 primary_script: "Thai"

--- a/ofl/wireone/METADATA.pb
+++ b/ofl/wireone/METADATA.pb
@@ -30,6 +30,7 @@ source {
     source_file: "fonts/TTF/WireOne-Regular.ttf"
     dest_file: "WireOne-Regular.ttf"
   }
+  branch: "master"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
This needs more careful review, as it seems that gftools-packager may still rely on that field.

(followup to PR #9259)