### PR TITLE
[batch 3/4] port info from fontc_crater targets list

### DIFF
--- a/ofl/notoseriftoto/METADATA.pb
+++ b/ofl/notoseriftoto/METADATA.pb
@@ -23,7 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/toto"
-  commit: "3ea8167782a839042453dec5d164f1a5f801a8e1"
+  commit: "654cc6c340ccd33ea8935bfe936933861eb998b1"
   archive_url: "https://github.com/notofonts/toto/releases/download/NotoSerifToto-v2.002/NotoSerifToto-v2.002.zip"
   files {
     source_file: "OFL.txt"
@@ -34,7 +34,8 @@ source {
     dest_file: "NotoSerifToto[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-serif-toto.yaml"
 }
 is_noto: true
-languages: "txo_Toto"  # Toto
+languages: "txo_Toto"
 primary_script: "Toto"

--- a/ofl/notoserifyezidi/METADATA.pb
+++ b/ofl/notoserifyezidi/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/yezidi"
+  commit: "905a5f0b0de80d566e756478bc77a0c0f37c3348"
   archive_url: "https://github.com/notofonts/yezidi/releases/download/NotoSerifYezidi-v1.001/NotoSerifYezidi-v1.001.zip"
   files {
     source_file: "OFL.txt"
@@ -41,7 +42,8 @@ source {
     dest_file: "NotoSerifYezidi[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-serif-yezidi.yaml"
 }
 is_noto: true
-languages: "ku_Yezi"  # Kurdish, Yezidi
+languages: "ku_Yezi"
 primary_script: "Yezi"

--- a/ofl/notoznamennymusicalnotation/METADATA.pb
+++ b/ofl/notoznamennymusicalnotation/METADATA.pb
@@ -20,6 +20,7 @@ subsets: "symbols"
 subsets: "znamenny"
 source {
   repository_url: "https://github.com/notofonts/znamenny"
+  commit: "342a8039c2317865d203a448d118c384f2b51313"
   archive_url: "https://github.com/notofonts/znamenny/releases/download/NotoZnamennyMusicalNotation-v1.003/NotoZnamennyMusicalNotation-v1.003.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"
@@ -38,6 +39,7 @@ source {
     dest_file: "NotoZnamennyMusicalNotation-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-znamenny.yaml"
 }
 is_noto: true
 sample_text {

--- a/ofl/nunito/METADATA.pb
+++ b/ofl/nunito/METADATA.pb
@@ -34,7 +34,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/nunito"
-  commit: "43d16f963c5c341c10efa0bfe7a82aa1bea8a938"
+  commit: "8c6a9bb9732545b9ed53f29ec5e1ab0ff53c4e6f"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -48,4 +48,5 @@ source {
     dest_file: "Nunito-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/nunitosans/METADATA.pb
+++ b/ofl/nunitosans/METADATA.pb
@@ -67,4 +67,5 @@ source {
     dest_file: "NunitoSans-Italic[YTLC,opsz,wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/oi/METADATA.pb
+++ b/ofl/oi/METADATA.pb
@@ -23,7 +23,7 @@ subsets: "tamil"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/kosbarts/Oi"
-  commit: "5e2b01ea2e873bb5fa58cee970faaaa156804b33"
+  commit: "bd7ccfa844054ec4a0b2b17e56c33830646668ea"
   files {
     source_file: "fonts/ttf/Oi-Regular.ttf"
     dest_file: "Oi-Regular.ttf"
@@ -33,6 +33,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/ojuju/METADATA.pb
+++ b/ofl/ojuju/METADATA.pb
@@ -25,7 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/jobosonchisa/ojuju"
-  commit: "7f366504f204a579b27c99cb6c6272183100cde0"
+  commit: "61052b2801035d3011c87708bd3367eeabd0bb82"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -39,6 +39,7 @@ source {
     dest_file: "Ojuju[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/ole/METADATA.pb
+++ b/ofl/ole/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/ole"
+  commit: "fe77f34a3002bc4c2e26a8e27bee31cb45307846"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,4 +32,5 @@ source {
     dest_file: "Ole-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/onest/METADATA.pb
+++ b/ofl/onest/METADATA.pb
@@ -24,7 +24,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/simpals/onest"
-  commit: "838e8c63a8e9efd5cb81cddcc7ffacb15bd9a596"
+  commit: "f18c06a14512e43a6191849278d6f07fdaf347d6"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -34,4 +34,5 @@ source {
     dest_file: "Onest[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/ooohbaby/METADATA.pb
+++ b/ofl/ooohbaby/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/oooh-baby"
+  commit: "f36e2452e1c1a793fcf49524ab392eb6a2cd1dce"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,4 +32,5 @@ source {
     dest_file: "OoohBaby-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }

--- a/ofl/orbit/METADATA.pb
+++ b/ofl/orbit/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/JAMO-TYPEFACE/Orbit"
-  commit: "9f58ea557b9b3fd068f61f355f742fb58e741966"
+  commit: "95122395c6d1fda07aebdf36f566a75678bc3bdd"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,5 +32,6 @@ source {
     dest_file: "Orbit-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Kore"

--- a/ofl/orbitron/METADATA.pb
+++ b/ofl/orbitron/METADATA.pb
@@ -21,6 +21,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/orbitron-vf"
+  commit: "f16482824e0ce4d008dee59b9b632e9ce9663359"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/oswald/METADATA.pb
+++ b/ofl/oswald/METADATA.pb
@@ -25,7 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/OswaldFont"
-  commit: "6e65651c229e897dc55fb8d17097ee7f75b2769b"
+  commit: "89795261ac9eeb9aa8cd99f43982c4e4b0e53261"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -35,6 +35,7 @@ source {
     dest_file: "Oswald[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 fallbacks {
   axis_target {

--- a/ofl/outfit/METADATA.pb
+++ b/ofl/outfit/METADATA.pb
@@ -32,4 +32,5 @@ source {
     dest_file: "Outfit[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/overpass/METADATA.pb
+++ b/ofl/overpass/METADATA.pb
@@ -34,6 +34,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/RedHatOfficial/Overpass"
+  commit: "c580d28bfab7f39013568e684a65eeb23eff588d"
   files {
     source_file: "fonts/variable/Overpass[wght].ttf"
     dest_file: "Overpass[wght].ttf"
@@ -47,5 +48,6 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://overpassfont.org/"

--- a/ofl/overpassmono/METADATA.pb
+++ b/ofl/overpassmono/METADATA.pb
@@ -25,6 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/RedHatOfficial/Overpass"
+  commit: "c580d28bfab7f39013568e684a65eeb23eff588d"
   files {
     source_file: "fonts/variable_mono/OverpassMono[wght].ttf"
     dest_file: "OverpassMono[wght].ttf"
@@ -34,4 +35,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/pacifico/METADATA.pb
+++ b/ofl/pacifico/METADATA.pb
@@ -20,4 +20,6 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/Pacifico"
+  commit: "423e7cb2b036ead2624c05197e17a83ddf5c6068"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/paprika/METADATA.pb
+++ b/ofl/paprika/METADATA.pb
@@ -27,4 +27,5 @@ source {
     dest_file: "Paprika-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/parkinsans/METADATA.pb
+++ b/ofl/parkinsans/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "Parkinsans[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Latn"
 stroke: "SANS_SERIF"

--- a/ofl/passionsconflict/METADATA.pb
+++ b/ofl/passionsconflict/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/passions-conflict"
+  commit: "214cc2936ec1ec8fde1143ce215c0ec189a6638d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "PassionsConflict-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/pathwayextreme/METADATA.pb
+++ b/ofl/pathwayextreme/METADATA.pb
@@ -61,4 +61,5 @@ source {
     dest_file: "PathwayExtreme-Italic[opsz,wdth,wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/paytoneone/METADATA.pb
+++ b/ofl/paytoneone/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/paytoneFont"
-  commit: "b1438bc11966d48a1e9e8943b7b8a32dcb0c533c"
+  commit: "126567cf41b70d287e05359dbaf31561496282fa"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -28,6 +28,7 @@ source {
     dest_file: "PaytoneOne-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/petemoss/METADATA.pb
+++ b/ofl/petemoss/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/petemoss"
+  commit: "c08e5306e6d86292071852778b043f5f81de32ae"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Petemoss-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/philosopher/METADATA.pb
+++ b/ofl/philosopher/METADATA.pb
@@ -73,4 +73,5 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/phudu/METADATA.pb
+++ b/ofl/phudu/METADATA.pb
@@ -38,6 +38,7 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/pinyonscript/METADATA.pb
+++ b/ofl/pinyonscript/METADATA.pb
@@ -28,6 +28,7 @@ source {
     dest_file: "PinyonScript-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/pixelifysans/METADATA.pb
+++ b/ofl/pixelifysans/METADATA.pb
@@ -23,7 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/eifetx/Pixelify-Sans"
-  commit: "b862e0925f58e77583ddb2e056a2d667f2f3544a"
+  commit: "39df74aba80df8157546034b878e8be1eb565ced"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -33,6 +33,7 @@ source {
     dest_file: "PixelifySans[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/platypi/METADATA.pb
+++ b/ofl/platypi/METADATA.pb
@@ -32,7 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/d-sargent/platypi"
-  commit: "8574bbbc965e398a8c3da7edd926edda82b63113"
+  commit: "c204c7ba647cd05f55a68be6973340fa47aa67d1"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -46,5 +46,6 @@ source {
     dest_file: "Platypi-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"

--- a/ofl/playball/METADATA.pb
+++ b/ofl/playball/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/play-ball"
+  commit: "13a54129eb380bb0f3a086b31da09e7f2cd46ba9"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Playball-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/playfair/METADATA.pb
+++ b/ofl/playfair/METADATA.pb
@@ -59,6 +59,7 @@ source {
     dest_file: "Playfair[opsz,wdth,wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/playfairdisplay/METADATA.pb
+++ b/ofl/playfairdisplay/METADATA.pb
@@ -33,6 +33,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/clauseggers/Playfair"
+  commit: "80a334101928546b04fa9e709ad4b2f11f8a9e10"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/playfairdisplaysc/METADATA.pb
+++ b/ofl/playfairdisplaysc/METADATA.pb
@@ -64,4 +64,6 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/clauseggers/Playfair"
+  commit: "80a334101928546b04fa9e709ad4b2f11f8a9e10"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/playpensans/METADATA.pb
+++ b/ofl/playpensans/METADATA.pb
@@ -28,7 +28,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playpen-Sans"
-  commit: "e9de3f5df6328821ed98775d347b8da652fc47fc"
+  commit: "c85bb380b56b2009e7c9bff11f573a3028034161"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -38,6 +38,7 @@ source {
     dest_file: "PlaypenSans[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 minisite_url: "https://www.type-together.com/making-playpen-sans"
 stroke: "SANS_SERIF"

--- a/ofl/playpensansarabic/METADATA.pb
+++ b/ofl/playpensansarabic/METADATA.pb
@@ -25,8 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playpen-Sans"
-  commit: "6990b3115c68779625bad656c6b0723db7435044"
-  config_yaml: "sources/config-Arabic.yaml"
+  commit: "c85bb380b56b2009e7c9bff11f573a3028034161"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -36,6 +35,7 @@ source {
     dest_file: "PlaypenSansArabic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 minisite_url: "https://www.type-together.com/making-playpen-sans"
 primary_script: "Arab"

--- a/ofl/playpensansdeva/METADATA.pb
+++ b/ofl/playpensansdeva/METADATA.pb
@@ -24,7 +24,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playpen-Sans"
-  commit: "12483714650a12591e1914cad7d123e2cadc45e9"
+  commit: "c85bb380b56b2009e7c9bff11f573a3028034161"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -34,6 +34,7 @@ source {
     dest_file: "PlaypenSansDeva[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 minisite_url: "https://www.type-together.com/making-playpen-sans"
 primary_script: "Deva"

--- a/ofl/playpensanshebrew/METADATA.pb
+++ b/ofl/playpensanshebrew/METADATA.pb
@@ -25,7 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playpen-Sans"
-  commit: "12483714650a12591e1914cad7d123e2cadc45e9"
+  commit: "c85bb380b56b2009e7c9bff11f573a3028034161"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -35,7 +35,7 @@ source {
     dest_file: "PlaypenSansHebrew[wght].ttf"
   }
   branch: "main"
-  config_yaml: "sources/config-Hebrew.yaml"
+  config_yaml: "sources/config.yml"
 }
 minisite_url: "https://www.type-together.com/making-playpen-sans"
 primary_script: "Hebr"

--- a/ofl/playpensansthai/METADATA.pb
+++ b/ofl/playpensansthai/METADATA.pb
@@ -25,8 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playpen-Sans"
-  commit: "edaffec145577d12d6b5439ecb954b9f76a4a9a5"
-  config_yaml: "sources/config-Thai.yaml"
+  commit: "c85bb380b56b2009e7c9bff11f573a3028034161"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -36,6 +35,7 @@ source {
     dest_file: "PlaypenSansThai[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 minisite_url: "https://www.type-together.com/making-playpen-sans"
 primary_script: "Thai"

--- a/ofl/playwritear/METADATA.pb
+++ b/ofl/playwritear/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite AR Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,7 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "c92b72cb8ae2e7458b5de4e0f8f08b0861c35afc"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -32,6 +31,7 @@ source {
     dest_file: "PlaywriteAR[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Argentina"
 minisite_url: "https://primarium.info/countries/argentina"

--- a/ofl/playwritearguides/METADATA.pb
+++ b/ofl/playwritearguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Argentina-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Argentina Guides"
 minisite_url: "https://primarium.info/countries/argentina"

--- a/ofl/playwriteat/METADATA.pb
+++ b/ofl/playwriteat/METADATA.pb
@@ -21,9 +21,7 @@ fonts {
   full_name: "Playwrite AT Italic"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
-
 axes {
   tag: "wght"
   min_value: 100.0
@@ -31,7 +29,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "c92b72cb8ae2e7458b5de4e0f8f08b0861c35afc"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -46,6 +44,7 @@ source {
     dest_file: "PlaywriteAT-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Österreich"
 minisite_url: "https://primarium.info/countries/austria"

--- a/ofl/playwriteatguides/METADATA.pb
+++ b/ofl/playwriteatguides/METADATA.pb
@@ -24,7 +24,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -36,7 +36,7 @@ source {
   files {
     source_file: "fonts/ttf/PlaywriteATGuides-Italic.ttf"
     dest_file: "PlaywriteATGuides-Italic.ttf"
-  }  
+  }
   files {
     source_file: "documentation/about-guides/AT/ARTICLE.en_us.html"
     dest_file: "article/ARTICLE.en_us.html"
@@ -58,6 +58,7 @@ source {
     dest_file: "article/Playwrite-Osterreich-Guides_4.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Österreich Guides"
 minisite_url: "https://primarium.info/countries/austria"

--- a/ofl/playwriteaunsw/METADATA.pb
+++ b/ofl/playwriteaunsw/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite AU NSW Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,7 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "c92b72cb8ae2e7458b5de4e0f8f08b0861c35afc"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -32,6 +31,7 @@ source {
     dest_file: "PlaywriteAUNSW[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Australia NSW"
 minisite_url: "https://primarium.info/countries/australia"

--- a/ofl/playwriteaunswguides/METADATA.pb
+++ b/ofl/playwriteaunswguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Australia-NSW-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Australia NSW Guides"
 minisite_url: "https://primarium.info/countries/australia"

--- a/ofl/playwriteauqld/METADATA.pb
+++ b/ofl/playwriteauqld/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite AU QLD Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteAUQLD[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Australia QLD"
 minisite_url: "https://primarium.info/countries/australia"

--- a/ofl/playwriteauqldguides/METADATA.pb
+++ b/ofl/playwriteauqldguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Australia-QLD-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Australia QLD Guides"
 minisite_url: "https://primarium.info/countries/australia"

--- a/ofl/playwriteausa/METADATA.pb
+++ b/ofl/playwriteausa/METADATA.pb
@@ -12,9 +12,7 @@ fonts {
   full_name: "Playwrite AU SA Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
-
 axes {
   tag: "wght"
   min_value: 100.0
@@ -22,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -32,6 +31,7 @@ source {
     dest_file: "PlaywriteAUSA[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Australia SA"
 minisite_url: "https://primarium.info/countries/australia"

--- a/ofl/playwriteausaguides/METADATA.pb
+++ b/ofl/playwriteausaguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Australia-SA-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Australia SA Guides"
 minisite_url: "https://primarium.info/countries/australia"

--- a/ofl/playwriteautas/METADATA.pb
+++ b/ofl/playwriteautas/METADATA.pb
@@ -12,9 +12,7 @@ fonts {
   full_name: "Playwrite AU TAS Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
-
 axes {
   tag: "wght"
   min_value: 100.0
@@ -22,7 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "c92b72cb8ae2e7458b5de4e0f8f08b0861c35afc"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -33,6 +31,7 @@ source {
     dest_file: "PlaywriteAUTAS[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Australia Tasmania"
 minisite_url: "https://primarium.info/countries/australia"

--- a/ofl/playwriteautasguides/METADATA.pb
+++ b/ofl/playwriteautasguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Australia-TAS-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Australia Tasmania Guides"
 minisite_url: "https://primarium.info/countries/australia"

--- a/ofl/playwriteauvic/METADATA.pb
+++ b/ofl/playwriteauvic/METADATA.pb
@@ -12,9 +12,7 @@ fonts {
   full_name: "Playwrite AU VIC Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
-
 axes {
   tag: "wght"
   min_value: 100.0
@@ -22,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -32,6 +31,7 @@ source {
     dest_file: "PlaywriteAUVIC[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Australia Victoria"
 minisite_url: "https://primarium.info/countries/australia"

--- a/ofl/playwriteauvicguides/METADATA.pb
+++ b/ofl/playwriteauvicguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Australia-VIC-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Australia Victoria Guides"
 minisite_url: "https://primarium.info/countries/australia"

--- a/ofl/playwritebevlg/METADATA.pb
+++ b/ofl/playwritebevlg/METADATA.pb
@@ -12,9 +12,7 @@ fonts {
   full_name: "Playwrite BE VLG Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
-
 axes {
   tag: "wght"
   min_value: 100.0
@@ -22,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -32,6 +31,7 @@ source {
     dest_file: "PlaywriteBEVLG[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite België Vlaanderen"
 minisite_url: "https://primarium.info/countries/belgium"

--- a/ofl/playwritebevlgguides/METADATA.pb
+++ b/ofl/playwritebevlgguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Belgie-Vlaanderen-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite België Vlaanderen Guides"
 minisite_url: "https://primarium.info/countries/belgium"

--- a/ofl/playwritebewal/METADATA.pb
+++ b/ofl/playwritebewal/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite BE WAL Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteBEWAL[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Belgique Wallonie-Bruxelles"
 minisite_url: "https://primarium.info/countries/belgium"

--- a/ofl/playwritebewalguides/METADATA.pb
+++ b/ofl/playwritebewalguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Belgique-Wallonie-Bruxelles-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Belgique Wallonie-Bruxelles Guides"
 minisite_url: "https://primarium.info/countries/belgium"

--- a/ofl/playwritebr/METADATA.pb
+++ b/ofl/playwritebr/METADATA.pb
@@ -12,9 +12,7 @@ fonts {
   full_name: "Playwrite BR Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
-
 axes {
   tag: "wght"
   min_value: 100.0
@@ -22,7 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "c92b72cb8ae2e7458b5de4e0f8f08b0861c35afc"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -33,6 +31,7 @@ source {
     dest_file: "PlaywriteBR[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Brasil"
 minisite_url: "https://primarium.info/countries/brazil"

--- a/ofl/playwritebrguides/METADATA.pb
+++ b/ofl/playwritebrguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Brasil-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Brasil Guides"
 minisite_url: "https://primarium.info/countries/brazil"

--- a/ofl/playwriteca/METADATA.pb
+++ b/ofl/playwriteca/METADATA.pb
@@ -12,9 +12,7 @@ fonts {
   full_name: "Playwrite CA Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
-
 axes {
   tag: "wght"
   min_value: 100.0
@@ -22,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -32,6 +31,7 @@ source {
     dest_file: "PlaywriteCA[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Canada"
 minisite_url: "https://primarium.info/countries/canada"

--- a/ofl/playwritecaguides/METADATA.pb
+++ b/ofl/playwritecaguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Canada-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Canada Guides"
 minisite_url: "https://primarium.info/countries/canada"

--- a/ofl/playwritecl/METADATA.pb
+++ b/ofl/playwritecl/METADATA.pb
@@ -12,9 +12,7 @@ fonts {
   full_name: "Playwrite CL Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
-
 axes {
   tag: "wght"
   min_value: 100.0
@@ -22,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -32,6 +31,7 @@ source {
     dest_file: "PlaywriteCL[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Chile"
 minisite_url: "https://primarium.info/countries/chile"

--- a/ofl/playwriteclguides/METADATA.pb
+++ b/ofl/playwriteclguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Chile-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Chile Guides"
 minisite_url: "https://primarium.info/countries/chile"

--- a/ofl/playwriteco/METADATA.pb
+++ b/ofl/playwriteco/METADATA.pb
@@ -12,9 +12,7 @@ fonts {
   full_name: "Playwrite CO Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
-
 axes {
   tag: "wght"
   min_value: 100.0
@@ -22,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -32,6 +31,7 @@ source {
     dest_file: "PlaywriteCO[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Colombia"
 minisite_url: "https://primarium.info/countries/colombia"

--- a/ofl/playwritecoguides/METADATA.pb
+++ b/ofl/playwritecoguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Colombia-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Colombia Guides"
 minisite_url: "https://primarium.info/countries/colombia"

--- a/ofl/playwritecu/METADATA.pb
+++ b/ofl/playwritecu/METADATA.pb
@@ -12,9 +12,7 @@ fonts {
   full_name: "Playwrite CU Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
-
 axes {
   tag: "wght"
   min_value: 100.0
@@ -22,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -32,6 +31,7 @@ source {
     dest_file: "PlaywriteCU[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Cuba"
 minisite_url: "https://primarium.info/countries/cuba"

--- a/ofl/playwritecuguides/METADATA.pb
+++ b/ofl/playwritecuguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Cuba-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Cuba Guides"
 minisite_url: "https://primarium.info/countries/cuba"

--- a/ofl/playwritecz/METADATA.pb
+++ b/ofl/playwritecz/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite CZ Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteCZ[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Česko"
 minisite_url: "https://primarium.info/countries/czech-republic"

--- a/ofl/playwriteczguides/METADATA.pb
+++ b/ofl/playwriteczguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Cesko-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Česko Guides"
 minisite_url: "https://primarium.info/countries/czech-republic"

--- a/ofl/playwritedegrund/METADATA.pb
+++ b/ofl/playwritedegrund/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite DE Grund Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteDEGrund[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Deutschland Grundschrift"
 minisite_url: "https://primarium.info/countries/germany"

--- a/ofl/playwritedegrundguides/METADATA.pb
+++ b/ofl/playwritedegrundguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Deutschland-Grundschrift-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Deutschland Grundschrift Guides"
 minisite_url: "https://primarium.info/countries/germany"

--- a/ofl/playwritedela/METADATA.pb
+++ b/ofl/playwritedela/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite DE LA Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteDELA[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Deutschland Lateinische Ausgangsschrift"
 minisite_url: "https://primarium.info/countries/germany"

--- a/ofl/playwritedelaguides/METADATA.pb
+++ b/ofl/playwritedelaguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Deutschland-LA-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Deutschland Lateinische Ausgangsschrift Guides"
 minisite_url: "https://primarium.info/countries/germany"

--- a/ofl/playwritedesas/METADATA.pb
+++ b/ofl/playwritedesas/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite DE SAS Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteDESAS[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Deutschland Schulausgangschrift"
 minisite_url: "https://primarium.info/countries/germany"

--- a/ofl/playwritedesasguides/METADATA.pb
+++ b/ofl/playwritedesasguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Deutschland-SAS-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Deutschland Schulausgangschrift Guides"
 minisite_url: "https://primarium.info/countries/germany"

--- a/ofl/playwritedeva/METADATA.pb
+++ b/ofl/playwritedeva/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite DE VA Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteDEVA[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Deutschland Vereinfachte Ausgangsschrift"
 minisite_url: "https://primarium.info/countries/germany"

--- a/ofl/playwritedevaguides/METADATA.pb
+++ b/ofl/playwritedevaguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Deutschland-VA-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Deutschland Vereinfachte Ausgangsschrift Guides"
 minisite_url: "https://primarium.info/countries/germany"

--- a/ofl/playwritedkloopet/METADATA.pb
+++ b/ofl/playwritedkloopet/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite DK Loopet Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteDKLoopet[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Danmark Loopet"
 minisite_url: "https://primarium.info/countries/denmark"

--- a/ofl/playwritedkloopetguides/METADATA.pb
+++ b/ofl/playwritedkloopetguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Danmark-Loopet-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Danmark Loopet Guides"
 minisite_url: "https://primarium.info/countries/denmark"

--- a/ofl/playwritedkuloopet/METADATA.pb
+++ b/ofl/playwritedkuloopet/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite DK Uloopet Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteDKUloopet[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Danmark Uloopet"
 minisite_url: "https://primarium.info/countries/denmark"

--- a/ofl/playwritedkuloopetguides/METADATA.pb
+++ b/ofl/playwritedkuloopetguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Danmark-Uloopet-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Danmark Uloopet Guides"
 minisite_url: "https://primarium.info/countries/denmark"

--- a/ofl/playwritees/METADATA.pb
+++ b/ofl/playwritees/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite ES Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteES[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite España"
 minisite_url: "https://primarium.info/countries/spain"

--- a/ofl/playwriteesdeco/METADATA.pb
+++ b/ofl/playwriteesdeco/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite ES Deco Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteESDeco[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite España Decorativa"
 minisite_url: "https://primarium.info/countries/spain"

--- a/ofl/playwriteesdecoguides/METADATA.pb
+++ b/ofl/playwriteesdecoguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Espana-Deco-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite España Decorativa Guides"
 minisite_url: "https://primarium.info/countries/spain"

--- a/ofl/playwriteesguides/METADATA.pb
+++ b/ofl/playwriteesguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Espana-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite España Guides"
 minisite_url: "https://primarium.info/countries/spain"

--- a/ofl/playwritefrmoderne/METADATA.pb
+++ b/ofl/playwritefrmoderne/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite FR Moderne Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteFRModerne[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite France Moderne"
 minisite_url: "https://primarium.info/countries/france"

--- a/ofl/playwritefrmoderneguides/METADATA.pb
+++ b/ofl/playwritefrmoderneguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-France-Moderne-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite France Moderne Guides"
 minisite_url: "https://primarium.info/countries/france"

--- a/ofl/playwritefrtrad/METADATA.pb
+++ b/ofl/playwritefrtrad/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite FR Trad Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteFRTrad[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite France Traditionnelle"
 minisite_url: "https://primarium.info/countries/france"

--- a/ofl/playwritefrtradguides/METADATA.pb
+++ b/ofl/playwritefrtradguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-France-Traditionnelle-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite France Traditionnelle Guides"
 minisite_url: "https://primarium.info/countries/france"

--- a/ofl/playwritegbj/METADATA.pb
+++ b/ofl/playwritegbj/METADATA.pb
@@ -21,7 +21,6 @@ fonts {
   full_name: "Playwrite GB J Italic"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -30,6 +29,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -44,6 +44,7 @@ source {
     dest_file: "PlaywriteGBJ-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite England Joined"
 minisite_url: "https://primarium.info/countries/england"

--- a/ofl/playwritegbjguides/METADATA.pb
+++ b/ofl/playwritegbjguides/METADATA.pb
@@ -22,9 +22,9 @@ fonts {
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
 subsets: "menu"
-
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -58,6 +58,7 @@ source {
     dest_file: "article/Playwrite-England-Joined-Guides_4.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite England Joined Guides"
 minisite_url: "https://primarium.info/countries/england"

--- a/ofl/playwritegbs/METADATA.pb
+++ b/ofl/playwritegbs/METADATA.pb
@@ -21,7 +21,6 @@ fonts {
   full_name: "Playwrite GB S Italic"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -30,6 +29,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -44,6 +44,7 @@ source {
     dest_file: "PlaywriteGBS-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite England SemiJoined"
 minisite_url: "https://primarium.info/countries/england"

--- a/ofl/playwritegbsguides/METADATA.pb
+++ b/ofl/playwritegbsguides/METADATA.pb
@@ -24,7 +24,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -58,6 +58,7 @@ source {
     dest_file: "article/Playwrite-England-SemiJoined-Guides_4.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite England SemiJoined Guides"
 minisite_url: "https://primarium.info/countries/england"

--- a/ofl/playwritehr/METADATA.pb
+++ b/ofl/playwritehr/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite HR Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteHR[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Hrvatska"
 minisite_url: "https://primarium.info/countries/croatia"

--- a/ofl/playwritehrguides/METADATA.pb
+++ b/ofl/playwritehrguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Hrvatska-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Hrvatska Guides"
 minisite_url: "https://primarium.info/countries/croatia"

--- a/ofl/playwritehrlijeva/METADATA.pb
+++ b/ofl/playwritehrlijeva/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite HR Lijeva Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteHRLijeva[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Hrvatska Lijeva"
 minisite_url: "https://primarium.info/countries/croatia"

--- a/ofl/playwritehrlijevaguides/METADATA.pb
+++ b/ofl/playwritehrlijevaguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Hrvatska-Lijeva-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Hrvatska Lijeva Guides"
 minisite_url: "https://primarium.info/countries/croatia"

--- a/ofl/playwritehu/METADATA.pb
+++ b/ofl/playwritehu/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite HU Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteHU[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Magyarország"
 minisite_url: "https://primarium.info/countries/hungary"

--- a/ofl/playwritehuguides/METADATA.pb
+++ b/ofl/playwritehuguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Magyarorszag-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Magyarország Guides"
 minisite_url: "https://primarium.info/countries/hungary"

--- a/ofl/playwriteid/METADATA.pb
+++ b/ofl/playwriteid/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite ID Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteID[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Indonesia"
 minisite_url: "https://primarium.info/countries/indonesia"

--- a/ofl/playwriteidguides/METADATA.pb
+++ b/ofl/playwriteidguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Indonesia-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Indonesia Guides"
 minisite_url: "https://primarium.info/countries/indonesia"

--- a/ofl/playwriteie/METADATA.pb
+++ b/ofl/playwriteie/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite IE Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteIE[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Ireland"
 minisite_url: "https://primarium.info/countries/ireland"

--- a/ofl/playwriteieguides/METADATA.pb
+++ b/ofl/playwriteieguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Ireland-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Ireland Guides"
 minisite_url: "https://primarium.info/countries/ireland"

--- a/ofl/playwritein/METADATA.pb
+++ b/ofl/playwritein/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite IN Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteIN[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite India"
 minisite_url: "https://primarium.info/countries/india"

--- a/ofl/playwriteinguides/METADATA.pb
+++ b/ofl/playwriteinguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-India-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite India Guides"
 minisite_url: "https://primarium.info/countries/india"

--- a/ofl/playwriteis/METADATA.pb
+++ b/ofl/playwriteis/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite IS Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteIS[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Ísland"
 minisite_url: "https://primarium.info/countries/iceland"

--- a/ofl/playwriteisguides/METADATA.pb
+++ b/ofl/playwriteisguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Island-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Ísland Guides"
 minisite_url: "https://primarium.info/countries/iceland"

--- a/ofl/playwriteitmoderna/METADATA.pb
+++ b/ofl/playwriteitmoderna/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite IT Moderna Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteITModerna[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Italia Moderna"
 minisite_url: "https://primarium.info/countries/italy"

--- a/ofl/playwriteitmodernaguides/METADATA.pb
+++ b/ofl/playwriteitmodernaguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Italia-Moderna-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Italia Moderna Guides"
 minisite_url: "https://primarium.info/countries/italy"

--- a/ofl/playwriteittrad/METADATA.pb
+++ b/ofl/playwriteittrad/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite IT Trad Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteITTrad[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Italia Tradizionale"
 minisite_url: "https://primarium.info/countries/italy"

--- a/ofl/playwriteittradguides/METADATA.pb
+++ b/ofl/playwriteittradguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Italia-Tradizionale-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Italia Tradizionale Guides"
 minisite_url: "https://primarium.info/countries/italy"

--- a/ofl/playwritemx/METADATA.pb
+++ b/ofl/playwritemx/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite MX Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteMX[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite México"
 minisite_url: "https://primarium.info/countries/mexico"

--- a/ofl/playwritemxguides/METADATA.pb
+++ b/ofl/playwritemxguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Mexico-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite México Guides"
 minisite_url: "https://primarium.info/countries/mexico"

--- a/ofl/playwritengmodern/METADATA.pb
+++ b/ofl/playwritengmodern/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite NG Modern Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteNGModern[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Nigeria Modern"
 minisite_url: "https://primarium.info/countries/nigeria"

--- a/ofl/playwritengmodernguides/METADATA.pb
+++ b/ofl/playwritengmodernguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Nigeria-Modern-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Nigeria Modern Guides"
 minisite_url: "https://primarium.info/countries/nigeria"

--- a/ofl/playwritenl/METADATA.pb
+++ b/ofl/playwritenl/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite NL Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteNL[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Netherland"
 minisite_url: "https://primarium.info/countries/the-netherlands"

--- a/ofl/playwritenlguides/METADATA.pb
+++ b/ofl/playwritenlguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Netherland-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Netherland Guides"
 minisite_url: "https://primarium.info/countries/the-netherlands"

--- a/ofl/playwriteno/METADATA.pb
+++ b/ofl/playwriteno/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite NO Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteNO[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Norge"
 minisite_url: "https://primarium.info/countries/norway"

--- a/ofl/playwritenoguides/METADATA.pb
+++ b/ofl/playwritenoguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Norge-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Norge Guides"
 minisite_url: "https://primarium.info/countries/norway"

--- a/ofl/playwritenz/METADATA.pb
+++ b/ofl/playwritenz/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite NZ Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteNZ[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite New Zealand"
 minisite_url: "https://primarium.info/countries/new-zealand"

--- a/ofl/playwritenzguides/METADATA.pb
+++ b/ofl/playwritenzguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-New-Zealand-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite New Zealand Guides"
 minisite_url: "https://primarium.info/countries/new-zealand"

--- a/ofl/playwritepe/METADATA.pb
+++ b/ofl/playwritepe/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite PE Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywritePE[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Perú"
 minisite_url: "https://primarium.info/countries/peru"

--- a/ofl/playwritepeguides/METADATA.pb
+++ b/ofl/playwritepeguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Peru-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Perú Guides"
 minisite_url: "https://primarium.info/countries/peru"

--- a/ofl/playwritepl/METADATA.pb
+++ b/ofl/playwritepl/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite PL Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywritePL[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Polska"
 minisite_url: "https://primarium.info/countries/poland"

--- a/ofl/playwriteplguides/METADATA.pb
+++ b/ofl/playwriteplguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Polska-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Polska Guides"
 minisite_url: "https://primarium.info/countries/poland"

--- a/ofl/playwritept/METADATA.pb
+++ b/ofl/playwritept/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite PT Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywritePT[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Portugal"
 minisite_url: "https://primarium.info/countries/portugal"

--- a/ofl/playwriteptguides/METADATA.pb
+++ b/ofl/playwriteptguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Portugal-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Portugal Guides"
 minisite_url: "https://primarium.info/countries/portugal"

--- a/ofl/playwritero/METADATA.pb
+++ b/ofl/playwritero/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite RO Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteRO[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite România"
 minisite_url: "https://primarium.info/countries/romania"

--- a/ofl/playwriteroguides/METADATA.pb
+++ b/ofl/playwriteroguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Romania-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite România Guides"
 minisite_url: "https://primarium.info/countries/romania"

--- a/ofl/playwritesk/METADATA.pb
+++ b/ofl/playwritesk/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite SK Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteSK[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Slovensko"
 minisite_url: "https://primarium.info/countries/slovakia"

--- a/ofl/playwriteskguides/METADATA.pb
+++ b/ofl/playwriteskguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Slovensko-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Slovensko Guides"
 minisite_url: "https://primarium.info/countries/slovakia"

--- a/ofl/playwritetz/METADATA.pb
+++ b/ofl/playwritetz/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite TZ Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteTZ[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Tanzania"
 minisite_url: "https://primarium.info/countries/tanzania"

--- a/ofl/playwritetzguides/METADATA.pb
+++ b/ofl/playwritetzguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Tanzania-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Tanzania Guides"
 minisite_url: "https://primarium.info/countries/tanzania"

--- a/ofl/playwriteusmodern/METADATA.pb
+++ b/ofl/playwriteusmodern/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite US Modern Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteUSModern[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite USA Modern"
 minisite_url: "https://primarium.info/countries/united-states-of-america"

--- a/ofl/playwriteusmodernguides/METADATA.pb
+++ b/ofl/playwriteusmodernguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-USA-Modern-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite USA Modern Guides"
 minisite_url: "https://primarium.info/countries/united-states-of-america"

--- a/ofl/playwriteustrad/METADATA.pb
+++ b/ofl/playwriteustrad/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite US Trad Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteUSTrad[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite USA Traditional"
 minisite_url: "https://primarium.info/countries/united-states-of-america"

--- a/ofl/playwriteustradguides/METADATA.pb
+++ b/ofl/playwriteustradguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-USA-Traditional-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite USA Traditional Guides"
 minisite_url: "https://primarium.info/countries/united-states-of-america"

--- a/ofl/playwritevn/METADATA.pb
+++ b/ofl/playwritevn/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite VN Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteVN[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Việt Nam"
 minisite_url: "https://primarium.info/countries/vietnam"

--- a/ofl/playwritevnguides/METADATA.pb
+++ b/ofl/playwritevnguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-Vietnam-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite Việt Nam Guides"
 minisite_url: "https://primarium.info/countries/vietnam"

--- a/ofl/playwriteza/METADATA.pb
+++ b/ofl/playwriteza/METADATA.pb
@@ -12,7 +12,6 @@ fonts {
   full_name: "Playwrite ZA Regular"
   copyright: "Copyright 2023 The Playwrite Project Authors (https://github.com/TypeTogether/Playwrite)"
 }
-# We use only the menu subset to avoid the subsetter issues identified with the PW fonts.
 subsets: "menu"
 axes {
   tag: "wght"
@@ -21,6 +20,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   archive_url: "https://github.com/TypeTogether/Playwrite/releases/download/v1.003/Playwrite-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -31,6 +31,7 @@ source {
     dest_file: "PlaywriteZA[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite South Africa"
 minisite_url: "https://primarium.info/countries/south-africa"

--- a/ofl/playwritezaguides/METADATA.pb
+++ b/ofl/playwritezaguides/METADATA.pb
@@ -15,7 +15,7 @@ fonts {
 subsets: "menu"
 source {
   repository_url: "https://github.com/TypeTogether/Playwrite"
-  commit: "0bd52a3a13b6f3492820c746fa4bfa5196005306"
+  commit: "02e4e15767f5b6c2109413429fc51879b9507ab4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -41,6 +41,7 @@ source {
     dest_file: "article/Playwrite-South-Africa-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite South Africa Guides"
 minisite_url: "https://primarium.info/countries/south-africa"

--- a/ofl/plusjakartasans/METADATA.pb
+++ b/ofl/plusjakartasans/METADATA.pb
@@ -33,7 +33,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/tokotype/PlusJakartaSans"
-  commit: "163c006ff169bbb932757276b98a26f36a1409d8"
+  commit: "18d1cd2f7ea10481919d2f05c1f7064b7307fc26"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -47,4 +47,5 @@ source {
     dest_file: "PlusJakartaSans-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/pochaevsk/METADATA.pb
+++ b/ofl/pochaevsk/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin"
 subsets: "menu"
 source {
   repository_url: "https://github.com/slavonic/pochaevsk"
-  commit: "4238da848a89ef6a6cf41937c98932ce9d7c2303"
+  commit: "2117e7362d9b465ff0ac1850b535860d43d05f1d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,6 +32,7 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Cyrl"
 primary_language: "cu_Cyrl"

--- a/ofl/podkova/METADATA.pb
+++ b/ofl/podkova/METADATA.pb
@@ -25,6 +25,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/cyrealtype/Podkova"
+  commit: "e321080f4bfe74e7b14b4e928880c495f8b40675"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/poltawskinowy/METADATA.pb
+++ b/ofl/poltawskinowy/METADATA.pb
@@ -32,7 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/kosmynkab/Poltawski-Nowy"
-  commit: "6e5631b27a50d7f63bf0d1528060c34d882e1f40"
+  commit: "4d541846c51c5267937a06fd5da9ab7837be166f"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -46,5 +46,6 @@ source {
     dest_file: "PoltawskiNowy-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Półtawski Nowy"

--- a/ofl/ponomar/METADATA.pb
+++ b/ofl/ponomar/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin"
 subsets: "menu"
 source {
   repository_url: "https://github.com/slavonic/Ponomar"
-  commit: "7c70a2c8d21d58543d9a5d202d50fb6c1d93e38a"
+  commit: "a3023c5d838ee65b5617f3f9179269160bd177e5"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,6 +32,7 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Cyrl"
 primary_language: "cu_Cyrl"

--- a/ofl/pontanosans/METADATA.pb
+++ b/ofl/pontanosans/METADATA.pb
@@ -32,5 +32,6 @@ source {
     dest_file: "PontanoSans[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/praise/METADATA.pb
+++ b/ofl/praise/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/praise-script"
+  commit: "678af73de9e596fa80cbd1ab89ba45a18ad69991"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Praise-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/puppiesplay/METADATA.pb
+++ b/ofl/puppiesplay/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/puppies-play"
+  commit: "5f5c9a3f1373ea85403f314696a968887c8106c3"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "PuppiesPlay-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/questrial/METADATA.pb
+++ b/ofl/questrial/METADATA.pb
@@ -18,4 +18,6 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/questrial"
+  commit: "8db71bfbabedd8c8dda35818ea5d5508758c2e19"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/qwigley/METADATA.pb
+++ b/ofl/qwigley/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/qwigley"
+  commit: "7a963366b5efe19ef39603d03888a2105105dc01"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Qwigley-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/qwitchergrypen/METADATA.pb
+++ b/ofl/qwitchergrypen/METADATA.pb
@@ -27,6 +27,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/qwitcher-grypen"
+  commit: "cd12ed20d42c30bae735809f5cf84d44ad598837"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -44,6 +45,7 @@ source {
     dest_file: "QwitcherGrypen-Bold.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/radiocanada/METADATA.pb
+++ b/ofl/radiocanada/METADATA.pb
@@ -52,4 +52,5 @@ source {
     dest_file: "RadioCanada-Italic[wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/radiocanadabig/METADATA.pb
+++ b/ofl/radiocanadabig/METADATA.pb
@@ -45,5 +45,6 @@ source {
     dest_file: "RadioCanadaBig-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/radley/METADATA.pb
+++ b/ofl/radley/METADATA.pb
@@ -26,6 +26,8 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/RadleyFont"
+  commit: "7f54a0b10f092538849afcfbae11b9968eb2970b"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/rammettoone/METADATA.pb
+++ b/ofl/rammettoone/METADATA.pb
@@ -27,6 +27,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/readexpro/METADATA.pb
+++ b/ofl/readexpro/METADATA.pb
@@ -39,5 +39,6 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Arab"

--- a/ofl/rem/METADATA.pb
+++ b/ofl/rem/METADATA.pb
@@ -50,4 +50,5 @@ source {
     dest_file: "REM-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/rethinksans/METADATA.pb
+++ b/ofl/rethinksans/METADATA.pb
@@ -45,5 +45,6 @@ source {
     dest_file: "RethinkSans-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/roadrage/METADATA.pb
+++ b/ofl/roadrage/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/road-rage"
+  commit: "e55c939b96e80e4760f27d81d1abca714739e3fe"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "RoadRage-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/robotoflex/METADATA.pb
+++ b/ofl/robotoflex/METADATA.pb
@@ -114,10 +114,12 @@ registry_default_overrides {
 }
 source {
   repository_url: "https://github.com/googlefonts/Roboto-Flex"
+  commit: "739e06dc46ebb14cddd88b9768a6c1504d4677f6"
   archive_url: "https://github.com/googlefonts/roboto-flex/releases/download/3.200/roboto-flex-fonts.zip"
   files {
     source_file: "roboto-flex-fonts/fonts/variable/RobotoFlex[GRAD,XOPQ,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght].ttf"
     dest_file: "RobotoFlex[GRAD,XOPQ,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/robotoserif/METADATA.pb
+++ b/ofl/robotoserif/METADATA.pb
@@ -49,6 +49,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/roboto-serif"
+  commit: "1ecc2513e8215b569246a5802f18aa4b0e1d67a5"
   archive_url: "https://github.com/googlefonts/roboto-serif/releases/download/v1.008/RobotoSerifFonts-v1.008.zip"
   files {
     source_file: "variable/RobotoSerif[GRAD,opsz,wdth,wght].ttf"
@@ -59,5 +60,6 @@ source {
     dest_file: "RobotoSerif-Italic[GRAD,opsz,wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 minisite_url: "https://fonts.withgoogle.com/roboto-serif"

--- a/ofl/rokkitt/METADATA.pb
+++ b/ofl/rokkitt/METADATA.pb
@@ -46,5 +46,6 @@ source {
     dest_file: "Rokkitt[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SLAB_SERIF"

--- a/ofl/rosario/METADATA.pb
+++ b/ofl/rosario/METADATA.pb
@@ -32,6 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Omnibus-Type/Rosario"
+  commit: "d8bf83600979c82357d8023243d3d01a386fc7fe"
   files {
     source_file: "fonts/variable/Rosario[wght].ttf"
     dest_file: "Rosario[wght].ttf"
@@ -45,4 +46,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/rubik/METADATA.pb
+++ b/ofl/rubik/METADATA.pb
@@ -49,4 +49,5 @@ source {
     dest_file: "Rubik[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/rugeboogie/METADATA.pb
+++ b/ofl/rugeboogie/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/ruge-boogie"
+  commit: "9031c615c877101741a6535077e283aba9536919"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "RugeBoogie-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/ruthie/METADATA.pb
+++ b/ofl/ruthie/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/ruthie"
+  commit: "73c981515aaf81ab6b027f7e10716f6be62c3fd5"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Ruthie-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/sancreek/METADATA.pb
+++ b/ofl/sancreek/METADATA.pb
@@ -29,6 +29,7 @@ source {
     dest_file: "Sancreek-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/sankofadisplay/METADATA.pb
+++ b/ofl/sankofadisplay/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/batsimadz/Sankofa-Display"
-  commit: "ee4cefac12dd65aff8be308854b717f374a2d89b"
+  commit: "078848b9058a9e51b36ac4602c7c7424d34bef21"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -28,5 +28,6 @@ source {
     dest_file: "SankofaDisplay-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://www.sankofadisplay.com"

--- a/ofl/sassyfrass/METADATA.pb
+++ b/ofl/sassyfrass/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/sassy-frass"
+  commit: "9d93a3cc26cb069a2405362b45d95f0ddd4453a1"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "SassyFrass-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/sawarabimincho/METADATA.pb
+++ b/ofl/sawarabimincho/METADATA.pb
@@ -34,4 +34,5 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/schibstedgrotesk/METADATA.pb
+++ b/ofl/schibstedgrotesk/METADATA.pb
@@ -45,4 +45,5 @@ source {
     dest_file: "SchibstedGrotesk-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/secularone/METADATA.pb
+++ b/ofl/secularone/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/secular"
-  commit: "7b6bf2d21cfc4bedfc320014224ef5713adc57a9"
+  commit: "6a1b3caa448955ffe8fe7e5440f620abc0913995"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -28,4 +28,5 @@ source {
     dest_file: "SecularOne-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/sedan/METADATA.pb
+++ b/ofl/sedan/METADATA.pb
@@ -44,6 +44,7 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/sedansc/METADATA.pb
+++ b/ofl/sedansc/METADATA.pb
@@ -31,6 +31,7 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/sedgwickave/METADATA.pb
+++ b/ofl/sedgwickave/METADATA.pb
@@ -18,4 +18,6 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/sedgwickave"
+  commit: "3b269a9037e6ed8c8bc8f4bd90cd4d955855a20e"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/sedgwickavedisplay/METADATA.pb
+++ b/ofl/sedgwickavedisplay/METADATA.pb
@@ -18,6 +18,8 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/sedgwickave"
+  commit: "3b269a9037e6ed8c8bc8f4bd90cd4d955855a20e"
+  config_yaml: "sources/config.yaml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/sendflowers/METADATA.pb
+++ b/ofl/sendflowers/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "SendFlowers-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/seymourone/METADATA.pb
+++ b/ofl/seymourone/METADATA.pb
@@ -28,6 +28,7 @@ source {
     dest_file: "SeymourOne-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/shafarik/METADATA.pb
+++ b/ofl/shafarik/METADATA.pb
@@ -20,7 +20,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/slavonic/shafarik"
-  commit: "44d30b29c35d555cdd53382a5fa0156ea0accd62"
+  commit: "e4045d59b275755b2b8532b201402786055466d8"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -34,5 +34,6 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Cyrl"

--- a/ofl/shalimar/METADATA.pb
+++ b/ofl/shalimar/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/shalimar"
+  commit: "f071bc2cfa26969d846d9848b7b2f53e9fab16f9"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Shalimar-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/shanti/METADATA.pb
+++ b/ofl/shanti/METADATA.pb
@@ -27,5 +27,6 @@ source {
     dest_file: "Shanti-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/signika/METADATA.pb
+++ b/ofl/signika/METADATA.pb
@@ -38,4 +38,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/signikanegative/METADATA.pb
+++ b/ofl/signikanegative/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/aaronbell/signika"
+  commit: "bd066259b5a87d24b23c4f0da03a96889b6d0503"
   files {
     source_file: "fonts/variable_negative/SignikaNegative[wght].ttf"
     dest_file: "SignikaNegative[wght].ttf"
@@ -32,4 +33,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/signikasc/METADATA.pb
+++ b/ofl/signikasc/METADATA.pb
@@ -23,4 +23,6 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/Signika"
+  commit: "7361a224d1d77274af1ea11dd06448c54c16f598"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/silkscreen/METADATA.pb
+++ b/ofl/silkscreen/METADATA.pb
@@ -26,7 +26,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/silkscreen"
-  commit: "8f254a7d67a37f8da1f4f82d9c4281458f5c554c"
+  commit: "206ccf3f5234c281461e63ecc59cbc6b0563472b"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -40,6 +40,7 @@ source {
     dest_file: "Silkscreen-Bold.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/smooch/METADATA.pb
+++ b/ofl/smooch/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/smooch"
+  commit: "90c4cbdfbb06bf83e05b0b690e73f9dc8a760d03"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Smooch-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/smoochsans/METADATA.pb
+++ b/ofl/smoochsans/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/smooch-sans"
+  commit: "0a0a405279f4a706e657e95d97fad245e327d5bd"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -36,6 +37,7 @@ source {
     dest_file: "SmoochSans[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/solitreo/METADATA.pb
+++ b/ofl/solitreo/METADATA.pb
@@ -32,5 +32,6 @@ source {
     dest_file: "Solitreo-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Hebr"

--- a/ofl/sometypemono/METADATA.pb
+++ b/ofl/sometypemono/METADATA.pb
@@ -45,6 +45,7 @@ source {
     dest_file: "SometypeMono-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "MONOSPACE"

--- a/ofl/sono/METADATA.pb
+++ b/ofl/sono/METADATA.pb
@@ -33,7 +33,7 @@ registry_default_overrides {
 }
 source {
   repository_url: "https://github.com/sursly/sono"
-  commit: "0e7274983bb034e232c9903f9d827ba4d595a888"
+  commit: "7dc859025b464e8530d90116782b5407b7b6376d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -43,6 +43,7 @@ source {
     dest_file: "sono[MONO,wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "MONOSPACE"

--- a/ofl/sourgummy/METADATA.pb
+++ b/ofl/sourgummy/METADATA.pb
@@ -50,6 +50,7 @@ source {
     dest_file: "SourGummy-Italic[wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/spacemono/METADATA.pb
+++ b/ofl/spacemono/METADATA.pb
@@ -67,5 +67,6 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://www.colophon-foundry.org/custom-projects/space-mono"

--- a/ofl/spectral/METADATA.pb
+++ b/ofl/spectral/METADATA.pb
@@ -137,7 +137,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/productiontype/Spectral"
-  commit: "e1179c4fc05c1ba7efd40038e203312b4c90c376"
+  commit: "dbc06862d7030eedb1b01b60cdad8f6102f4ddfa"
   files {
     source_file: "fonts/ttf/Spectral-ExtraLight.ttf"
     dest_file: "Spectral-ExtraLight.ttf"
@@ -199,6 +199,7 @@ source {
     dest_file: "ofl.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Latn"
 stroke: "SERIF"

--- a/ofl/spectralsc/METADATA.pb
+++ b/ofl/spectralsc/METADATA.pb
@@ -137,7 +137,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/productiontype/Spectral"
-  commit: "e1179c4fc05c1ba7efd40038e203312b4c90c376"
+  commit: "dbc06862d7030eedb1b01b60cdad8f6102f4ddfa"
   files {
     source_file: "fonts/ttf/SC/SpectralSC-ExtraLight.ttf"
     dest_file: "SpectralSC-ExtraLight.ttf"
@@ -199,6 +199,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Latn"
 stroke: "SERIF"

--- a/ofl/splash/METADATA.pb
+++ b/ofl/splash/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "Splash-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/splinesans/METADATA.pb
+++ b/ofl/splinesans/METADATA.pb
@@ -22,7 +22,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/SorkinType/SplineSans"
-  commit: "d524ab0d587c5067a17284918cd5f144ac521ec9"
+  commit: "5196436e0714c188c70f30a93b4759e8ed8afb69"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,4 +32,5 @@ source {
     dest_file: "SplineSans[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/splinesansmono/METADATA.pb
+++ b/ofl/splinesansmono/METADATA.pb
@@ -32,7 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/SorkinType/SplineSansMono"
-  commit: "97fed7e4bc166ad9c93d3af9c4c7ebf3104a57ed"
+  commit: "b167db03b7d7ae754bf7071c13415e7aeee7d073"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -46,6 +46,7 @@ source {
     dest_file: "SplineSansMono-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "MONOSPACE"

--- a/ofl/squarepeg/METADATA.pb
+++ b/ofl/squarepeg/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "SquarePeg-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/stylescript/METADATA.pb
+++ b/ofl/stylescript/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/style-script"
+  commit: "618d9e00fb65b051f65f00f8e09f57e07c6af251"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "StyleScript-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/suse/METADATA.pb
+++ b/ofl/suse/METADATA.pb
@@ -22,7 +22,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/SUSE/suse-font"
-  commit: "d5d0b353f3defb9dece73334a50cc4a62ae97e00"
+  commit: "f315ee46344ccc4f8d470cee3644b7bc99cadbaa"
   archive_url: "https://github.com/SUSE/suse-font/releases/download/v1.000/suse-font-v1.000.zip"
   files {
     source_file: "OFL.txt"
@@ -33,4 +33,5 @@ source {
     dest_file: "SUSE[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/tacone/METADATA.pb
+++ b/ofl/tacone/METADATA.pb
@@ -20,7 +20,7 @@ subsets: "symbols"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/Afrotype/tac"
-  commit: "5e8ff11215e3c3abfaffb94557c623a3ce5a5a07"
+  commit: "b18a7f59ff2e14cbc28968ea550926306426f6ce"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -34,6 +34,7 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
Port most of the repo_url & commit info from fontc_crater's target.json file. (https://github.com/googlefonts/fontc_crater/commit/ee7a65d433882450efa1d8418ed746bf07c05642)

These correspond to all target.json entries with a single config_yaml each. There are also 100 entries with multiple config_yaml values that I'll submit later because they need more careful review.

(issue #2587)