### PR TITLE
 Documenting Font Sources, 2025-04-02

### DIFF
--- a/ofl/brunoace/METADATA.pb
+++ b/ofl/brunoace/METADATA.pb
@@ -17,7 +17,8 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/Bruno-ace"
-  commit: "4eb5f7fc38a1548b353b4ee03b1f7043b48ae181"
+  commit: "58dc219db32ffd9eaf573f2dc3be2e342410e15a"
+  config_yaml: "sources/brunoace-regular.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/brunoacesc/METADATA.pb
+++ b/ofl/brunoacesc/METADATA.pb
@@ -17,7 +17,8 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/Bruno-ace"
-  commit: "4eb5f7fc38a1548b353b4ee03b1f7043b48ae181"
+  commit: "58dc219db32ffd9eaf573f2dc3be2e342410e15a"
+  config_yaml: "sources/brunoacesc-regular.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cormorant/METADATA.pb
+++ b/ofl/cormorant/METADATA.pb
@@ -35,6 +35,7 @@ axes {
 source {
   repository_url: "https://github.com/CatharsisFonts/Cormorant"
   commit: "cc1bfb51ce6568cb3abf9199ab718d543f6fa189"
+  config_yaml: "sources/build.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cormorantgaramond/METADATA.pb
+++ b/ofl/cormorantgaramond/METADATA.pb
@@ -35,6 +35,7 @@ axes {
 source {
   repository_url: "https://github.com/CatharsisFonts/Cormorant"
   commit: "6d210fd3550b7358ca62d6ba3e354ec1ec940813"
+  config_yaml: "sources/config-garamond.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cormorantinfant/METADATA.pb
+++ b/ofl/cormorantinfant/METADATA.pb
@@ -35,6 +35,7 @@ axes {
 source {
   repository_url: "https://github.com/CatharsisFonts/Cormorant"
   commit: "6d210fd3550b7358ca62d6ba3e354ec1ec940813"
+  config_yaml: "sources/config-infant.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cormorantsc/METADATA.pb
+++ b/ofl/cormorantsc/METADATA.pb
@@ -57,6 +57,7 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/CatharsisFonts/Cormorant"
   commit: "cc1bfb51ce6568cb3abf9199ab718d543f6fa189"
+  config_yaml: "sources/build.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cormorantunicase/METADATA.pb
+++ b/ofl/cormorantunicase/METADATA.pb
@@ -57,6 +57,7 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/CatharsisFonts/Cormorant"
   commit: "cc1bfb51ce6568cb3abf9199ab718d543f6fa189"
+  config_yaml: "sources/build.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cormorantupright/METADATA.pb
+++ b/ofl/cormorantupright/METADATA.pb
@@ -54,4 +54,30 @@ subsets: "menu"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/CatharsisFonts/Cormorant"
+  commit: "b1a0a7781e3a59d3c2a96f953650463469a2e841"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "1. TrueType Font Files/CormorantUpright-Bold.ttf"
+    dest_file: "CormorantUpright-Bold.ttf"
+  }
+  files {
+    source_file: "1. TrueType Font Files/CormorantUpright-Light.ttf"
+    dest_file: "CormorantUpright-Light.ttf"
+  }
+  files {
+    source_file: "1. TrueType Font Files/CormorantUpright-Medium.ttf"
+    dest_file: "CormorantUpright-Medium.ttf"
+  }
+  files {
+    source_file: "1. TrueType Font Files/CormorantUpright-Regular.ttf"
+    dest_file: "CormorantUpright-Regular.ttf"
+  }
+  files {
+    source_file: "1. TrueType Font Files/CormorantUpright-SemiBold.ttf"
+    dest_file: "CormorantUpright-SemiBold.ttf"
+  }
+  branch: "master"
 }

--- a/ofl/danfo/METADATA.pb
+++ b/ofl/danfo/METADATA.pb
@@ -23,7 +23,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/Afrotype/danfo"
-  commit: "f4a0c2dd9c65c42707208ec788371cec30b71b7f"
+  commit: "a66fc9ded8f42ad2d39b91c9cd8a1960737ad02a"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/notosansarmenian/METADATA.pb
+++ b/ofl/notosansarmenian/METADATA.pb
@@ -29,6 +29,7 @@ axes {
 source {
   repository_url: "https://github.com/notofonts/armenian"
   archive_url: "https://github.com/notofonts/armenian/releases/download/NotoSansArmenian-v2.008/NotoSansArmenian-v2.008.zip"
+  config_yaml: "sources/config-sans-armenian.yaml"
   files {
     source_file: "DESCRIPTION.en_us.html"
     dest_file: "DESCRIPTION.en_us.html"

--- a/ofl/notosansbalinese/METADATA.pb
+++ b/ofl/notosansbalinese/METADATA.pb
@@ -25,6 +25,7 @@ source {
   repository_url: "https://github.com/notofonts/balinese"
   commit: "e6c2d4c19072cb6da80d74ad9f683b749f5b6f00"
   archive_url: "https://github.com/notofonts/balinese/releases/download/NotoSansBalinese-v2.006/NotoSansBalinese-v2.006.zip"
+  config_yaml: "sources/config-sans-balinese.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/notoserifarmenian/METADATA.pb
+++ b/ofl/notoserifarmenian/METADATA.pb
@@ -29,6 +29,7 @@ axes {
 source {
   repository_url: "https://github.com/notofonts/armenian"
   archive_url: "https://github.com/notofonts/armenian/releases/download/NotoSerifArmenian-v2.008/NotoSerifArmenian-v2.008.zip"
+  config_yaml: "sources/config-serif-armenian.yaml"
   files {
     source_file: "DESCRIPTION.en_us.html"
     dest_file: "DESCRIPTION.en_us.html"

--- a/ofl/notoserifbalinese/METADATA.pb
+++ b/ofl/notoserifbalinese/METADATA.pb
@@ -20,6 +20,7 @@ source {
   repository_url: "https://github.com/notofonts/balinese"
   commit: "3677ecce1289bdd0014392c8ef878ba972b93bb0"
   archive_url: "https://github.com/notofonts/balinese/releases/download/NotoSerifBalinese-v2.007/NotoSerifBalinese-v2.007.zip"
+  config_yaml: "sources/config-serif-balinese.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/tacone/METADATA.pb
+++ b/ofl/tacone/METADATA.pb
@@ -20,7 +20,7 @@ subsets: "symbols"
 subsets: "vietnamese"
 source {
   repository_url: "https://github.com/Afrotype/tac"
-  commit: "b18a7f59ff2e14cbc28968ea550926306426f6ce"
+  commit: "85b9001fb4c9f6801808de5ee2f5e257ad062856"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"


### PR DESCRIPTION
* Font families with full source info: 695 of 1901 (36.56% of GF Library)
* 12 more (0.63% more) than [yesterday](https://github.com/google/fonts/pull/9293)
* Progress is being tracked at https://docs.google.com/spreadsheets/d/1ao3k56FwQy6W0Ll5QbU_wpuKEvNPYcn8YyEU9_L8O4Q/edit?usp=sharing