### PR TITLE
[Batch 4/4] port info from fontc_crater targets list

### DIFF
--- a/ofl/tagesschrift/METADATA.pb
+++ b/ofl/tagesschrift/METADATA.pb
@@ -31,4 +31,5 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/tapestry/METADATA.pb
+++ b/ofl/tapestry/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "Tapestry-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/teachers/METADATA.pb
+++ b/ofl/teachers/METADATA.pb
@@ -32,7 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/chankfonts/Teachers-fonts"
-  commit: "f903bca18f4ecb61ee43f6a33e30a91e21449836"
+  commit: "71a4377cf26d6d016527557d2c8bd18894d0c7ad"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -46,5 +46,6 @@ source {
     dest_file: "Teachers-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/tektur/METADATA.pb
+++ b/ofl/tektur/METADATA.pb
@@ -42,6 +42,7 @@ source {
     dest_file: "Tektur[wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/texturina/METADATA.pb
+++ b/ofl/texturina/METADATA.pb
@@ -41,6 +41,7 @@ registry_default_overrides {
 }
 source {
   repository_url: "https://github.com/Omnibus-Type/Texturina"
+  commit: "5f38963152042ab3bcb1722c1bdcc950f8605345"
   files {
     source_file: "fonts/variable/Texturina[opsz,wght].ttf"
     dest_file: "Texturina[opsz,wght].ttf"
@@ -198,6 +199,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/thenautigal/METADATA.pb
+++ b/ofl/thenautigal/METADATA.pb
@@ -27,6 +27,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/the-nautigal"
+  commit: "1d644f7cd792c5cc64a91e88f0ca568016f820aa"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -44,6 +45,7 @@ source {
     dest_file: "TheNautigal-Bold.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/tourney/METADATA.pb
+++ b/ofl/tourney/METADATA.pb
@@ -37,6 +37,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Etcetera-Type-Co/Tourney"
+  commit: "643f1026ad6d41b4527f42cd93c776414fdd6503"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -50,6 +51,7 @@ source {
     dest_file: "Tourney[wdth,wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/triodion/METADATA.pb
+++ b/ofl/triodion/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin"
 subsets: "menu"
 source {
   repository_url: "https://github.com/slavonic/Triodion"
-  commit: "9a608c40b343917da2d075afa6ca1e55dc6052f3"
+  commit: "3274de97310bf4660d6fb2a1ea49f771071be4b0"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -32,6 +32,7 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Cyrl"
 primary_language: "cu_Cyrl"

--- a/ofl/twinklestar/METADATA.pb
+++ b/ofl/twinklestar/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/twinkle-star"
+  commit: "b91b9bb130e238e2ab91d1dfd855cfcbb74c5677"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "TwinkleStar-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/updock/METADATA.pb
+++ b/ofl/updock/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "Updock-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/urbanist/METADATA.pb
+++ b/ofl/urbanist/METADATA.pb
@@ -31,6 +31,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/coreyhu/Urbanist"
+  commit: "549716453f76335ccc5a9e537cbe0da03d6fed34"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -44,6 +45,7 @@ source {
     dest_file: "Urbanist-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/victormono/METADATA.pb
+++ b/ofl/victormono/METADATA.pb
@@ -36,6 +36,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/rubjo/victor-mono-font"
+  commit: "8c00076e5afe53f3707db3ec0865b93f6d464b04"
   archive_url: "https://github.com/rubjo/victor-mono-font/releases/download/v1.561/victor-mono-font-fonts.zip"
   files {
     source_file: "OFL.txt"
@@ -54,6 +55,7 @@ source {
     dest_file: "VictorMono-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 minisite_url: "https://rubjo.github.io/victor-mono"
 stroke: "SANS_SERIF"

--- a/ofl/vinasans/METADATA.pb
+++ b/ofl/vinasans/METADATA.pb
@@ -28,6 +28,7 @@ source {
     dest_file: "VinaSans-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/voces/METADATA.pb
+++ b/ofl/voces/METADATA.pb
@@ -17,4 +17,6 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/VocesFont"
+  commit: "48b989992d00a8df49a81c26989876b77c633597"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/voltaire/METADATA.pb
+++ b/ofl/voltaire/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/SorkinType/Voltaire"
-  commit: "40a82d5f7a1c4b09f5a9ff5e8711d6cbb8bbc01d"
+  commit: "3587d918a1a19e01a9b8f9dbcb504ffc12d04dbe"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -28,6 +28,7 @@ source {
     dest_file: "Voltaire-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/vujahdayscript/METADATA.pb
+++ b/ofl/vujahdayscript/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/vujahday"
+  commit: "37a8a215d0a4b152bf5acb1b04b1dc3eade51ced"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "VujahdayScript-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/waterbrush/METADATA.pb
+++ b/ofl/waterbrush/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "WaterBrush-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/waterfall/METADATA.pb
+++ b/ofl/waterfall/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/waterfall"
+  commit: "89e483e54f06bc487898d221f99c1050ad8154b6"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -31,6 +32,7 @@ source {
     dest_file: "Waterfall-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/wavefont/METADATA.pb
+++ b/ofl/wavefont/METADATA.pb
@@ -38,7 +38,7 @@ registry_default_overrides {
 }
 source {
   repository_url: "https://github.com/dy/wavefont"
-  commit: "91649d7bede2a302b8b820dbccc2401672400cdd"
+  commit: "76d6e2cb12f3cbea3fb2766ae3f849a061a54227"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -48,6 +48,7 @@ source {
     dest_file: "Wavefont[ROND,YELA,wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 sample_text {
   masthead_full: "111198765432111987654432111"

--- a/ofl/whisper/METADATA.pb
+++ b/ofl/whisper/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "Whisper-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/windsong/METADATA.pb
+++ b/ofl/windsong/METADATA.pb
@@ -27,6 +27,7 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/googlefonts/windsong"
+  commit: "08da686e588864189c5c1616ed6971c1aeebafd5"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -44,6 +45,7 @@ source {
     dest_file: "WindSong-Medium.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/winkysans/METADATA.pb
+++ b/ofl/winkysans/METADATA.pb
@@ -45,6 +45,7 @@ source {
     dest_file: "WinkySans-Italic[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/wittgenstein/METADATA.pb
+++ b/ofl/wittgenstein/METADATA.pb
@@ -49,5 +49,6 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"

--- a/ofl/wixmadefordisplay/METADATA.pb
+++ b/ofl/wixmadefordisplay/METADATA.pb
@@ -25,12 +25,14 @@ axes {
 }
 source {
   repository_url: "https://github.com/wix/wixmadefor"
+  commit: "85646f130c8d3edffe66c4d8755c3f9f7abfa877"
   archive_url: "https://github.com/wix/wixmadefor/releases/download/3.100/wixmadefor-fonts.zip"
   files {
     source_file: "wixmadefor-fonts/fonts/variable/WixMadeforDisplay[wght].ttf"
     dest_file: "WixMadeforDisplay[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/worksans/METADATA.pb
+++ b/ofl/worksans/METADATA.pb
@@ -32,6 +32,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/weiweihuanghuang/Work-Sans"
+  commit: "b35c81086186162164947bd39574683073d9b268"
   files {
     source_file: "fonts/variable/WorkSans[wght].ttf"
     dest_file: "WorkSans[wght].ttf"
@@ -45,4 +46,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/yanonekaffeesatz/METADATA.pb
+++ b/ofl/yanonekaffeesatz/METADATA.pb
@@ -41,6 +41,7 @@ source {
     dest_file: "YanoneKaffeesatz[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/youngserif/METADATA.pb
+++ b/ofl/youngserif/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/noirblancrouge/YoungSerif"
-  commit: "8d67638d5ae1aa9e339d53326cd608e186d03dbd"
+  commit: "d307c79320df6b8ccc656b5ab83719519ddffc28"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -27,5 +27,6 @@ source {
     dest_file: "YoungSerif-Regular.ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"

--- a/ofl/ysabeau/METADATA.pb
+++ b/ofl/ysabeau/METADATA.pb
@@ -37,7 +37,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/CatharsisFonts/Ysabeau"
-  commit: "8e2ca3573545176256d370f891604bc453029568"
+  commit: "c21395fc7e596c66e8e03daa09babf245005ce01"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -55,4 +55,5 @@ source {
     dest_file: "Ysabeau-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/ysabeauinfant/METADATA.pb
+++ b/ofl/ysabeauinfant/METADATA.pb
@@ -37,7 +37,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/CatharsisFonts/Ysabeau"
-  commit: "8e2ca3573545176256d370f891604bc453029568"
+  commit: "c21395fc7e596c66e8e03daa09babf245005ce01"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -55,4 +55,5 @@ source {
     dest_file: "YsabeauInfant-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/ysabeauoffice/METADATA.pb
+++ b/ofl/ysabeauoffice/METADATA.pb
@@ -37,7 +37,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/CatharsisFonts/Ysabeau"
-  commit: "8e2ca3573545176256d370f891604bc453029568"
+  commit: "c21395fc7e596c66e8e03daa09babf245005ce01"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -55,4 +55,5 @@ source {
     dest_file: "YsabeauOffice-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/ysabeausc/METADATA.pb
+++ b/ofl/ysabeausc/METADATA.pb
@@ -28,7 +28,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/CatharsisFonts/Ysabeau"
-  commit: "8e2ca3573545176256d370f891604bc453029568"
+  commit: "c21395fc7e596c66e8e03daa09babf245005ce01"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -42,4 +42,5 @@ source {
     dest_file: "YsabeauSC[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/zendots/METADATA.pb
+++ b/ofl/zendots/METADATA.pb
@@ -17,6 +17,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/zen-dots"
+  commit: "c9f0bc02e2aad7544f843aefce01845a2d3ba372"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -30,6 +31,7 @@ source {
     dest_file: "ZenDots-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/zenloop/METADATA.pb
+++ b/ofl/zenloop/METADATA.pb
@@ -26,6 +26,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/zen-loop"
+  commit: "6ca53231f8adfb03f75d63b1dc1a8d8db6d641cf"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -43,6 +44,7 @@ source {
     dest_file: "ZenLoop-Italic.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/zentokyozoo/METADATA.pb
+++ b/ofl/zentokyozoo/METADATA.pb
@@ -17,6 +17,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/zen-tokyo-zoo"
+  commit: "083c7b58656f53568f964d72b31bba42b3df28c2"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -30,4 +31,5 @@ source {
     dest_file: "ZenTokyoZoo-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yml"
 }


### PR DESCRIPTION
Port most of the repo_url & commit info from fontc_crater's target.json file. (https://github.com/googlefonts/fontc_crater/commit/ee7a65d433882450efa1d8418ed746bf07c05642)

These correspond to all target.json entries with a single config_yaml each. There are also 100 entries with multiple config_yaml values that I'll submit later because they need more careful review.

(issue #2587)