### PR TITLE
Updating LXGW WenKai fonts, Cactus, and Chocolate to be classified as Chinese Traditional

### DIFF
--- a/ofl/cactusclassicalserif/METADATA.pb
+++ b/ofl/cactusclassicalserif/METADATA.pb
@@ -12,7 +12,7 @@ fonts {
   full_name: "Cactus Classical Serif Regular"
   copyright: "Copyright 2024 The Cactus Classical Serif Project Authors (https://github.com/MoonlitOwen/CactusSerif)"
 }
-subsets: "chinese-hongkong"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/chocolateclassicalsans/METADATA.pb
+++ b/ofl/chocolateclassicalsans/METADATA.pb
@@ -12,7 +12,7 @@ fonts {
   full_name: "Chocolate Classical Sans Regular"
   copyright: "Copyright 2024 The Chocolate Classical Sans Project Authors (https://github.com/MoonlitOwen/ChocolateSans)"
 }
-subsets: "chinese-hongkong"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/lxgwwenkaimonotc/METADATA.pb
+++ b/ofl/lxgwwenkaimonotc/METADATA.pb
@@ -30,7 +30,7 @@ fonts {
   full_name: "LXGW WenKai Mono TC Bold"
   copyright: "Copyright 2024 The LXGW WenKai Project Authors (https://github.com/lxgw/LxgwWenkaiTC)"
 }
-subsets: "chinese-hongkong"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "cyrillic-ext"
 subsets: "greek"

--- a/ofl/lxgwwenkaitc/METADATA.pb
+++ b/ofl/lxgwwenkaitc/METADATA.pb
@@ -30,7 +30,7 @@ fonts {
   full_name: "LXGW WenKai TC Bold"
   copyright: "Copyright 2024 The LXGW WenKai Project Authors (https://github.com/lxgw/LxgwWenkaiTC)"
 }
-subsets: "chinese-hongkong"
+subsets: "chinese-traditional"
 subsets: "cyrillic"
 subsets: "cyrillic-ext"
 subsets: "greek"


### PR DESCRIPTION
This PR is changing the subset definitions for the older TC projects onboarded (LXGW WenKai TC, Cactus Classical, and Chocolate Sans) from `chinese-hongkong` to `chinese-traditional` which is more accurate to the character designs and coverage present in the fonts. 

Per discussion with the Cantonese team, all TC-focused fonts should be categorized as `chinese-traditional` unless specifically mentioning `HK` in the name / documentation. 