### PR TITLE
Update Anton families to display

### DIFF
--- a/ofl/anton/METADATA.pb
+++ b/ofl/anton/METADATA.pb
@@ -1,7 +1,7 @@
 name: "Anton"
 designer: "Vernon Adams"
 license: "OFL"
-category: "SANS_SERIF"
+category: "DISPLAY"
 date_added: "2011-02-23"
 fonts {
   name: "Anton"

--- a/ofl/antonio/METADATA.pb
+++ b/ofl/antonio/METADATA.pb
@@ -1,7 +1,7 @@
 name: "Antonio"
 designer: "Vernon Adams"
 license: "OFL"
-category: "SANS_SERIF"
+category: "DISPLAY"
 date_added: "2013-03-06"
 fonts {
   name: "Antonio"

--- a/ofl/antonsc/METADATA.pb
+++ b/ofl/antonsc/METADATA.pb
@@ -1,7 +1,7 @@
 name: "Anton SC"
 designer: "Vernon Adams"
 license: "OFL"
-category: "SANS_SERIF"
+category: "DISPLAY"
 date_added: "2024-05-27"
 fonts {
   name: "Anton SC"


### PR DESCRIPTION
Per talk with @davelab6 these should not be categorized as sans-serif but rather display fonts. They don't look great for small body text.