### PR TITLE
[Batch 1/4] port info from fontc_crater targets list

### DIFF
--- a/ofl/abeezee/METADATA.pb
+++ b/ofl/abeezee/METADATA.pb
@@ -26,6 +26,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/abeezee"
+  commit: "b9bd3f3522d91aca81eb668f56d40c2c62a90125"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -39,4 +40,5 @@ source {
     dest_file: "ABeeZee-Italic.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/abhayalibre/METADATA.pb
+++ b/ofl/abhayalibre/METADATA.pb
@@ -48,11 +48,13 @@ fonts {
   full_name: "Abhaya Libre ExtraBold"
   copyright: "Copyright (c) 1996-2015 Pushpananda Ekanayake (pushpanandae@gmail.com) Copyright (c) 2015 Sol Matas (sol@sonnenshine.com.ar) Copyright (c) 2015 Mooniak (hello@mooniak.com)"
 }
-primary_script: "Sinh"
-source {
-  repository_url: "https://github.com/mooniak/abhaya-libre-font"
-}
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "sinhala"
+source {
+  repository_url: "https://github.com/mooniak/abhaya-libre-font"
+  commit: "edaabf89929778cb947bbd230a257c2a3bbd9979"
+  config_yaml: "sources/config.yaml"
+}
+primary_script: "Sinh"

--- a/ofl/adlamdisplay/METADATA.pb
+++ b/ofl/adlamdisplay/METADATA.pb
@@ -32,5 +32,6 @@ source {
     dest_file: "ADLaMDisplay-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Adlm"

--- a/ofl/adventpro/METADATA.pb
+++ b/ofl/adventpro/METADATA.pb
@@ -57,6 +57,7 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/afacad/METADATA.pb
+++ b/ofl/afacad/METADATA.pb
@@ -35,7 +35,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Dicotype/Afacad"
-  commit: "d7e973f5d3f17f54662ed9a18b130dcbf7a0e709"
+  commit: "b294b1f8610ff16a3846a255b1a6a2e6788a056e"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -49,5 +49,6 @@ source {
     dest_file: "Afacad-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/afacadflux/METADATA.pb
+++ b/ofl/afacadflux/METADATA.pb
@@ -28,7 +28,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Dicotype/Afacad"
-  commit: "4655a472cef57467e1604ce80336ab87ea72facc"
+  commit: "b294b1f8610ff16a3846a255b1a6a2e6788a056e"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -38,5 +38,6 @@ source {
     dest_file: "AfacadFlux[slnt,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/agbalumo/METADATA.pb
+++ b/ofl/agbalumo/METADATA.pb
@@ -19,7 +19,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/SorkinType/Agbalumo"
-  commit: "c6c381d3704ef794dde69b80489d0cde36fb6f9b"
+  commit: "9d9ec3e32c10533233c9e48835e436ff5e5aa451"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -33,5 +33,6 @@ source {
     dest_file: "Agbalumo-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 classifications: "DISPLAY"

--- a/ofl/agdasima/METADATA.pb
+++ b/ofl/agdasima/METADATA.pb
@@ -44,6 +44,7 @@ source {
     dest_file: "Agdasima-Bold.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/agudisplay/METADATA.pb
+++ b/ofl/agudisplay/METADATA.pb
@@ -23,7 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/theseunbadejo/Agu-Display"
-  commit: "17a7ce91583f40d9e8f21eab6c57870a59c1b668"
+  commit: "d520ebead8de4091a82040fe3d8f94d84c38c66f"
   archive_url: "https://github.com/theseunbadejo/Agu-Display/releases/download/1.05/Agu-Display-1.05.zip"
   files {
     source_file: "OFL.txt"
@@ -38,6 +38,7 @@ source {
     dest_file: "article/ARTICLE.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://www.agudisplay.com"
 stroke: "SERIF"

--- a/ofl/alata/METADATA.pb
+++ b/ofl/alata/METADATA.pb
@@ -28,4 +28,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/albertsans/METADATA.pb
+++ b/ofl/albertsans/METADATA.pb
@@ -31,7 +31,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/usted/Albert-Sans"
-  commit: "929c7d5058afd06870d1dd4ebc3a0ee98bb77420"
+  commit: "f7f46082233f5a29cb71d6ae1d8d0ef9c7962d6c"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -45,4 +45,5 @@ source {
     dest_file: "AlbertSans-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/aleo/METADATA.pb
+++ b/ofl/aleo/METADATA.pb
@@ -46,5 +46,6 @@ source {
     dest_file: "Aleo-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SLAB_SERIF"

--- a/ofl/alexandria/METADATA.pb
+++ b/ofl/alexandria/METADATA.pb
@@ -24,7 +24,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Gue3bara/Alexandria"
-  commit: "cee89798e4b38c8df61477a646aa9c111314e6ae"
+  commit: "4fd1422be3488837c41fbdb84a77350f0f56a734"
   files {
     source_file: "DESCRIPTION.en_us.html"
     dest_file: "DESCRIPTION.en_us.html"
@@ -38,5 +38,6 @@ source {
     dest_file: "Alexandria[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Arab"

--- a/ofl/alexbrush/METADATA.pb
+++ b/ofl/alexbrush/METADATA.pb
@@ -24,4 +24,5 @@ source {
     dest_file: "AlexBrush-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/alice/METADATA.pb
+++ b/ofl/alice/METADATA.pb
@@ -19,6 +19,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/cyrealtype/Alice"
+  commit: "19421efc21eeeb872773006539ddcd743fb72440"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -28,4 +29,5 @@ source {
     dest_file: "Alice-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/alike/METADATA.pb
+++ b/ofl/alike/METADATA.pb
@@ -29,5 +29,6 @@ source {
     dest_file: "Alike-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"

--- a/ofl/alikeangular/METADATA.pb
+++ b/ofl/alikeangular/METADATA.pb
@@ -29,6 +29,7 @@ source {
     dest_file: "AlikeAngular-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/alkatra/METADATA.pb
+++ b/ofl/alkatra/METADATA.pb
@@ -39,4 +39,5 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/allison/METADATA.pb
+++ b/ofl/allison/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/allison"
+  commit: "fe224232fbcf0a6db60877e835df7219a99784f3"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Allison-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/allura/METADATA.pb
+++ b/ofl/allura/METADATA.pb
@@ -24,6 +24,7 @@ source {
     dest_file: "Allura-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/alumnisans/METADATA.pb
+++ b/ofl/alumnisans/METADATA.pb
@@ -34,6 +34,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/alumni"
+  commit: "44a7998fa2bfa1b3e119983cdc565dd7f0f03bda"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -47,6 +48,7 @@ source {
     dest_file: "AlumniSans-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/alumnisanscollegiateone/METADATA.pb
+++ b/ofl/alumnisanscollegiateone/METADATA.pb
@@ -47,6 +47,7 @@ source {
     dest_file: "AlumniSansCollegiateOne-Italic.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/alumnisanscollegiateonesc/METADATA.pb
+++ b/ofl/alumnisanscollegiateonesc/METADATA.pb
@@ -47,6 +47,7 @@ source {
     dest_file: "AlumniSansCollegiateOneSC-Italic.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/alumnisansinlineone/METADATA.pb
+++ b/ofl/alumnisansinlineone/METADATA.pb
@@ -46,6 +46,7 @@ source {
     dest_file: "AlumniSansInlineOne-Italic.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/alumnisanspinstripe/METADATA.pb
+++ b/ofl/alumnisanspinstripe/METADATA.pb
@@ -48,6 +48,7 @@ source {
     dest_file: "AlumniSansPinstripe-Italic.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/alumnisanssc/METADATA.pb
+++ b/ofl/alumnisanssc/METADATA.pb
@@ -48,6 +48,7 @@ source {
     dest_file: "AlumniSansSC-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/amaticsc/METADATA.pb
+++ b/ofl/amaticsc/METADATA.pb
@@ -29,6 +29,8 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/AmaticSC"
+  commit: "308846136d2dcfb6aef2160d7e927698cdaf9c05"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/amita/METADATA.pb
+++ b/ofl/amita/METADATA.pb
@@ -27,6 +27,8 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/etunni/Amita"
+  commit: "92680c07f01285a23744cda1190690c5c7f3f73c"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/anaheim/METADATA.pb
+++ b/ofl/anaheim/METADATA.pb
@@ -37,4 +37,5 @@ source {
     dest_file: "Anaheim[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/anta/METADATA.pb
+++ b/ofl/anta/METADATA.pb
@@ -33,4 +33,5 @@ source {
     dest_file: "Anta-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/anton/METADATA.pb
+++ b/ofl/anton/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/AntonFont"
+  commit: "beb92fcad87808357123bb66881b4032dc96efe7"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Anton-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/antonio/METADATA.pb
+++ b/ofl/antonio/METADATA.pb
@@ -22,6 +22,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/antonioFont"
+  commit: "08562998b10c6c21a3505f47236b42f5d58c9909"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -35,6 +36,7 @@ source {
     dest_file: "Antonio[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/antonsc/METADATA.pb
+++ b/ofl/antonsc/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "AntonSC-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/anuphan/METADATA.pb
+++ b/ofl/anuphan/METADATA.pb
@@ -38,5 +38,6 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Thai"

--- a/ofl/anybody/METADATA.pb
+++ b/ofl/anybody/METADATA.pb
@@ -52,6 +52,7 @@ source {
     dest_file: "Anybody-Italic[wdth,wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/archivo/METADATA.pb
+++ b/ofl/archivo/METADATA.pb
@@ -37,6 +37,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Omnibus-Type/Archivo"
+  commit: "b5d63988ce19d044d3e10362de730af00526b672"
   files {
     source_file: "fonts/variable/Archivo[wdth,wght].ttf"
     dest_file: "Archivo[wdth,wght].ttf"
@@ -50,4 +51,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/archivonarrow/METADATA.pb
+++ b/ofl/archivonarrow/METADATA.pb
@@ -46,4 +46,5 @@ source {
     dest_file: "ArchivoNarrow-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/areyouserious/METADATA.pb
+++ b/ofl/areyouserious/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/are-you-serious"
+  commit: "2975e6bae2dba4fa1e30e9cd0b210e3a47b478d8"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "AreYouSerious-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/arizonia/METADATA.pb
+++ b/ofl/arizonia/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "Arizonia-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/aronesans/METADATA.pb
+++ b/ofl/aronesans/METADATA.pb
@@ -28,7 +28,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/niteeshy/ar-one-sans"
-  commit: "a463b112ca9393f1904765e0f32891b849eb9cf1"
+  commit: "6dc5e6850f2ced9f28e733c9a7860c54246e17a8"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -42,4 +42,5 @@ source {
     dest_file: "AROneSans[ARRR,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/asap/METADATA.pb
+++ b/ofl/asap/METADATA.pb
@@ -51,4 +51,5 @@ source {
     dest_file: "Asap-Italic[wdth,wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/asapcondensed/METADATA.pb
+++ b/ofl/asapcondensed/METADATA.pb
@@ -223,4 +223,5 @@ source {
     dest_file: "AsapCondensed-SemiBoldItalic.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/asar/METADATA.pb
+++ b/ofl/asar/METADATA.pb
@@ -18,5 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/SorkinType/Asar"
+  commit: "d04fb75bf304be9bfb0eff403a1d6ef8dc6c5f94"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Deva"

--- a/ofl/asset/METADATA.pb
+++ b/ofl/asset/METADATA.pb
@@ -34,6 +34,7 @@ source {
     dest_file: "Asset-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/atkinsonhyperlegible/METADATA.pb
+++ b/ofl/atkinsonhyperlegible/METADATA.pb
@@ -44,6 +44,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/atkinson-hyperlegible"
+  commit: "1cb311624b2ddf88e9e37873999d165a8cd28b46"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -69,4 +70,5 @@ source {
     dest_file: "AtkinsonHyperlegible-BoldItalic.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/atkinsonhyperlegiblemono/METADATA.pb
+++ b/ofl/atkinsonhyperlegiblemono/METADATA.pb
@@ -49,4 +49,5 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/atkinsonhyperlegiblenext/METADATA.pb
+++ b/ofl/atkinsonhyperlegiblenext/METADATA.pb
@@ -31,7 +31,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/atkinson-hyperlegible-next"
-  commit: "5d633f80fc654ef5fffa7cfc257528685158dcef"
+  commit: "7925f50f649b3813257faf2f4c0b381011f434f1"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -45,5 +45,6 @@ source {
     dest_file: "AtkinsonHyperlegibleNext-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/azeretmono/METADATA.pb
+++ b/ofl/azeretmono/METADATA.pb
@@ -31,6 +31,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/displaay/Azeret"
+  commit: "3d45a6c3e094f08bfc70551b525bd2037cac51ba"
   files {
     source_file: "fonts/variable/AzeretMono[wght].ttf"
     dest_file: "AzeretMono[wght].ttf"
@@ -44,4 +45,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/babylonica/METADATA.pb
+++ b/ofl/babylonica/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "Babylonica-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/bacasimeantique/METADATA.pb
+++ b/ofl/bacasimeantique/METADATA.pb
@@ -31,4 +31,5 @@ source {
     dest_file: "BacasimeAntique-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/badscript/METADATA.pb
+++ b/ofl/badscript/METADATA.pb
@@ -30,5 +30,6 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Latn"

--- a/ofl/bagelfatone/METADATA.pb
+++ b/ofl/bagelfatone/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/JAMO-TYPEFACE/BagelFat"
-  commit: "5ff1333d3384611f499419a844e2b3006dc7cacd"
+  commit: "d8dd4e8b5dd0e74fbf87a78290ee9a9aaed1270b"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,5 +32,6 @@ source {
     dest_file: "BagelFatOne-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Kore"

--- a/ofl/balsamiqsans/METADATA.pb
+++ b/ofl/balsamiqsans/METADATA.pb
@@ -46,6 +46,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/balsamiq/balsamiqsans"
+  commit: "009740f8b2c3915b1553182ec406aaddb1a12dc7"
   archive_url: "https://github.com/balsamiq/balsamiqsans/releases/download/1.020/balsamiqsans-fonts.zip"
   files {
     source_file: "balsamiqsans-fonts/fonts/ttf/BalsamiqSans-Bold.ttf"
@@ -64,6 +65,7 @@ source {
     dest_file: "BalsamiqSans-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/bangers/METADATA.pb
+++ b/ofl/bangers/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/bangers"
-  commit: "7b1747307aeb617957a216213de28b14d3281d9d"
+  commit: "ca6d2f15db343ee373e9c62a127f3a48cd251228"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -28,4 +28,5 @@ source {
     dest_file: "Bangers-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/baskervville/METADATA.pb
+++ b/ofl/baskervville/METADATA.pb
@@ -40,4 +40,5 @@ source {
     dest_file: "Baskervville-Italic.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/baskervvillesc/METADATA.pb
+++ b/ofl/baskervvillesc/METADATA.pb
@@ -27,4 +27,5 @@ source {
     dest_file: "BaskervvilleSC-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/beaurivage/METADATA.pb
+++ b/ofl/beaurivage/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/beau-rivage"
+  commit: "a80b72a03f6ea0a5667c58620973efdb72384ffa"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,4 +32,5 @@ source {
     dest_file: "BeauRivage-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/belanosima/METADATA.pb
+++ b/ofl/belanosima/METADATA.pb
@@ -58,6 +58,7 @@ source {
     dest_file: "Belanosima-Bold.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/benne/METADATA.pb
+++ b/ofl/benne/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/Benne"
+  commit: "0e13f2e4e66eb5ed0076224b113398b78109748d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,4 +32,5 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/bevan/METADATA.pb
+++ b/ofl/bevan/METADATA.pb
@@ -27,6 +27,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/BevanFont"
+  commit: "ab1035d7823b4c53400a6007ee077ecc9324c3e5"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -40,6 +41,7 @@ source {
     dest_file: "Bevan-Italic.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SLAB_SERIF"
 classifications: "DISPLAY"

--- a/ofl/bevietnampro/METADATA.pb
+++ b/ofl/bevietnampro/METADATA.pb
@@ -171,6 +171,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/bettergui/BeVietnamPro"
+  commit: "804e62d81abbbcdcce5686069c69b41b8c245192"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -248,4 +249,5 @@ source {
     dest_file: "BeVietnamPro-ThinItalic.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/bilbo/METADATA.pb
+++ b/ofl/bilbo/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/bilbo"
+  commit: "1ffb16299d6f1ae0304a0ed6a36a95acbb1148e3"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,4 +32,5 @@ source {
     dest_file: "Bilbo-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/biorhyme/METADATA.pb
+++ b/ofl/biorhyme/METADATA.pb
@@ -37,5 +37,6 @@ source {
     dest_file: "BioRhyme[wdth,wght].ttf"
   }
   branch: "gh-pages"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SLAB_SERIF"

--- a/ofl/birthstone/METADATA.pb
+++ b/ofl/birthstone/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/birthstone"
+  commit: "6fb65f5dc60e40fe907e5dfe22917613bde97f73"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Birthstone-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/birthstonebounce/METADATA.pb
+++ b/ofl/birthstonebounce/METADATA.pb
@@ -27,6 +27,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/birthstone-bounce"
+  commit: "db48de44b60017495c71a024aa2c079d70869225"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -44,6 +45,7 @@ source {
     dest_file: "BirthstoneBounce-Medium.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/bitcount/METADATA.pb
+++ b/ofl/bitcount/METADATA.pb
@@ -42,7 +42,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/petrvanblokland/TYPETR-Bitcount"
-  commit: "af0818eaeb3b0839806ea19134fc18f317cdcf5a"
+  commit: "653fc48a72cf3b6a293f6fc207a770f537921889"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -52,4 +52,5 @@ source {
     dest_file: "Bitcount[CRSV,ELSH,ELXP,slnt,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/bitcountpropsingleink/METADATA.pb
+++ b/ofl/bitcountpropsingleink/METADATA.pb
@@ -72,7 +72,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/petrvanblokland/TYPETR-Bitcount"
-  commit: "af0818eaeb3b0839806ea19134fc18f317cdcf5a"
+  commit: "653fc48a72cf3b6a293f6fc207a770f537921889"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -82,4 +82,5 @@ source {
     dest_file: "BitcountPropSingleInk[CRSV,ELSH,ELXP,SZP1,SZP2,XPN1,XPN2,YPN1,YPN2,slnt,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/bitcountsingleink/METADATA.pb
+++ b/ofl/bitcountsingleink/METADATA.pb
@@ -72,7 +72,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/petrvanblokland/TYPETR-Bitcount"
-  commit: "af0818eaeb3b0839806ea19134fc18f317cdcf5a"
+  commit: "653fc48a72cf3b6a293f6fc207a770f537921889"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -82,4 +82,5 @@ source {
     dest_file: "BitcountSingleInk[CRSV,ELSH,ELXP,SZP1,SZP2,XPN1,XPN2,YPN1,YPN2,slnt,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/bitter/METADATA.pb
+++ b/ofl/bitter/METADATA.pb
@@ -48,4 +48,5 @@ source {
     dest_file: "Bitter-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/bodonimoda/METADATA.pb
+++ b/ofl/bodonimoda/METADATA.pb
@@ -56,5 +56,6 @@ source {
     dest_file: "BodoniModa-Italic[opsz,wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"

--- a/ofl/bodonimodasc/METADATA.pb
+++ b/ofl/bodonimodasc/METADATA.pb
@@ -56,5 +56,6 @@ source {
     dest_file: "BodoniModaSC-Italic[opsz,wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"

--- a/ofl/boldonse/METADATA.pb
+++ b/ofl/boldonse/METADATA.pb
@@ -47,4 +47,5 @@ source {
     dest_file: "article/image4.jpg"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/bonanova/METADATA.pb
+++ b/ofl/bonanova/METADATA.pb
@@ -40,6 +40,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/kosmynkab/Bona-Nova"
+  commit: "a5cbdfb8741af20ea5bfe252f0128beed6c8beed"
   files {
     source_file: "fonts/ttf/BonaNova-Regular.ttf"
     dest_file: "BonaNova-Regular.ttf"
@@ -57,5 +58,6 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "http://bonanova.wtf/"

--- a/ofl/bonanovasc/METADATA.pb
+++ b/ofl/bonanovasc/METADATA.pb
@@ -58,5 +58,6 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "http://bonanova.wtf"

--- a/ofl/bonheurroyale/METADATA.pb
+++ b/ofl/bonheurroyale/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/bonheur-royale"
+  commit: "90087bb825c798641a29d2a1114ce7acd4048b0b"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "BonheurRoyale-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/brawler/METADATA.pb
+++ b/ofl/brawler/METADATA.pb
@@ -25,6 +25,7 @@ subsets: "latin"
 subsets: "menu"
 source {
   repository_url: "https://github.com/cyrealtype/Brawler"
+  commit: "a8e1fc6a4c43dedc38394c4f4086f526b72e852d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -42,4 +43,5 @@ source {
     dest_file: "Brawler-Bold.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/bricolagegrotesque/METADATA.pb
+++ b/ofl/bricolagegrotesque/METADATA.pb
@@ -43,6 +43,7 @@ source {
     dest_file: "BricolageGrotesque[opsz,wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://ateliertriay.github.io/bricolage"
 stroke: "SANS_SERIF"

--- a/ofl/briemhand/METADATA.pb
+++ b/ofl/briemhand/METADATA.pb
@@ -25,7 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/SorkinType/Briem-Hand"
-  commit: "68fedd7eb5d65c2c1490300719ef8b1fa51fbcd5"
+  commit: "7b991840508c9a90632354034ed0a72002836c05"
   archive_url: "https://github.com/SorkinType/Briem-Hand/releases/download/v1.004/Briem-Hand-v1.004.zip"
   files {
     source_file: "OFL.txt"
@@ -40,5 +40,6 @@ source {
     dest_file: "BriemHand[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 classifications: "HANDWRITING"

--- a/ofl/brygada1918/METADATA.pb
+++ b/ofl/brygada1918/METADATA.pb
@@ -35,6 +35,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/kosmynkab/Brygada-1918"
+  commit: "8325dc36ca87b8c7b8909c3e048fe90fd7e46c4b"
   files {
     source_file: "fonts/variable/Brygada1918[wght].ttf"
     dest_file: "Brygada1918[wght].ttf"
@@ -48,5 +49,6 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://brygada1918.eu/"

--- a/ofl/buenard/METADATA.pb
+++ b/ofl/buenard/METADATA.pb
@@ -22,7 +22,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/buenard"
-  commit: "4e9ae114c1180a9093d310e7985aa4e024e4901e"
+  commit: "cf400a29bbb4c8d850c221aa5b9835e8783648fb"
   files {
     source_file: "fonts/variable/Buenard[wght].ttf"
     dest_file: "Buenard[wght].ttf"
@@ -36,4 +36,5 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/bytesized/METADATA.pb
+++ b/ofl/bytesized/METADATA.pb
@@ -27,4 +27,5 @@ source {
     dest_file: "Bytesized-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/calistoga/METADATA.pb
+++ b/ofl/calistoga/METADATA.pb
@@ -28,6 +28,7 @@ source {
     dest_file: "Calistoga-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/caprasimo/METADATA.pb
+++ b/ofl/caprasimo/METADATA.pb
@@ -31,6 +31,7 @@ source {
     dest_file: "Caprasimo-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/caramel/METADATA.pb
+++ b/ofl/caramel/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/caramel"
+  commit: "87aff25878217835c9d22342d60678d4dcf8be75"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,4 +32,5 @@ source {
     dest_file: "Caramel-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/carattere/METADATA.pb
+++ b/ofl/carattere/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/carattere"
+  commit: "18fbebe0c73ec82068be167eb3e63a795bd814ac"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,4 +32,5 @@ source {
     dest_file: "Carattere-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/changa/METADATA.pb
+++ b/ofl/changa/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/changa-vf"
+  commit: "fb3207d4fe7234f610d0d4ef77dce01cfda57027"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,6 +33,7 @@ source {
     dest_file: "Changa[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/cherish/METADATA.pb
+++ b/ofl/cherish/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/cherish"
+  commit: "fd3a5b6b7fa7865540892380eb94290c2d49227b"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,4 +32,5 @@ source {
     dest_file: "Cherish-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/chivo/METADATA.pb
+++ b/ofl/chivo/METADATA.pb
@@ -32,7 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Omnibus-Type/Chivo"
-  commit: "d98623c96068cd02fbe9f22982d4b0504be8b851"
+  commit: "dc61c468d79781eb5183426e88e844af16cdc3e5"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -46,4 +46,5 @@ source {
     dest_file: "Chivo-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/chivomono/METADATA.pb
+++ b/ofl/chivomono/METADATA.pb
@@ -47,6 +47,7 @@ source {
     dest_file: "ChivoMono-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "MONOSPACE"

--- a/ofl/climatecrisis/METADATA.pb
+++ b/ofl/climatecrisis/METADATA.pb
@@ -26,7 +26,7 @@ registry_default_overrides {
 }
 source {
   repository_url: "https://github.com/dancoull/ClimateCrisis"
-  commit: "e0398e2d7e84a9f08cf7ec67bb463e4e2bb35431"
+  commit: "abb2058c737b353e2b32ece0bc6c229bf7f6858b"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -36,6 +36,7 @@ source {
     dest_file: "ClimateCrisis[YEAR].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://kampanjat.hs.fi/climatefont"
 stroke: "SANS_SERIF"

--- a/ofl/comforter/METADATA.pb
+++ b/ofl/comforter/METADATA.pb
@@ -19,6 +19,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/comforter"
+  commit: "3112f6b6990f10c7a101e5577b8267988989cff7"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,6 +33,7 @@ source {
     dest_file: "Comforter-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/comforterbrush/METADATA.pb
+++ b/ofl/comforterbrush/METADATA.pb
@@ -19,6 +19,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/comforter-brush"
+  commit: "4f308116699899ec59db6b7596e00912abd4ebef"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,6 +33,7 @@ source {
     dest_file: "ComforterBrush-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/comicrelief/METADATA.pb
+++ b/ofl/comicrelief/METADATA.pb
@@ -47,4 +47,5 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/comme/METADATA.pb
+++ b/ofl/comme/METADATA.pb
@@ -32,4 +32,5 @@ source {
     dest_file: "Comme[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/commissioner/METADATA.pb
+++ b/ofl/commissioner/METADATA.pb
@@ -41,7 +41,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/m4rc1e/Commissioner"
-  commit: "9bf35952a56ff7ba7d7fa1b0380e4bf2a63fcc35"
+  commit: "7f7dc8e9ed7ffeb3f7a91261f2b9549436ab3d02"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -51,4 +51,5 @@ source {
     dest_file: "Commissioner[FLAR,VOLM,slnt,wght].ttf"
   }
   branch: "flair-rename"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/corinthia/METADATA.pb
+++ b/ofl/corinthia/METADATA.pb
@@ -27,6 +27,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/corinthia"
+  commit: "9c81839655dfec773b737abc90cb09ac94b1bea1"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -44,6 +45,7 @@ source {
     dest_file: "Corinthia-Bold.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/crimsonpro/METADATA.pb
+++ b/ofl/crimsonpro/METADATA.pb
@@ -32,4 +32,6 @@ axes {
 }
 source {
   repository_url: "https://github.com/Fonthausen/CrimsonPro"
+  commit: "24e8f7bf59ec45d77c67879ad80d97e5f94c787b"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/crimsontext/METADATA.pb
+++ b/ofl/crimsontext/METADATA.pb
@@ -93,4 +93,5 @@ source {
     dest_file: "CrimsonText-SemiBoldItalic.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/cutive/METADATA.pb
+++ b/ofl/cutive/METADATA.pb
@@ -27,6 +27,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SLAB_SERIF"
 classifications: "DISPLAY"

--- a/ofl/cutivemono/METADATA.pb
+++ b/ofl/cutivemono/METADATA.pb
@@ -31,6 +31,7 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "MONOSPACE"

--- a/ofl/damion/METADATA.pb
+++ b/ofl/damion/METADATA.pb
@@ -27,4 +27,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/dancingscript/METADATA.pb
+++ b/ofl/dancingscript/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/DancingScript"
+  commit: "291f87c05206179b6bfd53735a5638b5cc84e3b3"
   files {
     source_file: "fonts/variable/DancingScript[wght].ttf"
     dest_file: "DancingScript[wght].ttf"
@@ -32,4 +33,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/danfo/METADATA.pb
+++ b/ofl/danfo/METADATA.pb
@@ -23,7 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Afrotype/danfo"
-  commit: "a66fc9ded8f42ad2d39b91c9cd8a1960737ad02a"
+  commit: "f4a0c2dd9c65c42707208ec788371cec30b71b7f"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -33,7 +33,8 @@ source {
     dest_file: "Danfo[ELSH].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
+minisite_url: "https://www.afrotype.com/danfo"
 stroke: "SERIF"
 classifications: "DISPLAY"
-minisite_url: "https://www.afrotype.com/danfo"

--- a/ofl/darkergrotesque/METADATA.pb
+++ b/ofl/darkergrotesque/METADATA.pb
@@ -33,4 +33,5 @@ source {
     dest_file: "DarkerGrotesque[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/davidlibre/METADATA.pb
+++ b/ofl/davidlibre/METADATA.pb
@@ -57,5 +57,6 @@ source {
     dest_file: "DavidLibre-Bold.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Hebr"

--- a/ofl/dekko/METADATA.pb
+++ b/ofl/dekko/METADATA.pb
@@ -18,6 +18,8 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/EbenSorkin/Dekko"
+  commit: "4887c14997f1158a2a122d4351343e8745a8d504"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "HANDWRITING"

--- a/ofl/delicioushandrawn/METADATA.pb
+++ b/ofl/delicioushandrawn/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/alphArtype/Delicious-Handrawn"
-  commit: "0a9b42f98d6f2ee40563a406b1cdd9bb5a58fe57"
+  commit: "454896185708d68530577800804c032756040370"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -27,6 +27,7 @@ source {
     dest_file: "DeliciousHandrawn-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/denkone/METADATA.pb
+++ b/ofl/denkone/METADATA.pb
@@ -19,7 +19,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/SorkinType/Denk-One"
-  commit: "95da30b8aa7bd5fb3045afb2fe054bf1b2e4e029"
+  commit: "eadc321b9f89db0d7090550e1d7bf6dcd75b6996"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -29,6 +29,7 @@ source {
     dest_file: "DenkOne-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/diphylleia/METADATA.pb
+++ b/ofl/diphylleia/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/JAMO-TYPEFACE/Diphylleia"
-  commit: "d481ed1f2dc17d2457f9788351a1d4e886cdc221"
+  commit: "6a20531aa22286238d89f3bc1d8c29694acaec53"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,5 +32,6 @@ source {
     dest_file: "Diphylleia-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Kore"

--- a/ofl/domine/METADATA.pb
+++ b/ofl/domine/METADATA.pb
@@ -22,4 +22,6 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/Domine"
+  commit: "2974ac627aad3a34190288c07fd0a0040d38550f"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/dosis/METADATA.pb
+++ b/ofl/dosis/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/dosis-vf"
+  commit: "3407d52f1d1b1c36c14e756ad0b36561d8d44a3b"
   files {
     source_file: "fonts/variable/Dosis[wght].ttf"
     dest_file: "Dosis[wght].ttf"
@@ -32,6 +33,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/doto/METADATA.pb
+++ b/ofl/doto/METADATA.pb
@@ -37,5 +37,6 @@ source {
     dest_file: "Doto[ROND,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 classifications: "DISPLAY"

--- a/ofl/dynapuff/METADATA.pb
+++ b/ofl/dynapuff/METADATA.pb
@@ -28,7 +28,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/dynapuff"
-  commit: "d1b4a98067a23e7ffbcf5b3665a887241983857b"
+  commit: "0cc624ef50b654ffe1a30785396aaba308406132"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -38,4 +38,5 @@ source {
     dest_file: "DynaPuff[wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/ebgaramond/METADATA.pb
+++ b/ofl/ebgaramond/METADATA.pb
@@ -36,5 +36,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/octaviopardo/EBGaramond12"
+  commit: "e608414f52e532b68e2182f96b4ce9db35335593"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://googlefonts.github.io/ebgaramond-specimen/"

--- a/ofl/eduauvicwantarrows/METADATA.pb
+++ b/ofl/eduauvicwantarrows/METADATA.pb
@@ -22,7 +22,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/SorkinType/VICWANTSchoolhandAustralia"
-  commit: "4d4efe710065410b34b66fa9d588498351642f41"
+  commit: "6529c525fceb9ec15e51dfa6d87244ef053c2d8a"
   archive_url: "https://github.com/SorkinType/VICWANTSchoolhandAustralia/releases/download/v1.002/VICWANTSchoolhandAustralia-v1.002.zip"
   files {
     source_file: "OFL.txt"
@@ -37,5 +37,6 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Edu Australia VIC WA NT Hand Arrows"

--- a/ofl/eduauvicwantdots/METADATA.pb
+++ b/ofl/eduauvicwantdots/METADATA.pb
@@ -22,7 +22,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/SorkinType/VICWANTSchoolhandAustralia"
-  commit: "abab94d19985f24132e45db4c4822b042eb63302"
+  commit: "6529c525fceb9ec15e51dfa6d87244ef053c2d8a"
   archive_url: "https://github.com/SorkinType/VICWANTSchoolhandAustralia/releases/download/v1.000/VICWANTSchoolhandAustralia-v1.000.zip"
   files {
     source_file: "OFL.txt"
@@ -37,5 +37,6 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Edu Australia VIC WA NT Hand Dots"

--- a/ofl/eduauvicwantguides/METADATA.pb
+++ b/ofl/eduauvicwantguides/METADATA.pb
@@ -22,7 +22,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/SorkinType/VICWANTSchoolhandAustralia"
-  commit: "abab94d19985f24132e45db4c4822b042eb63302"
+  commit: "6529c525fceb9ec15e51dfa6d87244ef053c2d8a"
   archive_url: "https://github.com/SorkinType/VICWANTSchoolhandAustralia/releases/download/v1.000/VICWANTSchoolhandAustralia-v1.000.zip"
   files {
     source_file: "OFL.txt"
@@ -37,5 +37,6 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Edu Australia VIC WA NT Hand Guides"

--- a/ofl/eduauvicwanthand/METADATA.pb
+++ b/ofl/eduauvicwanthand/METADATA.pb
@@ -22,7 +22,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/SorkinType/VICWANTSchoolhandAustralia"
-  commit: "88099a2e2d47e222cb62441730a2bc1c082754e1"
+  commit: "6529c525fceb9ec15e51dfa6d87244ef053c2d8a"
   archive_url: "https://github.com/SorkinType/VICWANTSchoolhandAustralia/releases/download/v1.001/VICWANTSchoolhandAustralia-v1.001.zip"
   files {
     source_file: "OFL.txt"
@@ -37,6 +37,7 @@ source {
     dest_file: "EduAUVICWANTHand[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Edu Australia VIC WA NT Hand"
 stroke: "SANS_SERIF"

--- a/ofl/eduauvicwantpre/METADATA.pb
+++ b/ofl/eduauvicwantpre/METADATA.pb
@@ -22,7 +22,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/SorkinType/VICWANTSchoolhandAustralia"
-  commit: "abab94d19985f24132e45db4c4822b042eb63302"
+  commit: "6529c525fceb9ec15e51dfa6d87244ef053c2d8a"
   archive_url: "https://github.com/SorkinType/VICWANTSchoolhandAustralia/releases/download/v1.000/VICWANTSchoolhandAustralia-v1.000.zip"
   files {
     source_file: "OFL.txt"
@@ -37,5 +37,6 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Edu Australia VIC WA NT Hand Precursive"

--- a/ofl/elmessiri/METADATA.pb
+++ b/ofl/elmessiri/METADATA.pb
@@ -24,6 +24,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Gue3bara/El-Messiri"
+  commit: "553b98d8e374318694b50862849af666268fd278"
   files {
     source_file: "fonts/variable/ElMessiri[wght].ttf"
     dest_file: "ElMessiri[wght].ttf"
@@ -33,5 +34,6 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Arab"

--- a/ofl/ephesis/METADATA.pb
+++ b/ofl/ephesis/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/ephesis"
+  commit: "8b303b53193b302c8894fb4635bbd49d4420d433"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Ephesis-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/epilogue/METADATA.pb
+++ b/ofl/epilogue/METADATA.pb
@@ -32,4 +32,6 @@ axes {
 }
 source {
   repository_url: "https://github.com/Etcetera-Type-Co/Epilogue"
+  commit: "76bd97a82f0105535fb06e6940f2140b2c1a660c"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/estonia/METADATA.pb
+++ b/ofl/estonia/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/estonia"
+  commit: "d4ee6f0558f9af9ad0cc950e740a81eb95b36526"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Estonia-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/exo/METADATA.pb
+++ b/ofl/exo/METADATA.pb
@@ -32,4 +32,6 @@ axes {
 }
 source {
   repository_url: "https://github.com/NDISCOVER/Exo-1.0"
+  commit: "3be4f55b626129f17a3b82677703e48c03dc2052"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/exo2/METADATA.pb
+++ b/ofl/exo2/METADATA.pb
@@ -48,4 +48,5 @@ source {
     dest_file: "Exo2-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/expletussans/METADATA.pb
+++ b/ofl/expletussans/METADATA.pb
@@ -31,6 +31,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/Expletus-Sans"
+  commit: "b64823a38d36cb09ec9ffce05f079585a4811217"
   files {
     source_file: "fonts/variable/ExpletusSans[wght].ttf"
     dest_file: "ExpletusSans[wght].ttf"
@@ -44,6 +45,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/explora/METADATA.pb
+++ b/ofl/explora/METADATA.pb
@@ -19,6 +19,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/explora"
+  commit: "b0d0e026f48eefee38dc06821f2c9088a347fa9b"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -28,6 +29,7 @@ source {
     dest_file: "Explora-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/facultyglyphic/METADATA.pb
+++ b/ofl/facultyglyphic/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/DylanYoungKoto/FacultyGlyphic"
-  commit: "217893d53b5e77627f997b41e75e45d5818bc0e2"
+  commit: "0f609bebfae8490a140feebfd3faacf3dfa87d62"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -27,6 +27,7 @@ source {
     dest_file: "FacultyGlyphic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Latn"
 stroke: "SANS_SERIF"

--- a/ofl/familjengrotesk/METADATA.pb
+++ b/ofl/familjengrotesk/METADATA.pb
@@ -32,7 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Familjen-Sthlm/Familjen-Grotesk"
-  commit: "3db181c2b39766045aff4a99663f515d3247512a"
+  commit: "de7dfe09f6014e43bfad3724ac4a07b95972763c"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -46,4 +46,5 @@ source {
     dest_file: "FamiljenGrotesk-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/faustina/METADATA.pb
+++ b/ofl/faustina/METADATA.pb
@@ -32,6 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Omnibus-Type/Faustina"
+  commit: "eaed5823e55b6256571a2bb379b5203083cab452"
   files {
     source_file: "fonts/variable/Faustina[wght].ttf"
     dest_file: "Faustina[wght].ttf"
@@ -41,4 +42,5 @@ source {
     dest_file: "Faustina-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/festive/METADATA.pb
+++ b/ofl/festive/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/festive"
+  commit: "5a37931ba2af0e7eb487e7c04f800e9006618bc7"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Festive-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/figtree/METADATA.pb
+++ b/ofl/figtree/METADATA.pb
@@ -31,7 +31,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/erikdkennedy/figtree"
-  commit: "efdedb2a9337b5baa897771e91ac9203f99e2084"
+  commit: "937cfe82ffa598f4965350aa9edfdf133f483d90"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -45,5 +45,6 @@ source {
     dest_file: "Figtree-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://www.erikdkennedy.com/projects/figtree.html"

--- a/ofl/finlandica/METADATA.pb
+++ b/ofl/finlandica/METADATA.pb
@@ -33,7 +33,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/HelsinkiTypeStudio/Finlandica"
-  commit: "f18a892e62bdcd80839549c04e3572e2bdca435e"
+  commit: "959e075ccc9652de57c72ecf56f887e13a537c85"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -47,4 +47,5 @@ source {
     dest_file: "Finlandica-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/fleurdeleah/METADATA.pb
+++ b/ofl/fleurdeleah/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/fleurdeleah"
+  commit: "69626faaf6a596ea822d4b0fd9521a506b9ffcc0"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "FleurDeLeah-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/foldit/METADATA.pb
+++ b/ofl/foldit/METADATA.pb
@@ -23,12 +23,14 @@ axes {
 }
 source {
   repository_url: "https://github.com/SophiaDesign/Foldit"
+  commit: "934034370b760240516ba533549436935c49fbc2"
   archive_url: "https://github.com/SophiaDesign/Foldit/releases/download/1.003/Foldit-fonts.zip"
   files {
     source_file: "Foldit-fonts/fonts/variable/Foldit[wght].ttf"
     dest_file: "Foldit[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/fragmentmono/METADATA.pb
+++ b/ofl/fragmentmono/METADATA.pb
@@ -28,7 +28,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/weiweihuanghuang/fragment-mono"
-  branch: "main"
+  commit: "177a79b53ae0c8f02e56a8671c29c57144f609e9"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,8 @@ source {
     source_file: "fonts/ttf/FragmentMono-Italic.ttf"
     dest_file: "FragmentMono-Italic.ttf"
   }
+  branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "MONOSPACE"

--- a/ofl/fragmentmonosc/METADATA.pb
+++ b/ofl/fragmentmonosc/METADATA.pb
@@ -28,7 +28,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/weiweihuanghuang/fragment-mono"
-  commit: "766d60703081ca3581e17764b36e8487c7ba6225"
+  commit: "177a79b53ae0c8f02e56a8671c29c57144f609e9"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -42,6 +42,7 @@ source {
     dest_file: "FragmentMonoSC-Italic.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "MONOSPACE"

--- a/ofl/francoisone/METADATA.pb
+++ b/ofl/francoisone/METADATA.pb
@@ -18,4 +18,6 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/francoisoneFont"
+  commit: "09ca2d148ed2ae88b0b89b5309f5eedd1daa2e0c"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/frankruhllibre/METADATA.pb
+++ b/ofl/frankruhllibre/METADATA.pb
@@ -33,5 +33,6 @@ source {
     dest_file: "FrankRuhlLibre[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"

--- a/ofl/fredoka/METADATA.pb
+++ b/ofl/fredoka/METADATA.pb
@@ -38,4 +38,5 @@ source {
     dest_file: "Fredoka[wdth,wght].ttf"
   }
   branch: "gh-pages"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/freeman/METADATA.pb
+++ b/ofl/freeman/METADATA.pb
@@ -29,6 +29,7 @@ source {
     dest_file: "Freeman-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/fruktur/METADATA.pb
+++ b/ofl/fruktur/METADATA.pb
@@ -28,7 +28,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/SorkinType/Fruktur"
-  commit: "a2277f91aebc0e5e70062bdd7f17f15d2a787cd2"
+  commit: "0f8b79b91438420d4c158890cb28bcb1eef407a0"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -42,4 +42,5 @@ source {
     dest_file: "Fruktur-Italic.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/fuggles/METADATA.pb
+++ b/ofl/fuggles/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/fuggles"
+  commit: "cc9766c14a1aabedb7ef7dbf3e9aa0e325542c5a"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Fuggles-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/funneldisplay/METADATA.pb
+++ b/ofl/funneldisplay/METADATA.pb
@@ -1,5 +1,5 @@
 name: "Funnel Display"
-designer: "NORD ID, Kristian Möller" 
+designer: "NORD ID, Kristian Möller"
 license: "OFL"
 category: "DISPLAY"
 date_added: "2024-09-25"
@@ -32,6 +32,7 @@ source {
     dest_file: "FunnelDisplay[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/funnelsans/METADATA.pb
+++ b/ofl/funnelsans/METADATA.pb
@@ -45,5 +45,6 @@ source {
     dest_file: "FunnelSans-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/fustat/METADATA.pb
+++ b/ofl/fustat/METADATA.pb
@@ -23,7 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Kief-Type-Foundry/Fustat"
-  commit: "3b33a705912543690e9b428ff62830fe2fa15603"
+  commit: "8e5354428eb81c3ebf9edbc86bfa9cdca23ce8b1"
   archive_url: "https://github.com/Kief-Type-Foundry/Fustat/releases/download/v1.007/Fustat-v1.007.zip"
   files {
     source_file: "OFL.txt"
@@ -38,5 +38,6 @@ source {
     dest_file: "Fustat[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Arab"

--- a/ofl/fuzzybubbles/METADATA.pb
+++ b/ofl/fuzzybubbles/METADATA.pb
@@ -27,6 +27,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/fuzzy-bubbles"
+  commit: "16d63fbca17f057559d0187fa7c07dd302d2276d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -44,6 +45,7 @@ source {
     dest_file: "FuzzyBubbles-Bold.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/gabarito/METADATA.pb
+++ b/ofl/gabarito/METADATA.pb
@@ -32,5 +32,6 @@ source {
     dest_file: "Gabarito[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/gabriela/METADATA.pb
+++ b/ofl/gabriela/METADATA.pb
@@ -29,6 +29,7 @@ source {
     dest_file: "Gabriela-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/gajrajone/METADATA.pb
+++ b/ofl/gajrajone/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Deva"
 stroke: "SANS_SERIF"

--- a/ofl/gamaamli/METADATA.pb
+++ b/ofl/gamaamli/METADATA.pb
@@ -32,7 +32,8 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
+minisite_url: "https://aayalolo.com/fonts/ga-maamli"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"
-minisite_url: "https://aayalolo.com/fonts/ga-maamli"

--- a/ofl/gantari/METADATA.pb
+++ b/ofl/gantari/METADATA.pb
@@ -31,7 +31,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Lafontype/Gantari"
-  commit: "5115aa79532c3b442fa22f94507e611ed369e2ba"
+  commit: "363a3dd5634bfec7e9f7db11ca3e1f4739a182ab"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -45,4 +45,5 @@ source {
     dest_file: "Gantari-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/gasoekone/METADATA.pb
+++ b/ofl/gasoekone/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/JAMO-TYPEFACE/Gasoek"
-  commit: "f3beadd65b93b5f43e9381a546d065253d6e655a"
+  commit: "f6b875c95ad933c5f937c2494ae2337f5aef2694"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,6 +32,7 @@ source {
     dest_file: "GasoekOne-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Kore"
 stroke: "SANS_SERIF"

--- a/ofl/gelasio/METADATA.pb
+++ b/ofl/gelasio/METADATA.pb
@@ -32,7 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/SorkinType/Gelasio"
-  commit: "a6ee02d6ba3d3a038610aa0972f0d4c39b251539"
+  commit: "9228e69b160d79f33950e026293f6e13ba9780d0"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -46,5 +46,6 @@ source {
     dest_file: "Gelasio-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"

--- a/ofl/genos/METADATA.pb
+++ b/ofl/genos/METADATA.pb
@@ -33,6 +33,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/genos"
+  commit: "707181862a0fe1ceecc334bb54c63ea4377e95d8"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -50,6 +51,7 @@ source {
     dest_file: "Genos-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/geologica/METADATA.pb
+++ b/ofl/geologica/METADATA.pb
@@ -59,4 +59,5 @@ source {
     dest_file: "Geologica[CRSV,SHRP,slnt,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/gideonroman/METADATA.pb
+++ b/ofl/gideonroman/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/gideon"
+  commit: "c7220310f3d5a41af5c7906b3c33672a0a2146c8"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "GideonRoman-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/gidole/METADATA.pb
+++ b/ofl/gidole/METADATA.pb
@@ -50,4 +50,5 @@ source {
     dest_file: "article/4GidoleNumbers.png"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/gloock/METADATA.pb
+++ b/ofl/gloock/METADATA.pb
@@ -29,6 +29,7 @@ source {
     dest_file: "Gloock-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/glory/METADATA.pb
+++ b/ofl/glory/METADATA.pb
@@ -32,6 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/glory"
+  commit: "76ea446c0499989af653f75c1cbd80447ef955d6"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -49,6 +50,7 @@ source {
     dest_file: "Glory[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/gluten/METADATA.pb
+++ b/ofl/gluten/METADATA.pb
@@ -38,6 +38,7 @@ source {
     dest_file: "Gluten[slnt,wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/golostext/METADATA.pb
+++ b/ofl/golostext/METADATA.pb
@@ -24,7 +24,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/golos-text"
-  commit: "d321a70cd12f84603617d4cf5d0e0321c2291dd9"
+  commit: "cf2e27222937d97c2d858fff0499bcc667a64e9d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -34,4 +34,5 @@ source {
     dest_file: "GolosText[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/graduate/METADATA.pb
+++ b/ofl/graduate/METADATA.pb
@@ -27,6 +27,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SLAB_SERIF"
 classifications: "DISPLAY"

--- a/ofl/grandifloraone/METADATA.pb
+++ b/ofl/grandifloraone/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/JAMO-TYPEFACE/Grandiflora"
-  commit: "b016ca716dade21cb890efc78b9349275c4e7c99"
+  commit: "5e5d39d3d49c5de0815020ba3996e9725d717e3f"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,6 +32,7 @@ source {
     dest_file: "GrandifloraOne-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Kore"
 classifications: "DISPLAY"

--- a/ofl/grandstander/METADATA.pb
+++ b/ofl/grandstander/METADATA.pb
@@ -32,7 +32,9 @@ axes {
 }
 source {
   repository_url: "https://github.com/Etcetera-Type-Co/Grandstander"
+  commit: "0bf9e31d529d7a67b23510b841cb3597db0cb130"
+  config_yaml: "sources/config.yaml"
 }
+minisite_url: "https://etceteratype.co/grandstander"
 classifications: "DISPLAY"
 classifications: "HANDWRITING"
-minisite_url: "https://etceteratype.co/grandstander"

--- a/ofl/grapenuts/METADATA.pb
+++ b/ofl/grapenuts/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/grapenuts"
+  commit: "1313fb48d7196fd9388b8327d1a30c03323c33ee"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "GrapeNuts-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/greatvibes/METADATA.pb
+++ b/ofl/greatvibes/METADATA.pb
@@ -48,6 +48,7 @@ source {
     dest_file: "GreatVibes-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/grechenfuemen/METADATA.pb
+++ b/ofl/grechenfuemen/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/grechen-fuemen"
+  commit: "4e4ac4caeac05708e6b3a05f0d91d1bb0476c045"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "GrechenFuemen-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/grenze/METADATA.pb
+++ b/ofl/grenze/METADATA.pb
@@ -171,4 +171,6 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/Omnibus-Type/Grenze"
+  commit: "a2a182c7b828c3d6a1784ef08b22be8521b2b9a7"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/grenzegotisch/METADATA.pb
+++ b/ofl/grenzegotisch/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/Omnibus-Type/Grenze-Gotisch"
+  commit: "7b5eac166bc3b2a519f98b5c124cb7a11670cc7b"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/greyqo/METADATA.pb
+++ b/ofl/greyqo/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/grey-qo"
+  commit: "33db197cb6b5c11851eee946d28a0380f9eced9d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "GreyQo-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/gwendolyn/METADATA.pb
+++ b/ofl/gwendolyn/METADATA.pb
@@ -27,6 +27,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/gwendolyn"
+  commit: "8ab228a0fd9cc201781ce4596cb039330b504e57"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -44,6 +45,7 @@ source {
     dest_file: "Gwendolyn-Bold.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/hankengrotesk/METADATA.pb
+++ b/ofl/hankengrotesk/METADATA.pb
@@ -33,7 +33,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/marcologous/hanken-grotesk"
-  commit: "e6e3c4df55acfe44333c587e3d97ae3c44b7dce5"
+  commit: "1ab416e82130b2d3ddb7710abf7ceabf07156a13"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -51,4 +51,5 @@ source {
     dest_file: "HankenGrotesk-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/heebo/METADATA.pb
+++ b/ofl/heebo/METADATA.pb
@@ -35,6 +35,7 @@ source {
     dest_file: "Heebo[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Hebr"
 stroke: "SANS_SERIF"

--- a/ofl/holtwoodonesc/METADATA.pb
+++ b/ofl/holtwoodonesc/METADATA.pb
@@ -27,6 +27,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SLAB_SERIF"
 classifications: "DISPLAY"

--- a/ofl/homenaje/METADATA.pb
+++ b/ofl/homenaje/METADATA.pb
@@ -16,4 +16,6 @@ subsets: "latin"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/Homenaje"
+  commit: "d371ad8e2f096db1f866c8fdfb9804f90dc39453"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/honk/METADATA.pb
+++ b/ofl/honk/METADATA.pb
@@ -34,7 +34,7 @@ registry_default_overrides {
 }
 source {
   repository_url: "https://github.com/EkType/Honk"
-  commit: "964739fca4b7f5485b21525df1e803fffbe6da99"
+  commit: "99094d4f6e3e73745fe3f2a6387d56c19d2a04cd"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -48,4 +48,5 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/hostgrotesk/METADATA.pb
+++ b/ofl/hostgrotesk/METADATA.pb
@@ -31,7 +31,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Element-Type/HostGrotesk"
-  commit: "4f267d366fec1961bb219fe156fe7b4821ce8a15"
+  commit: "ab2ba6769119e7ae71aa2fab46eedcb993c670a3"
   archive_url: "https://github.com/Element-Type/HostGrotesk/releases/download/1.002/HostGrotesk-1.002.zip"
   files {
     source_file: "OFL.txt"
@@ -46,6 +46,7 @@ source {
     dest_file: "HostGrotesk-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://elementtype.co/host-grotesk"
 primary_script: "Latn"

--- a/ofl/hubotsans/METADATA.pb
+++ b/ofl/hubotsans/METADATA.pb
@@ -37,7 +37,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/github/hubot-sans"
-  commit: "9c2cc3ac30ac77cc7c3b40e0813b3487a0c56b7b"
+  commit: "d4b2f67cd7686f5907296d3f027112bbc4f69f42"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -51,6 +51,7 @@ source {
     dest_file: "HubotSans-Italic[wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://github.com/mona-sans"
 primary_script: "Latn"

--- a/ofl/hurricane/METADATA.pb
+++ b/ofl/hurricane/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/hurricane"
+  commit: "bb10369a4820ebee5af7892e8661978c015cb077"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Hurricane-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/iansui/METADATA.pb
+++ b/ofl/iansui/METADATA.pb
@@ -17,10 +17,10 @@ subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "symbols2"
-primary_script: "Hant"
-primary_language: "yue_Hant"
-
 source {
   repository_url: "https://github.com/ButTaiwan/iansui"
-  commit: "41190e8094a9a5b47626c5d927daf0dcb226babf"
+  commit: "a66e7fe5bc492b358d8dc916f359157133a1d23c"
+  config_yaml: "sources/config.yaml"
 }
+primary_script: "Hant"
+primary_language: "yue_Hant"

--- a/ofl/imperialscript/METADATA.pb
+++ b/ofl/imperialscript/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/imperial-script"
+  commit: "01a1656c6ffebe306262129aafee029fe6a7f3f3"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "ImperialScript-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/inclusivesans/METADATA.pb
+++ b/ofl/inclusivesans/METADATA.pb
@@ -32,7 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/LivKing/Inclusive-Sans"
-  commit: "54ed9e4da94e7ea566a0322afc60b750c8544eaa"
+  commit: "38b8ed1dd67bd25ef4180140492810cf050ef501"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -46,5 +46,6 @@ source {
     dest_file: "InclusiveSans-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Zinh"

--- a/ofl/inconsolata/METADATA.pb
+++ b/ofl/inconsolata/METADATA.pb
@@ -29,4 +29,6 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/Inconsolata"
+  commit: "fc1fc21081558b39a2db43bfd9b65bf9acb50701"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/indieflower/METADATA.pb
+++ b/ofl/indieflower/METADATA.pb
@@ -18,6 +18,8 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/indieflower"
+  commit: "db44d10c34c1d74011b7f3bee8c7c12123b6068e"
+  config_yaml: "sources/config.yaml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/ingriddarling/METADATA.pb
+++ b/ofl/ingriddarling/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "IngridDarling-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/instrumentsans/METADATA.pb
+++ b/ofl/instrumentsans/METADATA.pb
@@ -36,7 +36,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Instrument/instrument-sans"
-  commit: "4a27996becc1c7d8e8d4095df4bb485068252bb2"
+  commit: "7fa22308a3d0c94ee2b3cd537a1196b65db34a3e"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -50,4 +50,5 @@ source {
     dest_file: "InstrumentSans-Italic[wdth,wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/instrumentserif/METADATA.pb
+++ b/ofl/instrumentserif/METADATA.pb
@@ -26,7 +26,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/Instrument/instrument-serif"
-  commit: "9aefd76b9b96dffbdc7b65d38c0dc5bcae2717a9"
+  commit: "65c0ef225f386a3c7e87570a4aa9cc0262c2fd81"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -40,4 +40,5 @@ source {
     dest_file: "InstrumentSerif-Italic.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/intertight/METADATA.pb
+++ b/ofl/intertight/METADATA.pb
@@ -50,6 +50,7 @@ source {
     dest_file: "InterTight-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/islandmoments/METADATA.pb
+++ b/ofl/islandmoments/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/island-moments"
+  commit: "665d59f297c782358f09699fc2231c0eee293f25"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "IslandMoments-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/italianno/METADATA.pb
+++ b/ofl/italianno/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/italianno"
+  commit: "3e3995ef5b90bd2b9dc587fb8f831f3a158cb95b"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,4 +32,5 @@ source {
     dest_file: "Italianno-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/jacquardabastarda9/METADATA.pb
+++ b/ofl/jacquardabastarda9/METADATA.pb
@@ -29,5 +29,6 @@ source {
     dest_file: "JacquardaBastarda9-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"

--- a/ofl/jacquardabastarda9charted/METADATA.pb
+++ b/ofl/jacquardabastarda9charted/METADATA.pb
@@ -29,5 +29,6 @@ source {
     dest_file: "JacquardaBastarda9Charted-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"

--- a/ofl/jaldi/METADATA.pb
+++ b/ofl/jaldi/METADATA.pb
@@ -27,4 +27,6 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/Omnibus-Type/Jaldi"
+  commit: "13315457c7dd2cadd03642a2edd9d9552d0c227f"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/jaro/METADATA.pb
+++ b/ofl/jaro/METADATA.pb
@@ -33,6 +33,7 @@ source {
     dest_file: "Jaro[opsz].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/jetbrainsmono/METADATA.pb
+++ b/ofl/jetbrainsmono/METADATA.pb
@@ -35,6 +35,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/JetBrains/JetBrainsMono"
+  commit: "19371302b95d218af43299bce79ddbddd0bc364d"
   files {
     source_file: "fonts/variable/JetBrainsMono[wght].ttf"
     dest_file: "JetBrainsMono[wght].ttf"
@@ -104,5 +105,6 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://www.jetbrains.com/lp/mono/"

--- a/ofl/joan/METADATA.pb
+++ b/ofl/joan/METADATA.pb
@@ -27,5 +27,6 @@ source {
     dest_file: "Joan-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"

--- a/ofl/josefinslab/METADATA.pb
+++ b/ofl/josefinslab/METADATA.pb
@@ -30,7 +30,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/josefinslab"
-  commit: "d14756349e966c3f4f6bec371e877da960a8470b"
+  commit: "61773366f714341802e5f131bd7181073094898f"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -44,6 +44,7 @@ source {
     dest_file: "JosefinSlab[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SLAB_SERIF"
 classifications: "DISPLAY"

--- a/ofl/jura/METADATA.pb
+++ b/ofl/jura/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/ossobuffo/jura"
+  commit: "f9df75d92c93324e74e5ec0df6d91c8ee4b84b5a"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/kablammo/METADATA.pb
+++ b/ofl/kablammo/METADATA.pb
@@ -25,7 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Vectro-Type-Foundry/kablammo"
-  commit: "49d6cecb53612bfb428995a43ba94dfda725c415"
+  commit: "cccc120d23cbf65f7f263122407d980a24f65f27"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -39,5 +39,6 @@ source {
     dest_file: "Kablammo[MORF].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 minisite_url: "https://fonts.withgoogle.com/kablammo"


### PR DESCRIPTION
Port most of the repo_url & commit info from fontc_crater's target.json file. (https://github.com/googlefonts/fontc_crater/commit/ee7a65d433882450efa1d8418ed746bf07c05642)

These correspond to all target.json entries with a single config_yaml each. There are also 100 entries with multiple config_yaml values that I'll submit later because they need more careful review.

(issue #2587)