### PR TITLE
[Batch 2/4] port info from fontc_crater targets list

### DIFF
--- a/ofl/kalnia/METADATA.pb
+++ b/ofl/kalnia/METADATA.pb
@@ -28,7 +28,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/fridamedrano/Kalnia-Typeface"
-  commit: "22e2d855245c5a4f94aa12461e1b1be5c0da841b"
+  commit: "b58d2689de548478ed6cee6937c37eabc4140958"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -42,6 +42,7 @@ source {
     dest_file: "Kalnia[wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/kalniaglaze/METADATA.pb
+++ b/ofl/kalniaglaze/METADATA.pb
@@ -27,7 +27,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/fridamedrano/Kalnia-Glaze"
-  commit: "1da962604705abc74467d29d5ca74e0f371f7dd5"
+  commit: "3338853e096724f548386c608d7c42c63c6c33bd"
   archive_url: "https://github.com/fridamedrano/Kalnia-Glaze/releases/download/v1.110/Kalnia-Glaze-v1.110.zip"
   files {
     source_file: "OFL.txt"
@@ -38,6 +38,7 @@ source {
     dest_file: "KalniaGlaze[wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://www.fridamedrano.com/kalniaglaze"
 stroke: "SERIF"

--- a/ofl/kameron/METADATA.pb
+++ b/ofl/kameron/METADATA.pb
@@ -22,7 +22,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/kameronFont"
-  commit: "4c36d3f42f93806b911562d50927406fbb043f89"
+  commit: "c13447c3b5fc11abd2eb640bd4a8dd789e38d76f"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,5 +32,6 @@ source {
     dest_file: "Kameron[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SLAB_SERIF"

--- a/ofl/kantumruypro/METADATA.pb
+++ b/ofl/kantumruypro/METADATA.pb
@@ -32,7 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/sovichet/kantumruy-pro"
-  commit: "8bf831210d27c1eda0129aa991d12af9e4c16632"
+  commit: "dfca20df61b64efa148539a0103e52189aca78bc"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -46,5 +46,6 @@ source {
     dest_file: "KantumruyPro-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Khmr"

--- a/ofl/karantina/METADATA.pb
+++ b/ofl/karantina/METADATA.pb
@@ -36,6 +36,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/ronykoch/Karantina"
+  commit: "efb7e920f0a441badef8920cd87d894383a19e6a"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -57,4 +58,5 @@ source {
     dest_file: "Karantina-Bold.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/karla/METADATA.pb
+++ b/ofl/karla/METADATA.pb
@@ -45,4 +45,5 @@ source {
     dest_file: "Karla-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/kdamthmorpro/METADATA.pb
+++ b/ofl/kdamthmorpro/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/sovichet/kdam-thmor-pro"
-  commit: "a78a9ff035108630f42ae15a04b4ab8150298786"
+  commit: "02b97ee272f9a32d06135f70e220d2c4d6dd218f"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -28,6 +28,7 @@ source {
     dest_file: "KdamThmorPro-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Khmr"
 stroke: "SANS_SERIF"

--- a/ofl/kings/METADATA.pb
+++ b/ofl/kings/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/kings"
+  commit: "316326276cb919f88ac51dbe887958e50a3bba49"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Kings-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/kodemono/METADATA.pb
+++ b/ofl/kodemono/METADATA.pb
@@ -23,7 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/isaozler/kode-mono"
-  commit: "94d565d4b6164cee482c68ee706e51135d6691ad"
+  commit: "2d427d3f44649656d2c1932bb671d0c4cd064041"
   files {
     source_file: "fonts/variable/KodeMono[wght].ttf"
     dest_file: "KodeMono[wght].ttf"
@@ -37,7 +37,8 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
+minisite_url: "https://kodemono.com"
 stroke: "SANS_SERIF"
 classifications: "MONOSPACE"
-minisite_url: "https://kodemono.com"

--- a/ofl/kolkerbrush/METADATA.pb
+++ b/ofl/kolkerbrush/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/kolker-brush"
+  commit: "03ba4eb35eb2801089ff9343695a1f54f9b8d5b7"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "KolkerBrush-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/konkhmersleokchher/METADATA.pb
+++ b/ofl/konkhmersleokchher/METADATA.pb
@@ -28,5 +28,6 @@ source {
     dest_file: "KonkhmerSleokchher-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Khmr"

--- a/ofl/kreon/METADATA.pb
+++ b/ofl/kreon/METADATA.pb
@@ -22,4 +22,6 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/kreon"
+  commit: "d7f798b480013cfa899779d6dae4511fd3c310cb"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/kumbhsans/METADATA.pb
+++ b/ofl/kumbhsans/METADATA.pb
@@ -43,4 +43,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/labrada/METADATA.pb
+++ b/ofl/labrada/METADATA.pb
@@ -46,4 +46,5 @@ source {
     dest_file: "Labrada[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/lavishlyyours/METADATA.pb
+++ b/ofl/lavishlyyours/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "LavishlyYours-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/leaguegothic/METADATA.pb
+++ b/ofl/leaguegothic/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/sursly/league-gothic"
+  commit: "f1d4a1c8c1db3c4a32cc13763c5fbb1776b5d478"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,6 +33,7 @@ source {
     dest_file: "LeagueGothic[wdth].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/leaguespartan/METADATA.pb
+++ b/ofl/leaguespartan/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/theleagueof/league-spartan"
+  commit: "27341b9bf93a2c7faa140538a64ce342486c5fb5"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,4 +33,5 @@ source {
     dest_file: "LeagueSpartan[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/lemonada/METADATA.pb
+++ b/ofl/lemonada/METADATA.pb
@@ -24,6 +24,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/Gue3bara/Lemonada"
+  commit: "21a53a1760f6f3c3e585bc50bc3463e97f1fa7e6"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Arab"
 stroke: "SANS_SERIF"

--- a/ofl/librebodoni/METADATA.pb
+++ b/ofl/librebodoni/METADATA.pb
@@ -46,4 +46,5 @@ source {
     dest_file: "LibreBodoni-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/librefranklin/METADATA.pb
+++ b/ofl/librefranklin/METADATA.pb
@@ -120,4 +120,5 @@ source {
     dest_file: "static/LibreFranklin-ThinItalic.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/licorice/METADATA.pb
+++ b/ofl/licorice/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/licorice"
+  commit: "8bc5263602a190f212684ea69d5b9d3b21a59bc0"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Licorice-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/lifesavers/METADATA.pb
+++ b/ofl/lifesavers/METADATA.pb
@@ -53,6 +53,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/linefont/METADATA.pb
+++ b/ofl/linefont/METADATA.pb
@@ -25,7 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/dy/linefont"
-  commit: "347effeda6955b1aa7febc34e17dcce3e04f5e15"
+  commit: "9edec1a1f780db52db0297bab464451f3dbd4d5a"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -35,6 +35,7 @@ source {
     dest_file: "Linefont[wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 sample_text {
   masthead_full: "ĀŤĀŤĀŤĀŤĀŤĀŤĀŤŤĀĀŤŤĀĀŤŤĀĀŤŤĀĀŤŤĀĀŤŤŤŤĀĀĀĀŤŤŤŤĀĀĀĀŤŤŤŤĀĀ"

--- a/ofl/liter/METADATA.pb
+++ b/ofl/liter/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/skugiz/liter"
-  commit: "4bcb5b1fcac534445cb40ac31c1c4c5669fcbbc6"
+  commit: "3808843f982fae783aedd11d2f6ed8956f37fa04"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -28,5 +28,6 @@ source {
     dest_file: "Liter-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/literata/METADATA.pb
+++ b/ofl/literata/METADATA.pb
@@ -55,4 +55,5 @@ source {
     dest_file: "Literata-Italic[opsz,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/lora/METADATA.pb
+++ b/ofl/lora/METADATA.pb
@@ -36,7 +36,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/cyrealtype/Lora-Cyrillic"
-  commit: "403b1a66ca2e79f81d749c5299559e168591a4df"
+  commit: "c44a1dde19a3fcff5bf549677e08a64510837e9d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -50,5 +50,6 @@ source {
     dest_file: "Lora-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"

--- a/ofl/lovelight/METADATA.pb
+++ b/ofl/lovelight/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/love-light"
+  commit: "e4fc541136be7d2814ac542a930be1ebaa17b5e1"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "LoveLight-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/loversquarrel/METADATA.pb
+++ b/ofl/loversquarrel/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/lovers-quarrel"
+  commit: "bf3a5fd5bf11cd96b5545ee9191a16460296eb71"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "LoversQuarrel-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/lugrasimo/METADATA.pb
+++ b/ofl/lugrasimo/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/docrepair-fonts/lugrasimo-fonts"
-  commit: "40395a6877a6bcdfe74deb2a7e355c0a4c7228e7"
+  commit: "18103084964ae884ad65dc31115dbc650b164a1a"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "Lugrasimo-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "HANDWRITING"

--- a/ofl/lumanosimo/METADATA.pb
+++ b/ofl/lumanosimo/METADATA.pb
@@ -31,6 +31,7 @@ source {
     dest_file: "Lumanosimo-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "HANDWRITING"

--- a/ofl/lunasima/METADATA.pb
+++ b/ofl/lunasima/METADATA.pb
@@ -50,4 +50,5 @@ source {
     dest_file: "Lunasima-Bold.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/luxuriousroman/METADATA.pb
+++ b/ofl/luxuriousroman/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/luxurious-roman"
+  commit: "79ca0d1eececc94be7fe0e23f306043de77c7457"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "LuxuriousRoman-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/luxuriousscript/METADATA.pb
+++ b/ofl/luxuriousscript/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/luxurious"
+  commit: "234fe6f071f7e4450893f159a4ca3512310c66ee"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "LuxuriousScript-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/madimione/METADATA.pb
+++ b/ofl/madimione/METADATA.pb
@@ -33,6 +33,7 @@ source {
     dest_file: "MadimiOne-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/mako/METADATA.pb
+++ b/ofl/mako/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/MakoFont"
-  commit: "493c8535e2ae836eea478f167b7c05755818360f"
+  commit: "f1365c6fd308090395e543858ce9c8520061c913"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -27,4 +27,5 @@ source {
     dest_file: "Mako-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/maname/METADATA.pb
+++ b/ofl/maname/METADATA.pb
@@ -30,5 +30,6 @@ source {
     dest_file: "Maname-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Sinh"

--- a/ofl/mansalva/METADATA.pb
+++ b/ofl/mansalva/METADATA.pb
@@ -29,6 +29,7 @@ source {
     dest_file: "Mansalva-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/manuale/METADATA.pb
+++ b/ofl/manuale/METADATA.pb
@@ -32,4 +32,6 @@ axes {
 }
 source {
   repository_url: "https://github.com/Omnibus-Type/Manuale"
+  commit: "20a5ab6a0da1c8cb56916d843e50db0ad6b6dfd3"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/markazitext/METADATA.pb
+++ b/ofl/markazitext/METADATA.pb
@@ -24,4 +24,6 @@ axes {
 }
 source {
   repository_url: "https://github.com/BornaIz/markazitext"
+  commit: "a876c4f0111b96f407741a877e79f207e9117338"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/marmelad/METADATA.pb
+++ b/ofl/marmelad/METADATA.pb
@@ -20,7 +20,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/cyrealtype/Marmelad-Cyrillic"
-  commit: "9ddac1c0cbdc888e1c6adae6f34e7db08ec6c187"
+  commit: "16362f68353c2115209b2e6f94e6d3ec8378626b"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -30,4 +30,5 @@ source {
     dest_file: "Marmelad-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/martianmono/METADATA.pb
+++ b/ofl/martianmono/METADATA.pb
@@ -30,7 +30,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/evilmartians/mono"
-  commit: "17865aac562a1a800888de6604f7251f135cf3b5"
+  commit: "a96373b28656b2608f28761e598471c99a4599e3"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -40,4 +40,5 @@ source {
     dest_file: "MartianMono[wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/matemasie/METADATA.pb
+++ b/ofl/matemasie/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/YADAMSS/Matemasie-Font"
-  commit: "a53371edff5c32131e93492ccb7618f4c567fbe0"
+  commit: "a6dbde5f9eb448066e8c751ee4c5b4146a7fbc99"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -47,6 +47,7 @@ source {
     dest_file: "article/4.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://yadamss.github.io/Matemasie-miniwebsite"
 stroke: "SANS_SERIF"

--- a/ofl/meaculpa/METADATA.pb
+++ b/ofl/meaculpa/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/mea-culpa"
+  commit: "13dd5b66076ddc6706d85a30dfed8d007e2f8350"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "MeaCulpa-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/meowscript/METADATA.pb
+++ b/ofl/meowscript/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/meow-script"
+  commit: "6882d389cb287bd7b7716c125e9728b81ed0ab41"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,4 +32,5 @@ source {
     dest_file: "MeowScript-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/merienda/METADATA.pb
+++ b/ofl/merienda/METADATA.pb
@@ -33,4 +33,5 @@ source {
     dest_file: "Merienda[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/merriweather/METADATA.pb
+++ b/ofl/merriweather/METADATA.pb
@@ -63,6 +63,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 fallbacks {
   axis_target {

--- a/ofl/metrophobic/METADATA.pb
+++ b/ofl/metrophobic/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/MetrophobicFont"
-  commit: "c834ca0e9188d756627252ae510266ed5e8d2416"
+  commit: "d4da54632ddd53631332a5a469183c887b4ea3e1"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -28,4 +28,5 @@ source {
     dest_file: "Metrophobic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/michroma/METADATA.pb
+++ b/ofl/michroma/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/Michroma-font"
-  commit: "07893d1b85a537a6ed4b96fdb091bee45eabe65f"
+  commit: "8602c0e9a86c0aa6529cc861926bf727568dcac8"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -27,6 +27,7 @@ source {
     dest_file: "Michroma-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/micro5/METADATA.pb
+++ b/ofl/micro5/METADATA.pb
@@ -29,5 +29,6 @@ source {
     dest_file: "Micro5-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/micro5charted/METADATA.pb
+++ b/ofl/micro5charted/METADATA.pb
@@ -29,5 +29,6 @@ source {
     dest_file: "Micro5Charted-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/miriamlibre/METADATA.pb
+++ b/ofl/miriamlibre/METADATA.pb
@@ -23,7 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/simoncozens/Miriam-Libre"
-  commit: "72606f962886b013985f71c300dda3b9deb61a6b"
+  commit: "fc1dbbb7ef6f331b10771c22d33b4bf7543efbd8"
   files {
     source_file: "fonts/variable/MiriamLibre[wght].ttf"
     dest_file: "MiriamLibre[wght].ttf"
@@ -33,4 +33,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/moderustic/METADATA.pb
+++ b/ofl/moderustic/METADATA.pb
@@ -39,5 +39,6 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/mohave/METADATA.pb
+++ b/ofl/mohave/METADATA.pb
@@ -31,4 +31,6 @@ axes {
 }
 source {
   repository_url: "https://github.com/tokotype/Mohave-Typefaces"
+  commit: "703dda9b4da22ec66dd2a09cc492f6228401147a"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/moiraione/METADATA.pb
+++ b/ofl/moiraione/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/JAMO-TYPEFACE/Moirai"
-  commit: "3220f0c211c8d3a3bb989896cf7ea66d16a925e6"
+  commit: "2da483959021f384eebc39feb6da1e8cbcdf452d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,5 +32,6 @@ source {
     dest_file: "MoiraiOne-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Kore"

--- a/ofl/monasans/METADATA.pb
+++ b/ofl/monasans/METADATA.pb
@@ -37,7 +37,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/github/mona-sans"
-  commit: "56384c90b986d431470303b4f7296585cb9c4515"
+  commit: "0d07d5a501a2d8d4ea456fab73aad6b9fda2060a"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -51,6 +51,7 @@ source {
     dest_file: "MonaSans[wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
-stroke: "SANS_SERIF"
 minisite_url: "https://github.com/mona-sans"
+stroke: "SANS_SERIF"

--- a/ofl/monda/METADATA.pb
+++ b/ofl/monda/METADATA.pb
@@ -37,4 +37,5 @@ source {
     dest_file: "Monda[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/monomakh/METADATA.pb
+++ b/ofl/monomakh/METADATA.pb
@@ -19,7 +19,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/slavonic/Monomakh"
-  commit: "762ecd97ee44511bb9bf696d2d3cffb65d74e54c"
+  commit: "5131e23dcd584741d7481ecbd3e81a8cb3eea871"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -33,5 +33,6 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Cyrl"

--- a/ofl/montecarlo/METADATA.pb
+++ b/ofl/montecarlo/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/monte-carlo"
+  commit: "62962590ae6b6dea67788c485d38217abe196e1b"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "MonteCarlo-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/montserrat/METADATA.pb
+++ b/ofl/montserrat/METADATA.pb
@@ -34,7 +34,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/JulietaUla/Montserrat"
-  commit: "f025b649a5302db60edb04a88199b8b941abc33a"
+  commit: "cc8daf2e7085006b9c112542fc82b58afc13521d"
   files {
     source_file: "fonts/variable/Montserrat[wght].ttf"
     dest_file: "Montserrat[wght].ttf"
@@ -48,6 +48,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "merge-forked-changes"
+  config_yaml: "sources/config.yaml"
 }
 fallbacks {
   axis_target {

--- a/ofl/montserratalternates/METADATA.pb
+++ b/ofl/montserratalternates/METADATA.pb
@@ -173,4 +173,6 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/JulietaUla/Montserrat"
+  commit: "cc8daf2e7085006b9c112542fc82b58afc13521d"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/montserratunderline/METADATA.pb
+++ b/ofl/montserratunderline/METADATA.pb
@@ -34,7 +34,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/JulietaUla/Montserrat"
-  commit: "679ead9bcd0d6cef6d3712369dc49fe72e8bd8d7"
+  commit: "cc8daf2e7085006b9c112542fc82b58afc13521d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -48,4 +48,5 @@ source {
     dest_file: "MontserratUnderline-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/moolahlah/METADATA.pb
+++ b/ofl/moolahlah/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/moolahlah"
+  commit: "ef0153966b76e4b4c136ed98e087607f71b75612"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "MooLahLah-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/mooli/METADATA.pb
+++ b/ofl/mooli/METADATA.pb
@@ -27,5 +27,6 @@ source {
     dest_file: "Mooli-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/moondance/METADATA.pb
+++ b/ofl/moondance/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/moondance"
+  commit: "ebba2ffb57b1b7c23e9dd382605ab9c92119cc49"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "MoonDance-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/msmadi/METADATA.pb
+++ b/ofl/msmadi/METADATA.pb
@@ -32,4 +32,5 @@ source {
     dest_file: "MsMadi-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/mulish/METADATA.pb
+++ b/ofl/mulish/METADATA.pb
@@ -34,6 +34,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/mulish"
+  commit: "5503f7a18ce79870148b9f9cb8e592ac44c044c3"
   files {
     source_file: "fonts/variable/Mulish[wght].ttf"
     dest_file: "Mulish[wght].ttf"
@@ -51,4 +52,5 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/murecho/METADATA.pb
+++ b/ofl/murecho/METADATA.pb
@@ -26,6 +26,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/positype/Murecho-Project"
+  commit: "0efba44c1c504efe50edc3ae30da5840461e5d49"
   files {
     source_file: "fonts/variable/Murecho[wght].ttf"
     dest_file: "Murecho[wght].ttf"
@@ -35,5 +36,6 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Hira"

--- a/ofl/museomoderno/METADATA.pb
+++ b/ofl/museomoderno/METADATA.pb
@@ -46,6 +46,7 @@ source {
     dest_file: "MuseoModerno-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/mynerve/METADATA.pb
+++ b/ofl/mynerve/METADATA.pb
@@ -29,6 +29,7 @@ source {
     dest_file: "Mynerve-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/mysoul/METADATA.pb
+++ b/ofl/mysoul/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/my-soul"
-  commit: "13b1f37605ab5bd23b9c71be2d8f639810996236"
+  commit: "bf7a506caeb8994fd9820787fb6f2c0f0480ec09"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,6 +32,7 @@ source {
     dest_file: "MySoul-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/neonderthaw/METADATA.pb
+++ b/ofl/neonderthaw/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/neonderthaw"
+  commit: "67e6f60e5addb09d39d7a36f908430cc508165fb"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Neonderthaw-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/newamsterdam/METADATA.pb
+++ b/ofl/newamsterdam/METADATA.pb
@@ -27,5 +27,6 @@ source {
     dest_file: "NewAmsterdam-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/norican/METADATA.pb
+++ b/ofl/norican/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/NoricanFont"
-  commit: "c8f871d4dd2a00f17ba95783a3bd41c296188faf"
+  commit: "5e30b33570463b57d70795d7ccac56b4d69688e5"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -27,4 +27,5 @@ source {
     dest_file: "Norican-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/notable/METADATA.pb
+++ b/ofl/notable/METADATA.pb
@@ -16,6 +16,8 @@ subsets: "latin"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/notable"
+  commit: "e3426360fa15b1824f4694663271956e50514498"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/notomusic/METADATA.pb
+++ b/ofl/notomusic/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "music"
 source {
   repository_url: "https://github.com/notofonts/music"
+  commit: "2c97b9ea6927a3a80bc7289d663d9115b070f365"
   archive_url: "https://github.com/notofonts/music/releases/download/NotoMusic-v2.003/NotoMusic-v2.003.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,6 +37,7 @@ source {
     dest_file: "NotoMusic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-music.yaml"
 }
 is_noto: true
 sample_text {

--- a/ofl/notonastaliqurdu/METADATA.pb
+++ b/ofl/notonastaliqurdu/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/nastaliq"
+  commit: "3508acd351a8603c6b74d2cff2da66b0806374d1"
   archive_url: "https://github.com/notofonts/nastaliq/releases/download/NotoNastaliqUrdu-v3.009/NotoNastaliqUrdu-v3.009.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -41,7 +42,8 @@ source {
     dest_file: "NotoNastaliqUrdu[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-nastaliq-urdu.yaml"
 }
 is_noto: true
-languages: "ur_Arab"  # Urdu
+languages: "ur_Arab"
 primary_script: "Arab"

--- a/ofl/notosansanatolianhieroglyphs/METADATA.pb
+++ b/ofl/notosansanatolianhieroglyphs/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/anatolian-hieroglyphs"
+  commit: "d82f0bce270456bb1e975e11b250f61cd1f0e8c7"
   archive_url: "https://github.com/notofonts/anatolian-hieroglyphs/releases/download/NotoSansAnatolianHieroglyphs-v2.001/NotoSansAnatolianHieroglyphs-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansAnatolianHieroglyphs-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-anatolian-hieroglyphs.yaml"
 }
 is_noto: true
-languages: "hlu_Hluw"  # Hieroglyphic Luwian
+languages: "hlu_Hluw"
 primary_script: "Hluw"

--- a/ofl/notosansavestan/METADATA.pb
+++ b/ofl/notosansavestan/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/avestan"
+  commit: "c19976eacac1ca2abf665d3363cf61893342c0ab"
   archive_url: "https://github.com/notofonts/avestan/releases/download/NotoSansAvestan-v2.003/NotoSansAvestan-v2.003.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansAvestan-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-avestan.yaml"
 }
 is_noto: true
-languages: "ae_Avst"  # Avestan
+languages: "ae_Avst"
 primary_script: "Avst"

--- a/ofl/notosansbamum/METADATA.pb
+++ b/ofl/notosansbamum/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/bamum"
+  commit: "92bf2329accf9c1e6bc9373a64def94578a5f89b"
   archive_url: "https://github.com/notofonts/bamum/releases/download/NotoSansBamum-v2.002/NotoSansBamum-v2.002.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -41,9 +42,10 @@ source {
     dest_file: "NotoSansBamum[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-bamum.yaml"
 }
 is_noto: true
-languages: "bax_Bamu"  # Bamun
+languages: "bax_Bamu"
 sample_text {
   masthead_full: "ꚢ𖠤ꚴ𖠏"
   masthead_partial: "ꚡ𖠩"

--- a/ofl/notosansbassavah/METADATA.pb
+++ b/ofl/notosansbassavah/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/bassa-vah"
+  commit: "bed459c24b109a612b53f44542d4fe6f9c754641"
   archive_url: "https://github.com/notofonts/bassa-vah/releases/download/NotoSansBassaVah-v2.002/NotoSansBassaVah-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -37,7 +38,8 @@ source {
     dest_file: "NotoSansBassaVah[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-bassa-vah.yaml"
 }
 is_noto: true
-languages: "bsq_Bass"  # Bassa
+languages: "bsq_Bass"
 primary_script: "Bass"

--- a/ofl/notosansbatak/METADATA.pb
+++ b/ofl/notosansbatak/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/batak"
+  commit: "9e4d85f112e7c8a5b1d958b5b848db15eea069b2"
   archive_url: "https://github.com/notofonts/batak/releases/download/NotoSansBatak-v2.003/NotoSansBatak-v2.003.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansBatak-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-batak.yaml"
 }
 is_noto: true
-languages: "bbc_Batk"  # Batak Toba, Batak
+languages: "bbc_Batk"
 primary_script: "Batk"

--- a/ofl/notosansbhaiksuki/METADATA.pb
+++ b/ofl/notosansbhaiksuki/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/bhaiksuki"
+  commit: "570db5a125e4f011e2d54b55220c0e2111adea2e"
   archive_url: "https://github.com/notofonts/bhaiksuki/releases/download/NotoSansBhaiksuki-v2.002/NotoSansBhaiksuki-v2.002.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansBhaiksuki-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-bhaiksuki.yaml"
 }
 is_noto: true
-languages: "sa_Bhks"  # Sanskrit, Bhaiksuki
+languages: "sa_Bhks"
 primary_script: "Bhks"

--- a/ofl/notosansbrahmi/METADATA.pb
+++ b/ofl/notosansbrahmi/METADATA.pb
@@ -20,6 +20,7 @@ subsets: "menu"
 subsets: "symbols"
 source {
   repository_url: "https://github.com/notofonts/brahmi"
+  commit: "7803437c1a61033137e89a7860cccb8f735a6088"
   archive_url: "https://github.com/notofonts/brahmi/releases/download/NotoSansBrahmi-v2.004/NotoSansBrahmi-v2.004.zip"
   files {
     source_file: "OFL.txt"
@@ -38,10 +39,11 @@ source {
     dest_file: "NotoSansBrahmi-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-brahmi.yaml"
 }
 is_noto: true
-languages: "aii_Brah"  # Assyrian Neo-Aramaic, Brahmi
-languages: "pi_Brah"  # Pali, Brahmi
-languages: "pka_Brah"  # Ardhamagadhi Prakrit
-languages: "sa_Brah"  # Sanskrit, Brahmi
+languages: "aii_Brah"
+languages: "pi_Brah"
+languages: "pka_Brah"
+languages: "sa_Brah"
 primary_script: "Brah"

--- a/ofl/notosansbuginese/METADATA.pb
+++ b/ofl/notosansbuginese/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/buginese"
+  commit: "8d73947363e673e82d4812be966a212d7633a7ee"
   archive_url: "https://github.com/notofonts/buginese/releases/download/NotoSansBuginese-v2.002/NotoSansBuginese-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -36,10 +37,11 @@ source {
     dest_file: "NotoSansBuginese-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-buginese.yaml"
 }
 is_noto: true
-languages: "bug_Bugi"  # Buginese, Buginese
-languages: "mak_Bugi"  # Makasar, Buginese
-languages: "mdr_Bugi"  # Mandar, Buginese
-languages: "sa_Bugi"  # Sanskrit, Buginese
+languages: "bug_Bugi"
+languages: "mak_Bugi"
+languages: "mdr_Bugi"
+languages: "sa_Bugi"
 primary_script: "Bugi"

--- a/ofl/notosansbuhid/METADATA.pb
+++ b/ofl/notosansbuhid/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/buhid"
+  commit: "f678808af467ed38aa5a8d29a3f0925c14b1f570"
   archive_url: "https://github.com/notofonts/buhid/releases/download/NotoSansBuhid-v2.001/NotoSansBuhid-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -28,7 +29,8 @@ source {
     dest_file: "NotoSansBuhid-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-buhid.yaml"
 }
 is_noto: true
-languages: "bku_Buhd"  # Buhid, Buhid
+languages: "bku_Buhd"
 primary_script: "Buhd"

--- a/ofl/notosanscanadianaboriginal/METADATA.pb
+++ b/ofl/notosanscanadianaboriginal/METADATA.pb
@@ -25,6 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/canadian-aboriginal"
+  commit: "1766b85dfc150695e2322c33fdc441f552720b6f"
   archive_url: "https://github.com/notofonts/canadian-aboriginal/releases/download/NotoSansCanadianAboriginal-v2.004/NotoSansCanadianAboriginal-v2.004.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -43,18 +44,19 @@ source {
     dest_file: "NotoSansCanadianAboriginal[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-canadian-aboriginal.yaml"
 }
 is_noto: true
-languages: "chp_Cans"  # Chipewyan, Unified Canadian Aboriginal Syllabics
-languages: "cr_Cans"  # Cree
-languages: "crj_Cans"  # Southern East Cree
-languages: "crk_Cans"  # Plains Cree
-languages: "crl_Cans"  # Northern East Cree
-languages: "crm_Cans"  # Moose Cree
-languages: "csw_Cans"  # Swampy Cree
-languages: "den_Cans"  # Slave, Unified Canadian Aboriginal Syllabics
-languages: "iu_Cans"  # Inuktitut
-languages: "nsk_Cans"  # Naskapi
-languages: "oj_Cans"  # Ojibwa
-languages: "ojb_Cans"  # Northwestern Ojibwa, Unified Canadian Aboriginal Syllabics, Canada
+languages: "chp_Cans"
+languages: "cr_Cans"
+languages: "crj_Cans"
+languages: "crk_Cans"
+languages: "crl_Cans"
+languages: "crm_Cans"
+languages: "csw_Cans"
+languages: "den_Cans"
+languages: "iu_Cans"
+languages: "nsk_Cans"
+languages: "oj_Cans"
+languages: "ojb_Cans"
 primary_script: "Cans"

--- a/ofl/notosanscarian/METADATA.pb
+++ b/ofl/notosanscarian/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/carian"
+  commit: "90653aaa664123ff3b49ac9a1380d08feb84cf4e"
   archive_url: "https://github.com/notofonts/carian/releases/download/NotoSansCarian-v2.002/NotoSansCarian-v2.002.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansCarian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-carian.yaml"
 }
 is_noto: true
-languages: "xcr_Cari"  # Carian
+languages: "xcr_Cari"
 primary_script: "Cari"

--- a/ofl/notosanscaucasianalbanian/METADATA.pb
+++ b/ofl/notosanscaucasianalbanian/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/caucasian-albanian"
+  commit: "fe112d99202d347b106fe63ebc6b10c3655e00cd"
   archive_url: "https://github.com/notofonts/caucasian-albanian/releases/download/NotoSansCaucasianAlbanian-v2.005/NotoSansCaucasianAlbanian-v2.005.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -32,9 +33,10 @@ source {
     dest_file: "NotoSansCaucasianAlbanian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-caucasian-albanian.yaml"
 }
 is_noto: true
-languages: "lez_Aghb"  # Lezghian, Caucasian Albanian
+languages: "lez_Aghb"
 sample_text {
   masthead_full: "𐔲𐕢𐔼𐕊"
   masthead_partial: "𐔱𐕁"

--- a/ofl/notosanschakma/METADATA.pb
+++ b/ofl/notosanschakma/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/chakma"
+  commit: "239fe3aac753fa2007fa34fa4897a6b520994e88"
   archive_url: "https://github.com/notofonts/chakma/releases/download/NotoSansChakma-v2.003/NotoSansChakma-v2.003.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansChakma-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-chakma.yaml"
 }
 is_noto: true
-languages: "ccp_Cakm"  # Chakma
+languages: "ccp_Cakm"
 primary_script: "Cakm"

--- a/ofl/notosanscham/METADATA.pb
+++ b/ofl/notosanscham/METADATA.pb
@@ -23,7 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/cham"
-  commit: "1688bf8b8c53fbc07d363c5ab31610a1a65f16f9"
+  commit: "ab48c582e3c834028dc0444b832874be83532350"
   archive_url: "https://github.com/notofonts/cham/releases/download/NotoSansCham-v2.005/NotoSansCham-v2.005.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -42,9 +42,10 @@ source {
     dest_file: "NotoSansCham[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-cham.yaml"
 }
 is_noto: true
-languages: "cja_Cham"  # Western Cham, Cham
-languages: "cjm_Cham"  # Eastern Cham
-languages: "sa_Cham"  # Sanskrit, Cham
+languages: "cja_Cham"
+languages: "cjm_Cham"
+languages: "sa_Cham"
 primary_script: "Cham"

--- a/ofl/notosanscherokee/METADATA.pb
+++ b/ofl/notosanscherokee/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/cherokee"
+  commit: "a8a61f7f537960c468130795eaa168f4a594266e"
   archive_url: "https://github.com/notofonts/cherokee/releases/download/NotoSansCherokee-v2.001/NotoSansCherokee-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -41,7 +42,8 @@ source {
     dest_file: "NotoSansCherokee[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-cherokee.yaml"
 }
 is_noto: true
-languages: "chr_Cher"  # Cherokee
+languages: "chr_Cher"
 primary_script: "Cher"

--- a/ofl/notosanschorasmian/METADATA.pb
+++ b/ofl/notosanschorasmian/METADATA.pb
@@ -20,6 +20,7 @@ subsets: "menu"
 subsets: "symbols"
 source {
   repository_url: "https://github.com/notofonts/chorasmian"
+  commit: "0ce3cfe5b4aecaa18ee820c9a668c7cd3744a29f"
   archive_url: "https://github.com/notofonts/chorasmian/releases/download/NotoSansChorasmian-v1.004/NotoSansChorasmian-v1.004.zip"
   files {
     source_file: "OFL.txt"
@@ -38,7 +39,8 @@ source {
     dest_file: "NotoSansChorasmian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-chorasmian.yaml"
 }
 is_noto: true
-languages: "aii_Chrs"  # Assyrian Neo-Aramaic, Chorasmian
+languages: "aii_Chrs"
 primary_script: "Chrs"

--- a/ofl/notosanscoptic/METADATA.pb
+++ b/ofl/notosanscoptic/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/coptic"
+  commit: "ed3522436a4e3c41b0479c8d7785facd3c397eaa"
   archive_url: "https://github.com/notofonts/coptic/releases/download/NotoSansCoptic-v2.004/NotoSansCoptic-v2.004.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansCoptic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-coptic.yaml"
 }
 is_noto: true
-languages: "cop_Copt"  # Coptic, Coptic
+languages: "cop_Copt"
 primary_script: "Copt"

--- a/ofl/notosanscuneiform/METADATA.pb
+++ b/ofl/notosanscuneiform/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/cuneiform"
+  commit: "24c590e3586376ead66466b6c8b8a810df24d06f"
   archive_url: "https://github.com/notofonts/cuneiform/releases/download/NotoSansCuneiform-v2.001/NotoSansCuneiform-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansCuneiform-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-cuneiform.yaml"
 }
 is_noto: true
-languages: "akk_Xsux"  # Akkadian
-languages: "hit_Xsux"  # Hittite
+languages: "akk_Xsux"
+languages: "hit_Xsux"
 primary_script: "Xsux"

--- a/ofl/notosanscypriot/METADATA.pb
+++ b/ofl/notosanscypriot/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/cypriot"
+  commit: "4f81293d17d7b3c9c67b9ab2c335905c75ad3f1d"
   archive_url: "https://github.com/notofonts/cypriot/releases/download/NotoSansCypriot-v2.002/NotoSansCypriot-v2.002.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansCypriot-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-cypriot.yaml"
 }
 is_noto: true
-languages: "grc_Cprt"  # Ancient Greek
+languages: "grc_Cprt"
 primary_script: "Cprt"

--- a/ofl/notosanscyprominoan/METADATA.pb
+++ b/ofl/notosanscyprominoan/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/cypro-minoan"
+  commit: "12b0fed7738a0a2b6d47040d383c2a5a5e796b0d"
   archive_url: "https://github.com/notofonts/cypro-minoan/releases/download/NotoSansCyproMinoan-v1.503/NotoSansCyproMinoan-v1.503.zip"
   files {
     source_file: "OFL.txt"
@@ -36,6 +37,7 @@ source {
     dest_file: "NotoSansCyproMinoan-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-cypro-minoan.yaml"
 }
 is_noto: true
 sample_text {

--- a/ofl/notosansdeseret/METADATA.pb
+++ b/ofl/notosansdeseret/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/deseret"
+  commit: "fab3d4d90de5f00b318f70a2d0c247402348fd8f"
   archive_url: "https://github.com/notofonts/deseret/releases/download/NotoSansDeseret-v2.001/NotoSansDeseret-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansDeseret-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-deseret.yaml"
 }
 is_noto: true
-languages: "en_Dsrt"  # English, Deseret
+languages: "en_Dsrt"
 primary_script: "Dsrt"

--- a/ofl/notosansduployan/METADATA.pb
+++ b/ofl/notosansduployan/METADATA.pb
@@ -27,7 +27,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/duployan"
-  commit: "dcec488da5e9c16d48051fe8d20b1b615bf8c9be"
+  commit: "9626869cc851873c96eafd019fab55d984bbebc0"
   archive_url: "https://github.com/notofonts/duployan/releases/download/NotoSansDuployan-v3.002/NotoSansDuployan-v3.002.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -50,10 +50,11 @@ source {
     dest_file: "NotoSansDuployan-Bold.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-duployan.yaml"
 }
 is_noto: true
-languages: "chn_Dupl"  # Chinook Jargon, Duployan
-languages: "fr_Dupl"  # French, Duployan
+languages: "chn_Dupl"
+languages: "fr_Dupl"
 sample_text {
   masthead_full: "𛰳𛱰𛱘𛱢"
   masthead_partial: "𛰠𛰏"

--- a/ofl/notosansegyptianhieroglyphs/METADATA.pb
+++ b/ofl/notosansegyptianhieroglyphs/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/egyptian-hieroglyphs"
-  commit: "08dec90190624040743ebb4e28d5552ae3d60862"
+  commit: "773da399bed8fb50cf285b13d75dfd1667d6fbca"
   archive_url: "https://github.com/notofonts/egyptian-hieroglyphs/releases/download/NotoSansEgyptianHieroglyphs-v2.002/NotoSansEgyptianHieroglyphs-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -37,8 +37,9 @@ source {
     dest_file: "NotoSansEgyptianHieroglyphs-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-egyptian-hieroglyphs.yaml"
 }
 is_noto: true
-languages: "aii_Egyp"  # Assyrian Neo-Aramaic, Egyptian hieroglyphs
-languages: "egy_Egyp"  # Ancient Egyptian
+languages: "aii_Egyp"
+languages: "egy_Egyp"
 primary_script: "Egyp"

--- a/ofl/notosanselbasan/METADATA.pb
+++ b/ofl/notosanselbasan/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/elbasan"
+  commit: "42c59134bafaf22df600e5b3e3a97224f14cca06"
   archive_url: "https://github.com/notofonts/elbasan/releases/download/NotoSansElbasan-v2.004/NotoSansElbasan-v2.004.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansElbasan-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-elbasan.yaml"
 }
 is_noto: true
-languages: "sq_Elba"  # Albanian, Elbasan
+languages: "sq_Elba"
 primary_script: "Elba"

--- a/ofl/notosanselymaic/METADATA.pb
+++ b/ofl/notosanselymaic/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/elymaic"
+  commit: "4a230cd737fee5c57d6343ff349ca74531a5e92c"
   archive_url: "https://github.com/notofonts/elymaic/releases/download/NotoSansElymaic-v1.002/NotoSansElymaic-v1.002.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansElymaic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-elymaic.yaml"
 }
 is_noto: true
-languages: "aii_Elym"  # Assyrian Neo-Aramaic, Elymaic
-languages: "xly_Elym"  # Elymian
+languages: "aii_Elym"
+languages: "xly_Elym"
 primary_script: "Elym"

--- a/ofl/notosansglagolitic/METADATA.pb
+++ b/ofl/notosansglagolitic/METADATA.pb
@@ -21,6 +21,7 @@ subsets: "menu"
 subsets: "symbols"
 source {
   repository_url: "https://github.com/notofonts/glagolitic"
+  commit: "142196c12c02018cbd55250f9ebf9380fa006203"
   archive_url: "https://github.com/notofonts/glagolitic/releases/download/NotoSansGlagolitic-v2.004/NotoSansGlagolitic-v2.004.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -39,7 +40,8 @@ source {
     dest_file: "NotoSansGlagolitic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-glagolitic.yaml"
 }
 is_noto: true
-languages: "cu_Glag"  # Church Slavic, Glagolitic
+languages: "cu_Glag"
 primary_script: "Glag"

--- a/ofl/notosansgothic/METADATA.pb
+++ b/ofl/notosansgothic/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/gothic"
+  commit: "1fdfe7f6a2be15afc26970deb0420146549766c3"
   archive_url: "https://github.com/notofonts/gothic/releases/download/NotoSansGothic-v2.001/NotoSansGothic-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansGothic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-gothic.yaml"
 }
 is_noto: true
-languages: "got_Goth"  # Gothic
+languages: "got_Goth"
 primary_script: "Goth"

--- a/ofl/notosansgunjalagondi/METADATA.pb
+++ b/ofl/notosansgunjalagondi/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/gunjala-gondi"
+  commit: "ab82937f84db18fad4493b1c689c8f8852ad13ed"
   archive_url: "https://github.com/notofonts/gunjala-gondi/releases/download/NotoSansGunjalaGondi-v1.004/NotoSansGunjalaGondi-v1.004.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -41,8 +42,9 @@ source {
     dest_file: "NotoSansGunjalaGondi[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-gunjala-gondi.yaml"
 }
 is_noto: true
-languages: "gon_Gong"  # Gondi, Gunjala Gondi
-languages: "wsg_Gong"  # Adilabad Gondi, Gunjala Gondi
+languages: "gon_Gong"
+languages: "wsg_Gong"
 primary_script: "Gong"

--- a/ofl/notosanshanifirohingya/METADATA.pb
+++ b/ofl/notosanshanifirohingya/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/hanifi-rohingya"
+  commit: "48ba61fd61998b8378d977bc999bf5caf7c80079"
   archive_url: "https://github.com/notofonts/hanifi-rohingya/releases/download/NotoSansHanifiRohingya-v2.102/NotoSansHanifiRohingya-v2.102.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -41,7 +42,8 @@ source {
     dest_file: "NotoSansHanifiRohingya[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-hanifi-rohingya.yaml"
 }
 is_noto: true
-languages: "rhg_Rohg"  # Rohingya
+languages: "rhg_Rohg"
 primary_script: "Rohg"

--- a/ofl/notosanshanunoo/METADATA.pb
+++ b/ofl/notosanshanunoo/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/hanunoo"
+  commit: "5799d6111ecc607bf5fcfdb9ce8b6dcb1712eef5"
   archive_url: "https://github.com/notofonts/hanunoo/releases/download/NotoSansHanunoo-v2.004/NotoSansHanunoo-v2.004.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -32,7 +33,8 @@ source {
     dest_file: "NotoSansHanunoo-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-hanunoo.yaml"
 }
 is_noto: true
-languages: "hnn_Hano"  # Hanunoo, Hanunoo
+languages: "hnn_Hano"
 primary_script: "Hano"

--- a/ofl/notosanshatran/METADATA.pb
+++ b/ofl/notosanshatran/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/hatran"
+  commit: "de472058911afccdf8ab8ddafc7b0314ad30e673"
   archive_url: "https://github.com/notofonts/hatran/releases/download/NotoSansHatran-v2.001/NotoSansHatran-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansHatran-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-hatran.yaml"
 }
 is_noto: true
-languages: "aii_Hatr"  # Assyrian Neo-Aramaic, Hatran
-languages: "mis_Hatr"  # Hatran Aramaic
+languages: "aii_Hatr"
+languages: "mis_Hatr"
 primary_script: "Hatr"

--- a/ofl/notosansimperialaramaic/METADATA.pb
+++ b/ofl/notosansimperialaramaic/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/imperial-aramaic"
-  commit: "f32017cb2dba233b0a09565037af84f12016b0c8"
+  commit: "059b859599f8e189962b73d357882446f195e77f"
   archive_url: "https://github.com/notofonts/imperial-aramaic/releases/download/NotoSansImperialAramaic-v2.002/NotoSansImperialAramaic-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -37,8 +37,9 @@ source {
     dest_file: "NotoSansImperialAramaic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-imperial-aramaic.yaml"
 }
 is_noto: true
-languages: "aii_Armi"  # Assyrian Neo-Aramaic, Imperial Aramaic
-languages: "arc_Armi"  # Aramaic
+languages: "aii_Armi"
+languages: "arc_Armi"
 primary_script: "Armi"

--- a/ofl/notosansindicsiyaqnumbers/METADATA.pb
+++ b/ofl/notosansindicsiyaqnumbers/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/indic-siyaq-numbers"
+  commit: "5c2be06e8ce0f4a3f552cc7100cffbbf5a200ad5"
   archive_url: "https://github.com/notofonts/indic-siyaq-numbers/releases/download/NotoSansIndicSiyaqNumbers-v2.002/NotoSansIndicSiyaqNumbers-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -36,6 +37,7 @@ source {
     dest_file: "NotoSansIndicSiyaqNumbers-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-indic-siyaq-numbers.yaml"
 }
 is_noto: true
 sample_text {

--- a/ofl/notosansinscriptionalpahlavi/METADATA.pb
+++ b/ofl/notosansinscriptionalpahlavi/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/inscriptional-pahlavi"
-  commit: "ccf6d043ac12c7817b7934f8fb98d217b8081762"
+  commit: "ae11e4305961021e457dc2f9a17b3a7eb1fe3357"
   archive_url: "https://github.com/notofonts/inscriptional-pahlavi/releases/download/NotoSansInscriptionalPahlavi-v2.004/NotoSansInscriptionalPahlavi-v2.004.zip"
   files {
     source_file: "OFL.txt"
@@ -37,8 +37,9 @@ source {
     dest_file: "NotoSansInscriptionalPahlavi-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-inscriptional-pahlavi.yaml"
 }
 is_noto: true
-languages: "aii_Phli"  # Assyrian Neo-Aramaic, Inscriptional Pahlavi
-languages: "pal_Phli"  # Pahlavi
+languages: "aii_Phli"
+languages: "pal_Phli"
 primary_script: "Phli"

--- a/ofl/notosansinscriptionalparthian/METADATA.pb
+++ b/ofl/notosansinscriptionalparthian/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/inscriptional-parthian"
-  commit: "893003503fb689e1b2a3d8810b7ee67d8ab98bf7"
+  commit: "3ad1b227f70b46d299ec1a911a39136c8b2a5a89"
   archive_url: "https://github.com/notofonts/inscriptional-parthian/releases/download/NotoSansInscriptionalParthian-v2.004/NotoSansInscriptionalParthian-v2.004.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -37,8 +37,9 @@ source {
     dest_file: "NotoSansInscriptionalParthian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-inscriptional-parthian.yaml"
 }
 is_noto: true
-languages: "aii_Prti"  # Assyrian Neo-Aramaic, Inscriptional Parthian
-languages: "xpr_Prti"  # Parthian
+languages: "aii_Prti"
+languages: "xpr_Prti"
 primary_script: "Prti"

--- a/ofl/notosansjavanese/METADATA.pb
+++ b/ofl/notosansjavanese/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/javanese"
+  commit: "da4d01347950f097f175ff332955f5d95f8bd617"
   archive_url: "https://github.com/notofonts/javanese/releases/download/NotoSansJavanese-v2.005/NotoSansJavanese-v2.005.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -41,7 +42,8 @@ source {
     dest_file: "NotoSansJavanese[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-javanese.yaml"
 }
 is_noto: true
-languages: "jv_Java"  # Javanese, Javanese
+languages: "jv_Java"
 primary_script: "Java"

--- a/ofl/notosanskaithi/METADATA.pb
+++ b/ofl/notosanskaithi/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/kaithi"
-  commit: "a439d16c5fd54cce21f4a46ee6cb18813c3d5112"
+  commit: "897d285a72e97fa29eed1c6db8db95ede52951e7"
   archive_url: "https://github.com/notofonts/kaithi/releases/download/NotoSansKaithi-v2.006/NotoSansKaithi-v2.006.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -37,7 +37,8 @@ source {
     dest_file: "NotoSansKaithi-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-kaithi.yaml"
 }
 is_noto: true
-languages: "bho_Kthi"  # Bhojpuri, Kaithi
+languages: "bho_Kthi"
 primary_script: "Kthi"

--- a/ofl/notosanskawi/METADATA.pb
+++ b/ofl/notosanskawi/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/kawi"
+  commit: "7b1182376580f1192b0ac9cc172ee1ee723655b7"
   archive_url: "https://github.com/notofonts/kawi/releases/download/NotoSansKawi-v1.000/NotoSansKawi-v1.000.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -41,7 +42,8 @@ source {
     dest_file: "NotoSansKawi[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-kawi.yaml"
 }
 is_noto: true
-languages: "kaw_Kawi"  # Old Javanese, Kawi
+languages: "kaw_Kawi"
 primary_script: "Kawi"

--- a/ofl/notosanskayahli/METADATA.pb
+++ b/ofl/notosanskayahli/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/kayah-li"
+  commit: "d804f259b83b41e7435284b5b389624631bedf35"
   archive_url: "https://github.com/notofonts/kayah-li/releases/download/NotoSansKayahLi-v2.002/NotoSansKayahLi-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -37,8 +38,9 @@ source {
     dest_file: "NotoSansKayahLi[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-kayah-li.yaml"
 }
 is_noto: true
-languages: "eky_Kali"  # Eastern Kayah
-languages: "kyu_Kali"  # Western Kayah
+languages: "eky_Kali"
+languages: "kyu_Kali"
 primary_script: "Kali"

--- a/ofl/notosanskharoshthi/METADATA.pb
+++ b/ofl/notosanskharoshthi/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/kharoshthi"
+  commit: "aacffd48d67ea30b8836a4069df73aa789148c01"
   archive_url: "https://github.com/notofonts/kharoshthi/releases/download/NotoSansKharoshthi-v2.004/NotoSansKharoshthi-v2.004.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansKharoshthi-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-kharoshthi.yaml"
 }
 is_noto: true
-languages: "pra_Khar"  # Prakrit
-languages: "sa_Khar"  # Sanskrit, Kharoshthi
+languages: "pra_Khar"
+languages: "sa_Khar"
 primary_script: "Khar"

--- a/ofl/notosanskhudawadi/METADATA.pb
+++ b/ofl/notosanskhudawadi/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/khudawadi"
-  commit: "77a425be0b41864390f3b973dbd41c9ad47922b9"
+  commit: "842e04f50a19bc13847da26afbbf3ccac2ccc125"
   archive_url: "https://github.com/notofonts/khudawadi/releases/download/NotoSansKhudawadi-v2.004/NotoSansKhudawadi-v2.004.zip"
   files {
     source_file: "OFL.txt"
@@ -37,7 +37,8 @@ source {
     dest_file: "NotoSansKhudawadi-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-khudawadi.yaml"
 }
 is_noto: true
-languages: "sd_Sind"  # Sindhi, Khudawadi
+languages: "sd_Sind"
 primary_script: "Sind"

--- a/ofl/notosanslepcha/METADATA.pb
+++ b/ofl/notosanslepcha/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "lepcha"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/lepcha"
+  commit: "22993dbe4ed924277e75a444a40d2b420a372e7c"
   archive_url: "https://github.com/notofonts/lepcha/releases/download/NotoSansLepcha-v2.006/NotoSansLepcha-v2.006.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansLepcha-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-lepcha.yaml"
 }
 is_noto: true
-languages: "lep_Lepc"  # Lepcha
+languages: "lep_Lepc"
 primary_script: "Lepc"

--- a/ofl/notosanslimbu/METADATA.pb
+++ b/ofl/notosanslimbu/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "limbu"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/limbu"
-  commit: "912b8113bbabaf7322956fe80a0ad18575e77d7e"
+  commit: "191ac5f51c1dc7603d7636a26161ff9c36b9671b"
   archive_url: "https://github.com/notofonts/limbu/releases/download/NotoSansLimbu-v2.005/NotoSansLimbu-v2.005.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -33,7 +33,8 @@ source {
     dest_file: "NotoSansLimbu-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-limbu.yaml"
 }
 is_noto: true
-languages: "lif_Limb"  # Limbu, Limbu
+languages: "lif_Limb"
 primary_script: "Limb"

--- a/ofl/notosanslineara/METADATA.pb
+++ b/ofl/notosanslineara/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "linear-a"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/linear-a"
+  commit: "e139e1cc000341fbe4c154932e02d4996f105b85"
   archive_url: "https://github.com/notofonts/linear-a/releases/download/NotoSansLinearA-v2.002/NotoSansLinearA-v2.002.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,10 +37,11 @@ source {
     dest_file: "NotoSansLinearA-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-linear-a.yaml"
 }
 is_noto: true
-languages: "lab_Lina"  # Linear A
-languages: "omn_Lina"  # Minoan
+languages: "lab_Lina"
+languages: "omn_Lina"
 sample_text {
   masthead_full: "𐘂𐚰𐚩𐛌"
   masthead_partial: "𐘁𐚵"

--- a/ofl/notosanslinearb/METADATA.pb
+++ b/ofl/notosanslinearb/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "linear-b"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/linear-b"
+  commit: "410f88c1d4d10b5db76217e57e7b153811ce0674"
   archive_url: "https://github.com/notofonts/linear-b/releases/download/NotoSansLinearB-v2.002/NotoSansLinearB-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansLinearB-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-linear-b.yaml"
 }
 is_noto: true
-languages: "gmy_Linb"  # Mycenaean Greek
-languages: "grc_Linb"  # Ancient Greek, Linear B
+languages: "gmy_Linb"
+languages: "grc_Linb"
 primary_script: "Linb"

--- a/ofl/notosanslisu/METADATA.pb
+++ b/ofl/notosanslisu/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/lisu"
+  commit: "d7e34571c41408f05975acaee719c2353408eb9e"
   archive_url: "https://github.com/notofonts/lisu/releases/download/NotoSansLisu-v2.102/NotoSansLisu-v2.102.zip"
   files {
     source_file: "OFL.txt"
@@ -33,7 +34,8 @@ source {
     dest_file: "NotoSansLisu[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-lisu.yaml"
 }
 is_noto: true
-languages: "lis_Lisu"  # Lisu
+languages: "lis_Lisu"
 primary_script: "Lisu"

--- a/ofl/notosanslycian/METADATA.pb
+++ b/ofl/notosanslycian/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "lycian"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/lycian"
+  commit: "1e9e778f10314086451d972c0e42693890dfda36"
   archive_url: "https://github.com/notofonts/lycian/releases/download/NotoSansLycian-v2.002/NotoSansLycian-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansLycian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-lycian.yaml"
 }
 is_noto: true
-languages: "xlc_Lyci"  # Lycian
+languages: "xlc_Lyci"
 primary_script: "Lyci"

--- a/ofl/notosanslydian/METADATA.pb
+++ b/ofl/notosanslydian/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "lydian"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/lydian"
+  commit: "fb2444aa3ac4b7e4bd8d5a0e971895f6545aa418"
   archive_url: "https://github.com/notofonts/lydian/releases/download/NotoSansLydian-v2.002/NotoSansLydian-v2.002.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansLydian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-lydian.yaml"
 }
 is_noto: true
-languages: "xld_Lydi"  # Lydian
+languages: "xld_Lydi"
 primary_script: "Lydi"

--- a/ofl/notosansmahajani/METADATA.pb
+++ b/ofl/notosansmahajani/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "mahajani"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/mahajani"
+  commit: "6af195b21b1841f6b842af2a3d2f6b252718a70d"
   archive_url: "https://github.com/notofonts/mahajani/releases/download/NotoSansMahajani-v2.003/NotoSansMahajani-v2.003.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansMahajani-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-mahajani.yaml"
 }
 is_noto: true
-languages: "hi_Mahj"  # Hindi, Mahajani
+languages: "hi_Mahj"
 primary_script: "Mahj"

--- a/ofl/notosansmandaic/METADATA.pb
+++ b/ofl/notosansmandaic/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "mandaic"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/mandaic"
-  commit: "ef8c8ef95fd08c51ffc93aa7f930cd0086d761b9"
+  commit: "36a3804b7febaa6827c198f9a39324c8b24ad366"
   archive_url: "https://github.com/notofonts/mandaic/releases/download/NotoSansMandaic-v2.003/NotoSansMandaic-v2.003.zip"
   files {
     source_file: "OFL.txt"
@@ -37,7 +37,8 @@ source {
     dest_file: "NotoSansMandaic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-mandaic.yaml"
 }
 is_noto: true
-languages: "myz_Mand"  # Mandaic
+languages: "myz_Mand"
 primary_script: "Mand"

--- a/ofl/notosansmanichaean/METADATA.pb
+++ b/ofl/notosansmanichaean/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "manichaean"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/manichaean"
+  commit: "d3d108ab2cdf0250927b267fab4d2c8dea07dd68"
   archive_url: "https://github.com/notofonts/manichaean/releases/download/NotoSansManichaean-v2.005/NotoSansManichaean-v2.005.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansManichaean-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-manichaean.yaml"
 }
 is_noto: true
-languages: "aii_Mani"  # Assyrian Neo-Aramaic, Manichaean
-languages: "xmn_Mani"  # Manichaean Middle Persian
+languages: "aii_Mani"
+languages: "xmn_Mani"
 primary_script: "Mani"

--- a/ofl/notosansmarchen/METADATA.pb
+++ b/ofl/notosansmarchen/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "marchen"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/marchen"
-  commit: "0efb2639aef028a6e8be45790b60b71e5450b177"
+  commit: "8b7d0d75ddbd5e2069b8b0f1a89a842d6b37cff2"
   archive_url: "https://github.com/notofonts/marchen/releases/download/NotoSansMarchen-v2.004/NotoSansMarchen-v2.004.zip"
   files {
     source_file: "OFL.txt"
@@ -37,8 +37,9 @@ source {
     dest_file: "NotoSansMarchen-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-marchen.yaml"
 }
 is_noto: true
-languages: "bo_Marc"  # Tibetan, Marchen
-languages: "sa_Marc"  # Sanskrit, Marchen
+languages: "bo_Marc"
+languages: "sa_Marc"
 primary_script: "Marc"

--- a/ofl/notosansmasaramgondi/METADATA.pb
+++ b/ofl/notosansmasaramgondi/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "masaram-gondi"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/masaram-gondi"
-  commit: "ce1d61955ea2cdc3da93cdc8dc0786aebd4a8667"
+  commit: "aa688154eb5d517ed368e6905fbf1d2e087141a1"
   archive_url: "https://github.com/notofonts/masaram-gondi/releases/download/NotoSansMasaramGondi-v1.005/NotoSansMasaramGondi-v1.005.zip"
   files {
     source_file: "OFL.txt"
@@ -37,10 +37,11 @@ source {
     dest_file: "NotoSansMasaramGondi-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-masaram-gondi.yaml"
 }
 is_noto: true
-languages: "esg_Gonm"  # Aheri Gondi
-languages: "gon_Gonm"  # Gondi, Masaram Gondi
-languages: "sa_Gonm"  # Sanskrit, Masaram Gondi
-languages: "wsg_Gonm"  # Adilabad Gondi
+languages: "esg_Gonm"
+languages: "gon_Gonm"
+languages: "sa_Gonm"
+languages: "wsg_Gonm"
 primary_script: "Gonm"

--- a/ofl/notosansmayannumerals/METADATA.pb
+++ b/ofl/notosansmayannumerals/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "mayan-numerals"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/mayan-numerals"
+  commit: "2361f677ead1b84ce88cdef75d6c25e6ca0ff39f"
   archive_url: "https://github.com/notofonts/mayan-numerals/releases/download/NotoSansMayanNumerals-v2.001/NotoSansMayanNumerals-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,6 +37,7 @@ source {
     dest_file: "NotoSansMayanNumerals-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-mayan-numerals.yaml"
 }
 is_noto: true
 sample_text {

--- a/ofl/notosansmedefaidrin/METADATA.pb
+++ b/ofl/notosansmedefaidrin/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/medefaidrin"
+  commit: "db67ede293998b151205e6b7ca30f699f71e1624"
   archive_url: "https://github.com/notofonts/medefaidrin/releases/download/NotoSansMedefaidrin-v1.002/NotoSansMedefaidrin-v1.002.zip"
   files {
     source_file: "OFL.txt"
@@ -37,7 +38,8 @@ source {
     dest_file: "NotoSansMedefaidrin[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-medefaidrin.yaml"
 }
 is_noto: true
-languages: "dmf_Medf"  # Medefaidrin
+languages: "dmf_Medf"
 primary_script: "Medf"

--- a/ofl/notosansmeeteimayek/METADATA.pb
+++ b/ofl/notosansmeeteimayek/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/meetei-mayek"
+  commit: "0df27325288cee071d2f5d06016b0de1e6738aa5"
   archive_url: "https://github.com/notofonts/meetei-mayek/releases/download/NotoSansMeeteiMayek-v2.002/NotoSansMeeteiMayek-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -41,8 +42,9 @@ source {
     dest_file: "NotoSansMeeteiMayek[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-meetei-mayek.yaml"
 }
 is_noto: true
-languages: "mni_Mtei"  # Manipuri, Meetei Mayek
-languages: "sa_Mtei"  # Sanskrit, Meetei Mayek / Meitei
+languages: "mni_Mtei"
+languages: "sa_Mtei"
 primary_script: "Mtei"

--- a/ofl/notosansmendekikakui/METADATA.pb
+++ b/ofl/notosansmendekikakui/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "mende-kikakui"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/mende-kikakui"
+  commit: "70eb55ce4b682dc87c87266a25aa9b12b44f479d"
   archive_url: "https://github.com/notofonts/mende-kikakui/releases/download/NotoSansMendeKikakui-v2.003/NotoSansMendeKikakui-v2.003.zip"
   files {
     source_file: "OFL.txt"
@@ -32,7 +33,8 @@ source {
     dest_file: "NotoSansMendeKikakui-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-mende-kikakui.yaml"
 }
 is_noto: true
-languages: "men_Mend"  # Mende, Mende
+languages: "men_Mend"
 primary_script: "Mend"

--- a/ofl/notosansmeroitic/METADATA.pb
+++ b/ofl/notosansmeroitic/METADATA.pb
@@ -20,6 +20,7 @@ subsets: "meroitic-cursive"
 subsets: "meroitic-hieroglyphs"
 source {
   repository_url: "https://github.com/notofonts/meroitic"
+  commit: "d682685c8c0ef7ef9d1091a6dad7d8ce2843e565"
   archive_url: "https://github.com/notofonts/meroitic/releases/download/NotoSansMeroitic-v2.002/NotoSansMeroitic-v2.002.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -38,9 +39,10 @@ source {
     dest_file: "NotoSansMeroitic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-meroitic.yaml"
 }
 is_noto: true
-languages: "xmr_Mero"  # Meroitic, Meroitic Hieroglyphs
+languages: "xmr_Mero"
 sample_text {
   masthead_full: "𐦂𐦝𐦤𐦿"
   masthead_partial: "𐦁𐦐"

--- a/ofl/notosansmiao/METADATA.pb
+++ b/ofl/notosansmiao/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "miao"
 source {
   repository_url: "https://github.com/notofonts/miao"
+  commit: "60e05da3a76e726c5496c3dcbead5051e8b782f7"
   archive_url: "https://github.com/notofonts/miao/releases/download/NotoSansMiao-v2.003/NotoSansMiao-v2.003.zip"
   files {
     source_file: "OFL.txt"
@@ -32,7 +33,8 @@ source {
     dest_file: "NotoSansMiao-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-miao.yaml"
 }
 is_noto: true
-languages: "hmd_Plrd"  # A-Hmao
+languages: "hmd_Plrd"
 primary_script: "Plrd"

--- a/ofl/notosansmodi/METADATA.pb
+++ b/ofl/notosansmodi/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "modi"
 source {
   repository_url: "https://github.com/notofonts/modi"
+  commit: "8e9d4844a2daef44f622cb15639649c5d075625d"
   archive_url: "https://github.com/notofonts/modi/releases/download/NotoSansModi-v2.004/NotoSansModi-v2.004.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansModi-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-modi.yaml"
 }
 is_noto: true
-languages: "mr_Modi"  # Marathi, Modi
+languages: "mr_Modi"
 primary_script: "Modi"

--- a/ofl/notosansmongolian/METADATA.pb
+++ b/ofl/notosansmongolian/METADATA.pb
@@ -20,7 +20,7 @@ subsets: "mongolian"
 subsets: "symbols"
 source {
   repository_url: "https://github.com/notofonts/mongolian"
-  commit: "37a437828f5f3fc0c1cc23be44f9ed7ae1863ecf"
+  commit: "a61ef47935dcf4e4675456b632d6248836a5496a"
   archive_url: "https://github.com/notofonts/mongolian/releases/download/NotoSansMongolian-v3.002/NotoSansMongolian-v3.002.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -39,9 +39,10 @@ source {
     dest_file: "NotoSansMongolian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-mongolian.yaml"
 }
 is_noto: true
-languages: "mn_Mong"  # Mongolian (Mongolian)
-languages: "mnc_Mong"  # Manchu
-languages: "sa_Mong"  # Sanskrit, Mongolian
+languages: "mn_Mong"
+languages: "mnc_Mong"
+languages: "sa_Mong"
 primary_script: "Mong"

--- a/ofl/notosansmro/METADATA.pb
+++ b/ofl/notosansmro/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "mro"
 source {
   repository_url: "https://github.com/notofonts/mro"
+  commit: "3d7debf9b0faf7750c1c9191e9bc348c2a1fcedd"
   archive_url: "https://github.com/notofonts/mro/releases/download/NotoSansMro-v2.001/NotoSansMro-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -32,8 +33,9 @@ source {
     dest_file: "NotoSansMro-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-mro.yaml"
 }
 is_noto: true
-languages: "mro_Mroo"  # Mru, Mro
-languages: "sa_Mroo"  # Sanskrit, Mro
+languages: "mro_Mroo"
+languages: "sa_Mroo"
 primary_script: "Mroo"

--- a/ofl/notosansmultani/METADATA.pb
+++ b/ofl/notosansmultani/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "multani"
 source {
   repository_url: "https://github.com/notofonts/multani"
+  commit: "1ef5899c9e386c6b824641d32352444d8c418a6c"
   archive_url: "https://github.com/notofonts/multani/releases/download/NotoSansMultani-v2.002/NotoSansMultani-v2.002.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansMultani-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-multani.yaml"
 }
 is_noto: true
-languages: "sa_Mult"  # Sanskrit, Multani
-languages: "skr_Mult"  # Saraiki, Multani
+languages: "sa_Mult"
+languages: "skr_Mult"
 primary_script: "Mult"

--- a/ofl/notosansnabataean/METADATA.pb
+++ b/ofl/notosansnabataean/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "nabataean"
 source {
   repository_url: "https://github.com/notofonts/nabataean"
+  commit: "d16bdaad189b2af2547b7e39819b0501f324f9f7"
   archive_url: "https://github.com/notofonts/nabataean/releases/download/NotoSansNabataean-v2.001/NotoSansNabataean-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansNabataean-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-nabataean.yaml"
 }
 is_noto: true
-languages: "aii_Nbat"  # Assyrian Neo-Aramaic, Nabataean
-languages: "arc_Nbat"  # Aramaic, Nabataean
+languages: "aii_Nbat"
+languages: "arc_Nbat"
 primary_script: "Nbat"

--- a/ofl/notosansnagmundari/METADATA.pb
+++ b/ofl/notosansnagmundari/METADATA.pb
@@ -23,7 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/nag-mundari"
-  commit: "aa14d2df1a500fe504b250182c6aa64822c8d441"
+  commit: "64846ef2e38f46694aca851f48837ed2635994a4"
   archive_url: "https://github.com/notofonts/nag-mundari/releases/download/NotoSansNagMundari-v1.001/NotoSansNagMundari-v1.001.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -42,7 +42,8 @@ source {
     dest_file: "NotoSansNagMundari[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 is_noto: true
-languages: "unr_Nagm"  # Mundari (Nag Mundari)
+languages: "unr_Nagm"
 primary_script: "Nagm"

--- a/ofl/notosansnandinagari/METADATA.pb
+++ b/ofl/notosansnandinagari/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "nandinagari"
 source {
   repository_url: "https://github.com/notofonts/nandinagari"
-  commit: "c75145633ab708aedddef32f5141e8a19a0ece99"
+  commit: "6fd9a06474f168966558decc068b3f404b7d9063"
   archive_url: "https://github.com/notofonts/nandinagari/releases/download/NotoSansNandinagari-v1.003/NotoSansNandinagari-v1.003.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -37,7 +37,8 @@ source {
     dest_file: "NotoSansNandinagari-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-nandinagari.yaml"
 }
 is_noto: true
-languages: "sa_Nand"  # Sanskrit (Nandinagari)
+languages: "sa_Nand"
 primary_script: "Nand"

--- a/ofl/notosansnewa/METADATA.pb
+++ b/ofl/notosansnewa/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "newa"
 source {
   repository_url: "https://github.com/notofonts/newa"
+  commit: "5a902c1fb6abf546e88d61af912d0b40f2a55de3"
   archive_url: "https://github.com/notofonts/newa/releases/download/NotoSansNewa-v2.007/NotoSansNewa-v2.007.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,12 +37,13 @@ source {
     dest_file: "NotoSansNewa-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-newa.yaml"
 }
 is_noto: true
-languages: "bn_Newa"  # Bengali, Newa
-languages: "hi_Newa"  # Hindi, Newa
-languages: "mai_Newa"  # Maithili, Newa
-languages: "ne_Newa"  # Nepali, Newa
-languages: "new_Newa"  # Newari, Newa
-languages: "sa_Newa"  # Sanskrit, Newa
+languages: "bn_Newa"
+languages: "hi_Newa"
+languages: "mai_Newa"
+languages: "ne_Newa"
+languages: "new_Newa"
+languages: "sa_Newa"
 primary_script: "Newa"

--- a/ofl/notosansnewtailue/METADATA.pb
+++ b/ofl/notosansnewtailue/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/new-tai-lue"
+  commit: "f591483c535ff7c2db1f010907be69251fc0bb1c"
   archive_url: "https://github.com/notofonts/new-tai-lue/releases/download/NotoSansNewTaiLue-v2.004/NotoSansNewTaiLue-v2.004.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -41,7 +42,8 @@ source {
     dest_file: "NotoSansNewTaiLue[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 is_noto: true
-languages: "khb_Talu"  # Lü
+languages: "khb_Talu"
 primary_script: "Talu"

--- a/ofl/notosansogham/METADATA.pb
+++ b/ofl/notosansogham/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "ogham"
 source {
   repository_url: "https://github.com/notofonts/ogham"
+  commit: "f9ef276aefef0c9442f613db21f69a02d4102888"
   archive_url: "https://github.com/notofonts/ogham/releases/download/NotoSansOgham-v2.001/NotoSansOgham-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansOgham-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-ogham.yaml"
 }
 is_noto: true
-languages: "sga_Ogam"  # Old Irish, Ogham
+languages: "sga_Ogam"
 primary_script: "Ogam"

--- a/ofl/notosansolchiki/METADATA.pb
+++ b/ofl/notosansolchiki/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/ol-chiki"
+  commit: "61f81d5651c9c31d44d2731dc840607dd443c604"
   archive_url: "https://github.com/notofonts/ol-chiki/releases/download/NotoSansOlChiki-v2.003/NotoSansOlChiki-v2.003.zip"
   files {
     source_file: "OFL.txt"
@@ -41,7 +42,8 @@ source {
     dest_file: "NotoSansOlChiki[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-ol-chiki.yaml"
 }
 is_noto: true
-languages: "sat_Olck"  # Santali, Ol Chiki
+languages: "sat_Olck"
 primary_script: "Olck"

--- a/ofl/notosansoldhungarian/METADATA.pb
+++ b/ofl/notosansoldhungarian/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "old-hungarian"
 source {
   repository_url: "https://github.com/notofonts/old-hungarian"
+  commit: "1e4081448c3313c4486e148b86aff6cbbc1584d5"
   archive_url: "https://github.com/notofonts/old-hungarian/releases/download/NotoSansOldHungarian-v2.005/NotoSansOldHungarian-v2.005.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansOldHungarian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-old-hungarian.yaml"
 }
 is_noto: true
-languages: "ohu_Hung"  # Old Hungarian
+languages: "ohu_Hung"
 primary_script: "Hung"

--- a/ofl/notosansolditalic/METADATA.pb
+++ b/ofl/notosansolditalic/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "old-italic"
 source {
   repository_url: "https://github.com/notofonts/old-italic"
-  commit: "51420632db471f800592bd0f03617585b0f7734d"
+  commit: "486912f34b04a5ce9eb157ab3045ac665b6c36a8"
   archive_url: "https://github.com/notofonts/old-italic/releases/download/NotoSansOldItalic-v2.004/NotoSansOldItalic-v2.004.zip"
   files {
     source_file: "OFL.txt"
@@ -37,9 +37,10 @@ source {
     dest_file: "NotoSansOldItalic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-old.yaml"
 }
 is_noto: true
-languages: "ett_Ital"  # Etruscan
-languages: "osc_Ital"  # Oscan
-languages: "xum_Ital"  # Umbrian
+languages: "ett_Ital"
+languages: "osc_Ital"
+languages: "xum_Ital"
 primary_script: "Ital"

--- a/ofl/notosansoldnortharabian/METADATA.pb
+++ b/ofl/notosansoldnortharabian/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "old-north-arabian"
 source {
   repository_url: "https://github.com/notofonts/old-north-arabian"
+  commit: "da9dd37a1d09e6c3b3c17d7f3d907c3ba8dc1a76"
   archive_url: "https://github.com/notofonts/old-north-arabian/releases/download/NotoSansOldNorthArabian-v2.001/NotoSansOldNorthArabian-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansOldNorthArabian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-old-north-arabian.yaml"
 }
 is_noto: true
-languages: "aii_Narb"  # Assyrian Neo-Aramaic, Old North Arabian
-languages: "xna_Narb"  # Ancient North Arabian
+languages: "aii_Narb"
+languages: "xna_Narb"
 primary_script: "Narb"

--- a/ofl/notosansoldpermic/METADATA.pb
+++ b/ofl/notosansoldpermic/METADATA.pb
@@ -19,6 +19,7 @@ subsets: "menu"
 subsets: "old-permic"
 source {
   repository_url: "https://github.com/notofonts/old-permic"
+  commit: "080df8840211dde6b17fc87957950358b723e5e0"
   archive_url: "https://github.com/notofonts/old-permic/releases/download/NotoSansOldPermic-v2.001/NotoSansOldPermic-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -37,10 +38,11 @@ source {
     dest_file: "NotoSansOldPermic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-old-permic.yaml"
 }
 is_noto: true
-languages: "koi_Perm"  # Komi-Permyak, Old Permic
-languages: "kv_Perm"  # Komi, Old Permic
+languages: "koi_Perm"
+languages: "kv_Perm"
 sample_text {
   masthead_full: "𐍒𐍟𐍦𐍘"
   masthead_partial: "𐍑𐍤"

--- a/ofl/notosansoldpersian/METADATA.pb
+++ b/ofl/notosansoldpersian/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "old-persian"
 source {
   repository_url: "https://github.com/notofonts/old-persian"
+  commit: "27b5583d16934490eda51cb723316f65d8b8379b"
   archive_url: "https://github.com/notofonts/old-persian/releases/download/NotoSansOldPersian-v2.001/NotoSansOldPersian-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansOldPersian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-old-persian.yaml"
 }
 is_noto: true
-languages: "peo_Xpeo"  # Old Persian
-languages: "sa_Xpeo"  # Sanskrit, Old Persian
+languages: "peo_Xpeo"
+languages: "sa_Xpeo"
 primary_script: "Xpeo"

--- a/ofl/notosansoldsogdian/METADATA.pb
+++ b/ofl/notosansoldsogdian/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "old-sogdian"
 source {
   repository_url: "https://github.com/notofonts/old-sogdian"
-  commit: "63f94079fe9323c00a4bb1c4e4d5477008c76130"
+  commit: "aa13b986b6b48a97ab305a8915d2349fdfc87692"
   archive_url: "https://github.com/notofonts/old-sogdian/releases/download/NotoSansOldSogdian-v2.003/NotoSansOldSogdian-v2.003.zip"
   files {
     source_file: "OFL.txt"
@@ -37,8 +37,9 @@ source {
     dest_file: "NotoSansOldSogdian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-old-sogdian.yaml"
 }
 is_noto: true
-languages: "aii_Sogo"  # Assyrian Neo-Aramaic, Old Sogdian
-languages: "sog_Sogo"  # Sogdian, Old Sogdian
+languages: "aii_Sogo"
+languages: "sog_Sogo"
 primary_script: "Sogo"

--- a/ofl/notosansoldsoutharabian/METADATA.pb
+++ b/ofl/notosansoldsoutharabian/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "old-south-arabian"
 source {
   repository_url: "https://github.com/notofonts/old-south-arabian"
+  commit: "e77ff1f357de7696d8c44f0ea0394a32d6a19745"
   archive_url: "https://github.com/notofonts/old-south-arabian/releases/download/NotoSansOldSouthArabian-v2.001/NotoSansOldSouthArabian-v2.001.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansOldSouthArabian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-old-south-arabian.yaml"
 }
 is_noto: true
-languages: "aii_Sarb"  # Assyrian Neo-Aramaic, Old South Arabian
-languages: "xsa_Sarb"  # Sabaean
+languages: "aii_Sarb"
+languages: "xsa_Sarb"
 primary_script: "Sarb"

--- a/ofl/notosansoldturkic/METADATA.pb
+++ b/ofl/notosansoldturkic/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "old-turkic"
 source {
   repository_url: "https://github.com/notofonts/old-turkic"
-  commit: "b9616aba12e777d230e9fd4e52a049477c862e59"
+  commit: "598d6ec8b4cb7db6012a370b9546b29d4a0bc607"
   archive_url: "https://github.com/notofonts/old-turkic/releases/download/NotoSansOldTurkic-v2.004/NotoSansOldTurkic-v2.004.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -37,7 +37,8 @@ source {
     dest_file: "NotoSansOldTurkic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-old-turkic.yaml"
 }
 is_noto: true
-languages: "otk_Orkh"  # Old Turkish
+languages: "otk_Orkh"
 primary_script: "Orkh"

--- a/ofl/notosansosage/METADATA.pb
+++ b/ofl/notosansosage/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "osage"
 source {
   repository_url: "https://github.com/notofonts/osage"
+  commit: "7778dc00e3e91c0ca4498acbf6ea5b43b70fefcb"
   archive_url: "https://github.com/notofonts/osage/releases/download/NotoSansOsage-v2.002/NotoSansOsage-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansOsage-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-osage.yaml"
 }
 is_noto: true
-languages: "osa_Osge"  # Osage
+languages: "osa_Osge"
 primary_script: "Osge"

--- a/ofl/notosansosmanya/METADATA.pb
+++ b/ofl/notosansosmanya/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "osmanya"
 source {
   repository_url: "https://github.com/notofonts/osmanya"
+  commit: "6b87e2ca0c0b8e746247b9c2d073d4cacd522dce"
   archive_url: "https://github.com/notofonts/osmanya/releases/download/NotoSansOsmanya-v2.001/NotoSansOsmanya-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansOsmanya-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-osmanya.yaml"
 }
 is_noto: true
-languages: "so_Osma"  # Somali, Osmanya
+languages: "so_Osma"
 primary_script: "Osma"

--- a/ofl/notosanspahawhhmong/METADATA.pb
+++ b/ofl/notosanspahawhhmong/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "pahawh-hmong"
 source {
   repository_url: "https://github.com/notofonts/pahawh-hmong"
+  commit: "793abf16bdd65ee298dcfaf6a8c77113341c4890"
   archive_url: "https://github.com/notofonts/pahawh-hmong/releases/download/NotoSansPahawhHmong-v2.001/NotoSansPahawhHmong-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,10 +37,11 @@ source {
     dest_file: "NotoSansPahawhHmong-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-pahawh-hmong.yaml"
 }
 is_noto: true
-languages: "hmd_Hmng"  # A-Hmao, Pahawh Hmong
-languages: "hmn_Hmng"  # Hmong, Pahawh Hmong
-languages: "hnj_Hmng"  # Mong Njua, Pahawh Hmong
-languages: "mww_Hmng"  # Hmong Daw
+languages: "hmd_Hmng"
+languages: "hmn_Hmng"
+languages: "hnj_Hmng"
+languages: "mww_Hmng"
 primary_script: "Hmng"

--- a/ofl/notosanspalmyrene/METADATA.pb
+++ b/ofl/notosanspalmyrene/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "palmyrene"
 source {
   repository_url: "https://github.com/notofonts/palmyrene"
+  commit: "bbb69ea150a25cabb937bcbd654c171ff958b426"
   archive_url: "https://github.com/notofonts/palmyrene/releases/download/NotoSansPalmyrene-v2.001/NotoSansPalmyrene-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansPalmyrene-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-palmyrene.yaml"
 }
 is_noto: true
-languages: "aii_Palm"  # Assyrian Neo-Aramaic, Palmyrene
-languages: "arc_Palm"  # Aramaic, Palmyrene
+languages: "aii_Palm"
+languages: "arc_Palm"
 primary_script: "Palm"

--- a/ofl/notosanspaucinhau/METADATA.pb
+++ b/ofl/notosanspaucinhau/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "pau-cin-hau"
 source {
   repository_url: "https://github.com/notofonts/pau-cin-hau"
+  commit: "31ef11c2be728b8f709ea9b65fa04aa3519af39a"
   archive_url: "https://github.com/notofonts/pau-cin-hau/releases/download/NotoSansPauCinHau-v2.002/NotoSansPauCinHau-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -36,9 +37,10 @@ source {
     dest_file: "NotoSansPauCinHau-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-pau-cin-hau.yaml"
 }
 is_noto: true
-languages: "ctd_Pauc"  # Tedim Chin, Pau Cin Hau
+languages: "ctd_Pauc"
 sample_text {
   masthead_full: "𑫂𑫱𑫪𑫜"
   masthead_partial: "𑫁𑫶"

--- a/ofl/notosansphagspa/METADATA.pb
+++ b/ofl/notosansphagspa/METADATA.pb
@@ -20,6 +20,7 @@ subsets: "phags-pa"
 subsets: "symbols"
 source {
   repository_url: "https://github.com/notofonts/phags-pa"
+  commit: "a2cd1a7833b6e7d2be2519fe2539b1d3be53f28e"
   archive_url: "https://github.com/notofonts/phags-pa/releases/download/NotoSansPhagsPa-v2.004/NotoSansPhagsPa-v2.004.zip"
   files {
     source_file: "OFL.txt"
@@ -38,11 +39,12 @@ source {
     dest_file: "NotoSansPhagsPa-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-phags-pa.yaml"
 }
 is_noto: true
-languages: "lzh_Phag"  # Literary Chinese, Phags-pa
-languages: "mn_Phag"  # Mongolian, Phags-pa
-languages: "sa_Phag"  # Sanskrit, Phags-pa
-languages: "zh_Phag"  # Chinese, Phags-pa
+languages: "lzh_Phag"
+languages: "mn_Phag"
+languages: "sa_Phag"
+languages: "zh_Phag"
 display_name: "Noto Sans Phags-pa"
 primary_script: "Phag"

--- a/ofl/notosansphoenician/METADATA.pb
+++ b/ofl/notosansphoenician/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "phoenician"
 source {
   repository_url: "https://github.com/notofonts/phoenician"
+  commit: "42000fa28062130c663c83e38fe9df00f9a85a4f"
   archive_url: "https://github.com/notofonts/phoenician/releases/download/NotoSansPhoenician-v2.001/NotoSansPhoenician-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansPhoenician-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-phoenician.yaml"
 }
 is_noto: true
-languages: "aii_Phnx"  # Assyrian Neo-Aramaic, Phoenician
-languages: "phn_Phnx"  # Phoenician
+languages: "aii_Phnx"
+languages: "phn_Phnx"
 primary_script: "Phnx"

--- a/ofl/notosanspsalterpahlavi/METADATA.pb
+++ b/ofl/notosanspsalterpahlavi/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "psalter-pahlavi"
 source {
   repository_url: "https://github.com/notofonts/psalter-pahlavi"
-  commit: "67ed6002f772c9b7cea9c8d56c28e2fe65bd114d"
+  commit: "2f531fdc967e90d6d01da58384063314ccd14bf5"
   archive_url: "https://github.com/notofonts/psalter-pahlavi/releases/download/NotoSansPsalterPahlavi-v2.003/NotoSansPsalterPahlavi-v2.003.zip"
   files {
     source_file: "OFL.txt"
@@ -37,8 +37,9 @@ source {
     dest_file: "NotoSansPsalterPahlavi-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-psalter-pahlavi.yaml"
 }
 is_noto: true
-languages: "aii_Phlp"  # Assyrian Neo-Aramaic, Psalter Pahlavi
-languages: "pal_Phlp"  # Pahlavi, Psalter Pahlavi
+languages: "aii_Phlp"
+languages: "pal_Phlp"
 primary_script: "Phlp"

--- a/ofl/notosansrejang/METADATA.pb
+++ b/ofl/notosansrejang/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "rejang"
 source {
   repository_url: "https://github.com/notofonts/rejang"
+  commit: "260e890f159e60ffbcc4994006a003b7a9a28f07"
   archive_url: "https://github.com/notofonts/rejang/releases/download/NotoSansRejang-v2.002/NotoSansRejang-v2.002.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansRejang-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-rejang.yaml"
 }
 is_noto: true
-languages: "rej_Rjng"  # Rejang, Rejang
-languages: "sa_Rjng"  # Sanskrit, Rejang
+languages: "rej_Rjng"
+languages: "sa_Rjng"
 primary_script: "Rjng"

--- a/ofl/notosansrunic/METADATA.pb
+++ b/ofl/notosansrunic/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "runic"
 source {
   repository_url: "https://github.com/notofonts/runic"
+  commit: "0badcd990e0be2e6010362488af5a901a7bfefa1"
   archive_url: "https://github.com/notofonts/runic/releases/download/NotoSansRunic-v2.002/NotoSansRunic-v2.002.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,9 +37,10 @@ source {
     dest_file: "NotoSansRunic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-runic.yaml"
 }
 is_noto: true
-languages: "de_Runr"  # German, Runic
-languages: "got_Runr"  # Gothic, Runic
-languages: "non_Runr"  # Old Norse
+languages: "de_Runr"
+languages: "got_Runr"
+languages: "non_Runr"
 primary_script: "Runr"

--- a/ofl/notosanssamaritan/METADATA.pb
+++ b/ofl/notosanssamaritan/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "samaritan"
 source {
   repository_url: "https://github.com/notofonts/samaritan"
+  commit: "86c2e96b021b020d39b51641a541443e36c7ce62"
   archive_url: "https://github.com/notofonts/samaritan/releases/download/NotoSansSamaritan-v2.001/NotoSansSamaritan-v2.001.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,9 +37,10 @@ source {
     dest_file: "NotoSansSamaritan-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-samaritan.yaml"
 }
 is_noto: true
-languages: "aii_Samr"  # Assyrian Neo-Aramaic, Samaritan
-languages: "sam_Samr"  # Samaritan Aramaic, Samaritan
-languages: "smp_Samr"  # Samaritan
+languages: "aii_Samr"
+languages: "sam_Samr"
+languages: "smp_Samr"
 primary_script: "Samr"

--- a/ofl/notosanssaurashtra/METADATA.pb
+++ b/ofl/notosanssaurashtra/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "saurashtra"
 source {
   repository_url: "https://github.com/notofonts/saurashtra"
+  commit: "922f6bdd4c2f6b6bae4d140253f810359ef2e62b"
   archive_url: "https://github.com/notofonts/saurashtra/releases/download/NotoSansSaurashtra-v2.002/NotoSansSaurashtra-v2.002.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansSaurashtra-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-saurashtra.yaml"
 }
 is_noto: true
-languages: "saz_Saur"  # Saurashtra
+languages: "saz_Saur"
 primary_script: "Saur"

--- a/ofl/notosanssharada/METADATA.pb
+++ b/ofl/notosanssharada/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "sharada"
 source {
   repository_url: "https://github.com/notofonts/sharada"
+  commit: "cafc138eaa89d3fa491ea6d81051fc910ade8c87"
   archive_url: "https://github.com/notofonts/sharada/releases/download/NotoSansSharada-v2.006/NotoSansSharada-v2.006.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansSharada-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-sharada.yaml"
 }
 is_noto: true
-languages: "sa_Shrd"  # Sanskrit, Sharada
+languages: "sa_Shrd"
 primary_script: "Shrd"

--- a/ofl/notosansshavian/METADATA.pb
+++ b/ofl/notosansshavian/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "shavian"
 source {
   repository_url: "https://github.com/notofonts/shavian"
+  commit: "15edbc9e0dd0c0ad627c658bbf439dce175a8ba4"
   archive_url: "https://github.com/notofonts/shavian/releases/download/NotoSansShavian-v2.001/NotoSansShavian-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansShavian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-shavian.yaml"
 }
 is_noto: true
-languages: "en_Shaw"  # English, Shavian
+languages: "en_Shaw"
 primary_script: "Shaw"

--- a/ofl/notosanssiddham/METADATA.pb
+++ b/ofl/notosanssiddham/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "siddham"
 source {
   repository_url: "https://github.com/notofonts/siddham"
+  commit: "6ff212cb17efb2ad8b6a3b677d61cb66edc44dae"
   archive_url: "https://github.com/notofonts/siddham/releases/download/NotoSansSiddham-v2.005/NotoSansSiddham-v2.005.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansSiddham-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-siddham.yaml"
 }
 is_noto: true
-languages: "sa_Sidd"  # Sanskrit, Siddham
+languages: "sa_Sidd"
 primary_script: "Sidd"

--- a/ofl/notosanssignwriting/METADATA.pb
+++ b/ofl/notosanssignwriting/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "signwriting"
 source {
   repository_url: "https://github.com/notofonts/sign-writing"
+  commit: "a0a0e9a8691ea81cfd32f7afb971c1ed4bf58f9a"
   archive_url: "https://github.com/notofonts/sign-writing/releases/download/NotoSansSignWriting-v2.005/NotoSansSignWriting-v2.005.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,6 +37,7 @@ source {
     dest_file: "NotoSansSignWriting-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-sign-writing.yaml"
 }
 is_noto: true
 sample_text {

--- a/ofl/notosanssogdian/METADATA.pb
+++ b/ofl/notosanssogdian/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "sogdian"
 source {
   repository_url: "https://github.com/notofonts/sogdian"
+  commit: "9f27761f150f7d0952e4873296cdc0eeaa6d28d3"
   archive_url: "https://github.com/notofonts/sogdian/releases/download/NotoSansSogdian-v2.002/NotoSansSogdian-v2.002.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansSogdian-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-sogdian.yaml"
 }
 is_noto: true
-languages: "aii_Sogd"  # Assyrian Neo-Aramaic, Sogdian
-languages: "sog_Sogd"  # Sogdian
+languages: "aii_Sogd"
+languages: "sog_Sogd"
 primary_script: "Sogd"

--- a/ofl/notosanssorasompeng/METADATA.pb
+++ b/ofl/notosanssorasompeng/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/sora-sompeng"
+  commit: "d6dc3eaa0f252c018aaf41314e24bcc889a8c5e4"
   archive_url: "https://github.com/notofonts/sora-sompeng/releases/download/NotoSansSoraSompeng-v2.101/NotoSansSoraSompeng-v2.101.zip"
   files {
     source_file: "OFL.txt"
@@ -41,8 +42,9 @@ source {
     dest_file: "NotoSansSoraSompeng[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-sora-sompeng.yaml"
 }
 is_noto: true
-languages: "sa_Sora"  # Sanskrit, Sora Sompeng
-languages: "srb_Sora"  # Sora, Sora Sompeng
+languages: "sa_Sora"
+languages: "srb_Sora"
 primary_script: "Sora"

--- a/ofl/notosanssoyombo/METADATA.pb
+++ b/ofl/notosanssoyombo/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "soyombo"
 source {
   repository_url: "https://github.com/notofonts/soyombo"
+  commit: "c2488cb18ec2296faa98ddc50144c1be4e94dffb"
   archive_url: "https://github.com/notofonts/soyombo/releases/download/NotoSansSoyombo-v2.001/NotoSansSoyombo-v2.001.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansSoyombo-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-soyombo.yaml"
 }
 is_noto: true
-languages: "cmg_Soyo"  # Classical Mongolian
-languages: "sa_Soyo"  # Sanskrit, Soyombo
+languages: "cmg_Soyo"
+languages: "sa_Soyo"
 primary_script: "Soyo"

--- a/ofl/notosanssundanese/METADATA.pb
+++ b/ofl/notosanssundanese/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/sundanese"
+  commit: "8069fb6e2b3a9bc2888748b4d3cc1dd5919728ee"
   archive_url: "https://github.com/notofonts/sundanese/releases/download/NotoSansSundanese-v2.005/NotoSansSundanese-v2.005.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -41,7 +42,8 @@ source {
     dest_file: "NotoSansSundanese[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-sundanese.yaml"
 }
 is_noto: true
-languages: "su_Sund"  # Sundanese, Sundanese
+languages: "su_Sund"
 primary_script: "Sund"

--- a/ofl/notosanssylotinagri/METADATA.pb
+++ b/ofl/notosanssylotinagri/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "syloti-nagri"
 source {
   repository_url: "https://github.com/notofonts/syloti-nagri"
+  commit: "24ab3ac364a1b0882f36fa18f8f090145b009bf8"
   archive_url: "https://github.com/notofonts/syloti-nagri/releases/download/NotoSansSylotiNagri-v2.004/NotoSansSylotiNagri-v2.004.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansSylotiNagri-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-syloti-nagri.yaml"
 }
 is_noto: true
-languages: "syl_Sylo"  # Sylheti, Syloti Nagri
+languages: "syl_Sylo"
 primary_script: "Sylo"

--- a/ofl/notosanstagalog/METADATA.pb
+++ b/ofl/notosanstagalog/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "tagalog"
 source {
   repository_url: "https://github.com/notofonts/tagalog"
+  commit: "3546fa08fc9d624166a1521054c6f3f473ee1485"
   archive_url: "https://github.com/notofonts/tagalog/releases/download/NotoSansTagalog-v2.002/NotoSansTagalog-v2.002.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansTagalog-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-tagalog.yaml"
 }
 is_noto: true
-languages: "fil_Tglg"  # Filipino, Tagalog
+languages: "fil_Tglg"
 primary_script: "Tglg"

--- a/ofl/notosanstagbanwa/METADATA.pb
+++ b/ofl/notosanstagbanwa/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "tagbanwa"
 source {
   repository_url: "https://github.com/notofonts/tagbanwa"
+  commit: "ec39a09e038aae3d9551027fcfb43b417aa486a2"
   archive_url: "https://github.com/notofonts/tagbanwa/releases/download/NotoSansTagbanwa-v2.001/NotoSansTagbanwa-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansTagbanwa-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-tagbanwa.yaml"
 }
 is_noto: true
-languages: "sa_Tagb"  # Sanskrit, Tagbanwa
-languages: "tbw_Tagb"  # Tagbanwa, Tagbanwa
+languages: "sa_Tagb"
+languages: "tbw_Tagb"
 primary_script: "Tagb"

--- a/ofl/notosanstaile/METADATA.pb
+++ b/ofl/notosanstaile/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "tai-le"
 source {
   repository_url: "https://github.com/notofonts/tai-le"
+  commit: "297f30f9460ad4d16f64ed70f659320e415ccee1"
   archive_url: "https://github.com/notofonts/tai-le/releases/download/NotoSansTaiLe-v2.002/NotoSansTaiLe-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansTaiLe-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-tai-le.yaml"
 }
 is_noto: true
-languages: "tdd_Tale"  # Tai Nüa
+languages: "tdd_Tale"
 primary_script: "Tale"

--- a/ofl/notosanstaitham/METADATA.pb
+++ b/ofl/notosanstaitham/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/tai-tham"
+  commit: "e336c5170ba284d0726e4a82a5b7a12fa07367bf"
   archive_url: "https://github.com/notofonts/tai-tham/releases/download/NotoSansTaiTham-v2.002/NotoSansTaiTham-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -41,8 +42,9 @@ source {
     dest_file: "NotoSansTaiTham[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-tai-tham.yaml"
 }
 is_noto: true
-languages: "kkh_Lana"  # Tai Khün
-languages: "nod_Lana"  # Northern Thai
+languages: "kkh_Lana"
+languages: "nod_Lana"
 primary_script: "Lana"

--- a/ofl/notosanstaiviet/METADATA.pb
+++ b/ofl/notosanstaiviet/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "tai-viet"
 source {
   repository_url: "https://github.com/notofonts/tai-viet"
+  commit: "8e1e11187d6bc19f48530777d268d2eee8b644b6"
   archive_url: "https://github.com/notofonts/tai-viet/releases/download/NotoSansTaiViet-v2.004/NotoSansTaiViet-v2.004.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansTaiViet-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-tai-viet.yaml"
 }
 is_noto: true
-languages: "blt_Tavt"  # Tai Dam
+languages: "blt_Tavt"
 primary_script: "Tavt"

--- a/ofl/notosanstakri/METADATA.pb
+++ b/ofl/notosanstakri/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "takri"
 source {
   repository_url: "https://github.com/notofonts/takri"
+  commit: "bf175ad0b88bacf551fa992f19ce0e1cd2270b22"
   archive_url: "https://github.com/notofonts/takri/releases/download/NotoSansTakri-v2.005/NotoSansTakri-v2.005.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansTakri-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-takri.yaml"
 }
 is_noto: true
-languages: "doi_Takr"  # Dogri, Takri
+languages: "doi_Takr"
 primary_script: "Takr"

--- a/ofl/notosanstangsa/METADATA.pb
+++ b/ofl/notosanstangsa/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/tangsa"
+  commit: "8d40c34e78702e6ec2ef9a8e2cbd6a38cd7f6d4a"
   archive_url: "https://github.com/notofonts/tangsa/releases/download/NotoSansTangsa-v1.506/NotoSansTangsa-v1.506.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -41,7 +42,8 @@ source {
     dest_file: "NotoSansTangsa[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-tangsa.yaml"
 }
 is_noto: true
-languages: "nst_Tnsa"  # Tangsa
+languages: "nst_Tnsa"
 primary_script: "Tnsa"

--- a/ofl/notosansthaana/METADATA.pb
+++ b/ofl/notosansthaana/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/thaana"
+  commit: "18a413df01de7199c95d4115b8cd5ad492b9819c"
   archive_url: "https://github.com/notofonts/thaana/releases/download/NotoSansThaana-v3.001/NotoSansThaana-v3.001.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -41,7 +42,8 @@ source {
     dest_file: "NotoSansThaana[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-thaana.yaml"
 }
 is_noto: true
-languages: "dv_Thaa"  # Divehi
+languages: "dv_Thaa"
 primary_script: "Thaa"

--- a/ofl/notosanstifinagh/METADATA.pb
+++ b/ofl/notosanstifinagh/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "tifinagh"
 source {
   repository_url: "https://github.com/notofonts/tifinagh"
+  commit: "6c19a68ff330ec938fb21d6be8c94b2183e1b077"
   archive_url: "https://github.com/notofonts/tifinagh/releases/download/NotoSansTifinagh-v2.006/NotoSansTifinagh-v2.006.zip"
   files {
     source_file: "OFL.txt"
@@ -36,14 +37,15 @@ source {
     dest_file: "NotoSansTifinagh-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-tifinagh.yaml"
 }
 is_noto: true
-languages: "ber_Tfng"  # Berber, Tifinagh
-languages: "kab_Tfng"  # Kabyle, Tifinagh
-languages: "rif_Tfng"  # Riffian
-languages: "shi_Tfng"  # Tachelhit, Tifinagh
-languages: "taq_Tfng"  # Tamasheq, Tifinagh
-languages: "tzm_Tfng"  # Central Atlas Tamazight, Tifinagh
-languages: "zen_Tfng"  # Zenaga
-languages: "zgh_Tfng"  # Standard Moroccan Tamazight
+languages: "ber_Tfng"
+languages: "kab_Tfng"
+languages: "rif_Tfng"
+languages: "shi_Tfng"
+languages: "taq_Tfng"
+languages: "tzm_Tfng"
+languages: "zen_Tfng"
+languages: "zgh_Tfng"
 primary_script: "Tfng"

--- a/ofl/notosanstirhuta/METADATA.pb
+++ b/ofl/notosanstirhuta/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "tirhuta"
 source {
   repository_url: "https://github.com/notofonts/tirhuta"
+  commit: "3c941a6f7183c147e807ed92b4a4f894c4e5e7f6"
   archive_url: "https://github.com/notofonts/tirhuta/releases/download/NotoSansTirhuta-v2.003/NotoSansTirhuta-v2.003.zip"
   files {
     source_file: "OFL.txt"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansTirhuta-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-tirhuta.yaml"
 }
 is_noto: true
-languages: "mai_Tirh"  # Maithili, Tirhuta
-languages: "sa_Tirh"  # Sanskrit, Tirhuta
+languages: "mai_Tirh"
+languages: "sa_Tirh"
 primary_script: "Tirh"

--- a/ofl/notosansugaritic/METADATA.pb
+++ b/ofl/notosansugaritic/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "ugaritic"
 source {
   repository_url: "https://github.com/notofonts/ugaritic"
+  commit: "9ddf5ed058fcb2b8694c6dbdd4d0e914989e1d92"
   archive_url: "https://github.com/notofonts/ugaritic/releases/download/NotoSansUgaritic-v2.001/NotoSansUgaritic-v2.001.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansUgaritic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-ugaritic.yaml"
 }
 is_noto: true
-languages: "aii_Ugar"  # Assyrian Neo-Aramaic, Ugaritic
-languages: "uga_Ugar"  # Ugaritic
+languages: "aii_Ugar"
+languages: "uga_Ugar"
 primary_script: "Ugar"

--- a/ofl/notosansvai/METADATA.pb
+++ b/ofl/notosansvai/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vai"
 source {
   repository_url: "https://github.com/notofonts/vai"
+  commit: "f30c6331f2be292991c1ae047f5aeec48bd79644"
   archive_url: "https://github.com/notofonts/vai/releases/download/NotoSansVai-v2.001/NotoSansVai-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansVai-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-vai.yaml"
 }
 is_noto: true
-languages: "vai_Vaii"  # Vai
+languages: "vai_Vaii"
 primary_script: "Vaii"

--- a/ofl/notosanswancho/METADATA.pb
+++ b/ofl/notosanswancho/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "wancho"
 source {
   repository_url: "https://github.com/notofonts/wancho"
+  commit: "91ab06e9185d9a294a4c6a522dfa9d55d56d561f"
   archive_url: "https://github.com/notofonts/wancho/releases/download/NotoSansWancho-v2.001/NotoSansWancho-v2.001.zip"
   files {
     source_file: "OFL.txt"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansWancho-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-wancho.yaml"
 }
 is_noto: true
-languages: "nnp_Wcho"  # Wancho Naga
-languages: "sa_Wcho"  # Sanskrit, Wancho
+languages: "nnp_Wcho"
+languages: "sa_Wcho"
 primary_script: "Wcho"

--- a/ofl/notosanswarangciti/METADATA.pb
+++ b/ofl/notosanswarangciti/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "warang-citi"
 source {
   repository_url: "https://github.com/notofonts/warang-citi"
+  commit: "4e2380582fe87044e718328edaf1eaa38e108fc4"
   archive_url: "https://github.com/notofonts/warang-citi/releases/download/NotoSansWarangCiti-v3.002/NotoSansWarangCiti-v3.002.zip"
   files {
     source_file: "OFL.txt"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSansWarangCiti-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-warang-citi.yaml"
 }
 is_noto: true
-languages: "hoc_Wara"  # Ho, Warang Citi
-languages: "sa_Wara"  # Sanskrit, Varang Kshiti / Warang Citi
+languages: "hoc_Wara"
+languages: "sa_Wara"
 primary_script: "Wara"

--- a/ofl/notosansyi/METADATA.pb
+++ b/ofl/notosansyi/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "yi"
 source {
   repository_url: "https://github.com/notofonts/yi"
+  commit: "bdf568a724f7dd9c59f6fb04cdac4e3450699d63"
   archive_url: "https://github.com/notofonts/yi/releases/download/NotoSansYi-v2.002/NotoSansYi-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSansYi-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-yi.yaml"
 }
 is_noto: true
-languages: "ii_Yiii"  # Sichuan Yi
+languages: "ii_Yiii"
 primary_script: "Yiii"

--- a/ofl/notosanszanabazarsquare/METADATA.pb
+++ b/ofl/notosanszanabazarsquare/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "zanabazar-square"
 source {
   repository_url: "https://github.com/notofonts/zanabazar-square"
+  commit: "41b2554e25c1ff4c7ea1231c8c966d0d5ec200b3"
   archive_url: "https://github.com/notofonts/zanabazar-square/releases/download/NotoSansZanabazarSquare-v2.006/NotoSansZanabazarSquare-v2.006.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -36,9 +37,10 @@ source {
     dest_file: "NotoSansZanabazarSquare-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-sans-zanabazar-square.yaml"
 }
 is_noto: true
-languages: "bo_Zanb"  # Tibetan, Zanabazar
-languages: "mn_Zanb"  # Mongolian, Zanabazar
-languages: "sa_Zanb"  # Sanskrit, Zanabazar
+languages: "bo_Zanb"
+languages: "mn_Zanb"
+languages: "sa_Zanb"
 primary_script: "Zanb"

--- a/ofl/notoserifahom/METADATA.pb
+++ b/ofl/notoserifahom/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/ahom"
+  commit: "fb3e25e81eb2a7d8301ddd86085f60a4b2a88d73"
   archive_url: "https://github.com/notofonts/ahom/releases/download/NotoSerifAhom-v2.007/NotoSerifAhom-v2.007.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,8 +37,9 @@ source {
     dest_file: "NotoSerifAhom-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-serif-ahom.yaml"
 }
 is_noto: true
-languages: "aho_Ahom"  # Ahom
-languages: "sa_Ahom"  # Sanskrit, Ahom
+languages: "aho_Ahom"
+languages: "sa_Ahom"
 primary_script: "Ahom"

--- a/ofl/notoserifdogra/METADATA.pb
+++ b/ofl/notoserifdogra/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/dogra"
+  commit: "ca3e78b572e9f0a62e7b843905255e7cbd2db380"
   archive_url: "https://github.com/notofonts/dogra/releases/download/NotoSerifDogra-v1.007/NotoSerifDogra-v1.007.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSerifDogra-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-serif-dogra.yaml"
 }
 is_noto: true
-languages: "doi_Dogr"  # Dogri, Dogra
+languages: "doi_Dogr"
 primary_script: "Dogr"

--- a/ofl/notoserifhentaigana/METADATA.pb
+++ b/ofl/notoserifhentaigana/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/hentaigana"
+  commit: "05826fcd095f41f3517f4126dda514f51de644cc"
   archive_url: "https://github.com/notofonts/hentaigana/releases/download/NotoSerifHentaigana-v1.000/NotoSerifHentaigana-v1.000.zip"
   files {
     source_file: "ARTICLE.en_us.html"
@@ -41,15 +42,13 @@ source {
     dest_file: "NotoSerifHentaigana[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 is_noto: true
 sample_text {
-  # The text is the traditional Japanese pangram poem "Iroha"
-  # https://en.wikipedia.org/wiki/Iroha
   masthead_full: "𛀆𛄆𛂡𛂉"
   masthead_partial: "𛀆𛄆"
   styles: "𛀆𛄆𛂡𛂉𛂺𛂳𛁹 𛁢𛃱𛂏𛃸𛄖 𛄉𛀗𛃧𛁟𛄀𛁗 𛁩𛂒𛁿𛃰𛃐"
-  # This is "I-I-I-I RO-RO-RO-RO HA-HA-HA-HA ..." using different variant forms of each character
   tester: "𛀆𛀇𛀈𛀉 𛄂𛄃𛄄𛄅 𛂞𛂟𛂠𛂡 𛂇𛂈𛂉𛂊 𛂺𛂻𛂼𛂽 𛂳𛂴𛂵𛂶 𛁷𛁸𛁹𛁺 𛁢𛁣𛁤𛁥 𛃱𛃲𛃳𛃴 𛂏𛂐𛂑 𛃸𛃹𛃺𛃻 𛄖𛄗𛄘𛄙"
   poster_sm: "𛀆𛄆𛂡𛂉𛂺𛂳𛁹 𛁢𛃱𛂏𛃸𛄖 𛄉𛀗𛃧𛁟𛄀𛁗 𛁩𛂒𛁿𛃰𛃐"
   poster_md: "𛀆𛄆𛂡𛂉𛂺𛂳𛁹 𛁢𛃱𛂏𛃸𛄖 𛄉𛀗𛃧𛁟𛄀𛁗 𛁩𛂒𛁿𛃰𛃐"

--- a/ofl/notoserifmakasar/METADATA.pb
+++ b/ofl/notoserifmakasar/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "makasar"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/makasar"
+  commit: "e7902cc5d89ed7d091c247c855f516fe49f8b6ac"
   archive_url: "https://github.com/notofonts/makasar/releases/download/NotoSerifMakasar-v1.001/NotoSerifMakasar-v1.001.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSerifMakasar-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 is_noto: true
-languages: "mak_Maka"  # Makasar, Old Makasar
+languages: "mak_Maka"
 primary_script: "Maka"

--- a/ofl/notoserifolduyghur/METADATA.pb
+++ b/ofl/notoserifolduyghur/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "old-uyghur"
 source {
   repository_url: "https://github.com/notofonts/old-uyghur"
-  commit: "da8ad06ede81ce5a88624f05a916306aa9179f5f"
+  commit: "44b6cbf951161b70309c5e4ddff7738e76aec195"
   archive_url: "https://github.com/notofonts/old-uyghur/releases/download/NotoSerifOldUyghur-v1.004/NotoSerifOldUyghur-v1.004.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -37,7 +37,8 @@ source {
     dest_file: "NotoSerifOldUyghur-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-serif-old-uyghur.yaml"
 }
 is_noto: true
-languages: "oui_Ougr"  # Old Uyghur, Old Uyghur
+languages: "oui_Ougr"
 primary_script: "Ougr"

--- a/ofl/notoserifottomansiyaq/METADATA.pb
+++ b/ofl/notoserifottomansiyaq/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "ottoman-siyaq-numbers"
 source {
   repository_url: "https://github.com/notofonts/ottoman-siyaq-numbers"
+  commit: "b6cca8ffe60e4978e07980dd9ae8820a474a9301"
   archive_url: "https://github.com/notofonts/ottoman-siyaq-numbers/releases/download/NotoSerifOttomanSiyaq-v1.006/NotoSerifOttomanSiyaq-v1.006.zip"
   files {
     source_file: "OFL.txt"
@@ -36,6 +37,7 @@ source {
     dest_file: "NotoSerifOttomanSiyaq-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 is_noto: true
 sample_text {

--- a/ofl/notoseriftangut/METADATA.pb
+++ b/ofl/notoseriftangut/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "tangut"
 source {
   repository_url: "https://github.com/notofonts/tangut"
+  commit: "fd05a0c467af2d97ebcb6ed46453c9a0a37dfa66"
   archive_url: "https://github.com/notofonts/tangut/releases/download/NotoSerifTangut-v2.169/NotoSerifTangut-v2.169.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -36,7 +37,8 @@ source {
     dest_file: "NotoSerifTangut-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-serif-tangut.yaml"
 }
 is_noto: true
-languages: "txg_Tang"  # Tangut
+languages: "txg_Tang"
 primary_script: "Tang"

--- a/ofl/notoseriftibetan/METADATA.pb
+++ b/ofl/notoseriftibetan/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/tibetan"
+  commit: "28f1693070a917c50b3d275c9381def412a2ea2b"
   archive_url: "https://github.com/notofonts/tibetan/releases/download/NotoSerifTibetan-v2.103/NotoSerifTibetan-v2.103.zip"
   files {
     source_file: "OFL.txt"
@@ -41,12 +42,13 @@ source {
     dest_file: "NotoSerifTibetan[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-serif-tibetan.yaml"
 }
 is_noto: true
-languages: "bft_Tibt"  # Balti, Tibetan
-languages: "bo_Tibt"  # Tibetan
-languages: "dz_Tibt"  # Dzongkha
-languages: "taj_Tibt"  # Eastern Tamang, Tibetan
-languages: "tdg_Tibt"  # Western Tamang, Tibetan
-languages: "tsj_Tibt"  # Tshangla
+languages: "bft_Tibt"
+languages: "bo_Tibt"
+languages: "dz_Tibt"
+languages: "taj_Tibt"
+languages: "tdg_Tibt"
+languages: "tsj_Tibt"
 primary_script: "Tibt"

--- a/ofl/notoseriftodhri/METADATA.pb
+++ b/ofl/notoseriftodhri/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "todhri"
 source {
   repository_url: "https://github.com/notofonts/todhri"
-  commit: "850ebfdfca2d445c3e53577ec0b4c7e5d80a7d0f"
+  commit: "203e8ffb944c09d0974ca652a202a18ef3be234f"
   archive_url: "https://github.com/notofonts/todhri/releases/download/NotoSerifTodhri-v1.000/NotoSerifTodhri-v1.000.zip"
   files {
     source_file: "OFL.txt"
@@ -37,7 +37,8 @@ source {
     dest_file: "article/ARTICLE.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config-serif-todhri.yaml"
 }
 is_noto: true
-languages: "sq_Todr"  # Albanian (Todhri)
+languages: "sq_Todr"
 primary_script: "Todr"


### PR DESCRIPTION
Port most of the repo_url & commit info from fontc_crater's target.json file. (https://github.com/googlefonts/fontc_crater/commit/ee7a65d433882450efa1d8418ed746bf07c05642)

These correspond to all target.json entries with a single config_yaml each. There are also 100 entries with multiple config_yaml values that I'll submit later because they need more careful review.

(issue #2587)