### PR TITLE
Documenting Font Sources, 2025-04-03

### DIFF
--- a/ofl/alatsi/METADATA.pb
+++ b/ofl/alatsi/METADATA.pb
@@ -20,6 +20,7 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/SorkinType/Alatsi/"
   commit: "92b5663a41d41e2912ec46cb4e523303e33f9723"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/geist/METADATA.pb
+++ b/ofl/geist/METADATA.pb
@@ -24,6 +24,7 @@ axes {
 source {
   repository_url: "https://github.com/vercel/geist-font"
   commit: "b193ef74010119759bfb7f71ddf81a3dee238535"
+  config_yaml: "sources/config-Geist.yaml"
   archive_url: "https://github.com/vercel/geist-font/releases/download/1.4.01/Geist-1.4.01.zip"
   files {
     source_file: "variable/Geist[wght].ttf"

--- a/ofl/geistmono/METADATA.pb
+++ b/ofl/geistmono/METADATA.pb
@@ -24,6 +24,7 @@ axes {
 source {
   repository_url: "https://github.com/vercel/geist-font"
   commit: "b193ef74010119759bfb7f71ddf81a3dee238535"
+  config_yaml: "sources/config-GeistMono.yaml"
   archive_url: "https://github.com/vercel/geist-font/releases/download/1.4.01/GeistMono-1.4.01.zip"
   files {
     source_file: "variable/GeistMono[wght].ttf"

--- a/ofl/hahmlet/METADATA.pb
+++ b/ofl/hahmlet/METADATA.pb
@@ -24,6 +24,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/hyper-type/hahmlet/"
+  commit: "106541144954a9b7037b8d3837097ba660312655"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "fonts/variable/Hahmlet[wght].ttf"
     dest_file: "Hahmlet[wght].ttf"

--- a/ofl/jacquard12/METADATA.pb
+++ b/ofl/jacquard12/METADATA.pb
@@ -20,6 +20,7 @@ subsets: "symbols"
 source {
   repository_url: "https://github.com/scfried/soft-type-jacquard"
   commit: "b11565152caccd6eaedce5fe2ca0e377d1a7c597"
+  config_yaml: "sources/config-jacquard12.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/jacquard12charted/METADATA.pb
+++ b/ofl/jacquard12charted/METADATA.pb
@@ -20,6 +20,7 @@ subsets: "symbols"
 source {
   repository_url: "https://github.com/scfried/soft-type-jacquard"
   commit: "b11565152caccd6eaedce5fe2ca0e377d1a7c597"
+  config_yaml: "sources/config-jacquard12charted.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/jacquard24/METADATA.pb
+++ b/ofl/jacquard24/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/scfried/soft-type-jacquard"
   commit: "b11565152caccd6eaedce5fe2ca0e377d1a7c597"
+  config_yaml: "sources/config-jacquard24.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/jacquard24charted/METADATA.pb
+++ b/ofl/jacquard24charted/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/scfried/soft-type-jacquard"
   commit: "b11565152caccd6eaedce5fe2ca0e377d1a7c597"
+  config_yaml: "sources/config-jacquard24charted.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/jacquardabastarda9charted/METADATA.pb
+++ b/ofl/jacquardabastarda9charted/METADATA.pb
@@ -29,6 +29,6 @@ source {
     dest_file: "JacquardaBastarda9Charted-Regular.ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "sources/config-charted.yaml"
 }
 stroke: "SERIF"

--- a/ofl/jersey10/METADATA.pb
+++ b/ofl/jersey10/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/scfried/soft-type-jersey"
   commit: "d8446c4c9c2ba14cf408c295be35213c006e19ff"
+  config_yaml: "sources/config-jersey10.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/jersey10charted/METADATA.pb
+++ b/ofl/jersey10charted/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/scfried/soft-type-jersey"
   commit: "d8446c4c9c2ba14cf408c295be35213c006e19ff"
+  config_yaml: "sources/config-jersey10charted.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/jersey15/METADATA.pb
+++ b/ofl/jersey15/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/scfried/soft-type-jersey"
   commit: "d8446c4c9c2ba14cf408c295be35213c006e19ff"
+  config_yaml: "sources/config-jersey15.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/jersey15charted/METADATA.pb
+++ b/ofl/jersey15charted/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/scfried/soft-type-jersey"
   commit: "d8446c4c9c2ba14cf408c295be35213c006e19ff"
+  config_yaml: "sources/config-jersey15charted.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/jersey20/METADATA.pb
+++ b/ofl/jersey20/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/scfried/soft-type-jersey"
   commit: "d8446c4c9c2ba14cf408c295be35213c006e19ff"
+  config_yaml: "sources/config-jersey20.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/jersey20charted/METADATA.pb
+++ b/ofl/jersey20charted/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/scfried/soft-type-jersey"
   commit: "d8446c4c9c2ba14cf408c295be35213c006e19ff"
+  config_yaml: "sources/config-jersey20charted.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/jersey25/METADATA.pb
+++ b/ofl/jersey25/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/scfried/soft-type-jersey"
   commit: "d8446c4c9c2ba14cf408c295be35213c006e19ff"
+  config_yaml: "sources/config-jersey25.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/jersey25charted/METADATA.pb
+++ b/ofl/jersey25charted/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/scfried/soft-type-jersey"
   commit: "afc20d521110d3ba6d6614d226896c74d62f8f2f"
+  config_yaml: "sources/config-jersey25charted.yaml"
   files {
     source_file: "fonts/ttf/Jersey25Charted-Regular.ttf"
     dest_file: "Jersey25Charted-Regular.ttf"

--- a/ofl/mavenpro/METADATA.pb
+++ b/ofl/mavenpro/METADATA.pb
@@ -24,6 +24,7 @@ axes {
 source {
   repository_url: "https://www.github.com/m4rc1e/mavenproFont"
   commit: "a694ee80d067e6f8cad700930e78ce395d4949e6"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "fonts/variable/MavenPro[wght].ttf"
     dest_file: "MavenPro[wght].ttf"

--- a/ofl/notosanskhojki/METADATA.pb
+++ b/ofl/notosanskhojki/METADATA.pb
@@ -18,6 +18,8 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/khojki"
+  commit: "02e25bf94664812076be4fa7dd1d688641e4bf8a"
+  config_yaml: "sources/config-sans-khojki.yaml"
   archive_url: "https://github.com/notofonts/khojki/releases/download/NotoSansKhojki-v2.005/NotoSansKhojki-v2.005.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notoserifkhojki/METADATA.pb
+++ b/ofl/notoserifkhojki/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/khojki"
+  commit: "02e25bf94664812076be4fa7dd1d688641e4bf8a"
+  config_yaml: "sources/config-serif-khojki.yaml"
   archive_url: "https://github.com/notofonts/khojki/releases/download/NotoSerifKhojki-v2.005/NotoSerifKhojki-v2.005.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/protestguerrilla/METADATA.pb
+++ b/ofl/protestguerrilla/METADATA.pb
@@ -21,6 +21,7 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/octaviopardo/Protest"
   commit: "094e74050a0547c8decd760b4f926321a5e72c6e"
+  config_yaml: "sources/config-Guerrilla.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/protestrevolution/METADATA.pb
+++ b/ofl/protestrevolution/METADATA.pb
@@ -21,6 +21,7 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/octaviopardo/Protest"
   commit: "094e74050a0547c8decd760b4f926321a5e72c6e"
+  config_yaml: "sources/config-Revolution.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/protestriot/METADATA.pb
+++ b/ofl/protestriot/METADATA.pb
@@ -21,6 +21,7 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/octaviopardo/Protest"
   commit: "094e74050a0547c8decd760b4f926321a5e72c6e"
+  config_yaml: "sources/config-Riot.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/proteststrike/METADATA.pb
+++ b/ofl/proteststrike/METADATA.pb
@@ -21,6 +21,7 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/octaviopardo/Protest"
   commit: "094e74050a0547c8decd760b4f926321a5e72c6e"
+  config_yaml: "sources/config-Strike.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/teko/METADATA.pb
+++ b/ofl/teko/METADATA.pb
@@ -24,6 +24,7 @@ axes {
 source {
   repository_url: "https://www.github.com/googlefonts/teko"
   commit: "6715caf853f342eef57ea367b6c2991cd3928398"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/yarndings12/METADATA.pb
+++ b/ofl/yarndings12/METADATA.pb
@@ -19,6 +19,7 @@ subsets: "symbols"
 source {
   repository_url: "https://github.com/scfried/soft-type-yarndings"
   commit: "31a5afb1007733ed93b7ade5b1eccc164fc75bca"
+  config_yaml: "sources/config-yarndings12.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/yarndings12charted/METADATA.pb
+++ b/ofl/yarndings12charted/METADATA.pb
@@ -19,6 +19,7 @@ subsets: "symbols"
 source {
   repository_url: "https://github.com/scfried/soft-type-yarndings"
   commit: "31a5afb1007733ed93b7ade5b1eccc164fc75bca"
+  config_yaml: "sources/config-yarndings12charted.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/yarndings20/METADATA.pb
+++ b/ofl/yarndings20/METADATA.pb
@@ -19,6 +19,7 @@ subsets: "symbols"
 source {
   repository_url: "https://github.com/scfried/soft-type-yarndings"
   commit: "31a5afb1007733ed93b7ade5b1eccc164fc75bca"
+  config_yaml: "sources/config-yarndings20.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/yarndings20charted/METADATA.pb
+++ b/ofl/yarndings20charted/METADATA.pb
@@ -19,6 +19,7 @@ subsets: "symbols"
 source {
   repository_url: "https://github.com/scfried/soft-type-yarndings"
   commit: "31a5afb1007733ed93b7ade5b1eccc164fc75bca"
+  config_yaml: "sources/config-yarndings20charted.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"


### PR DESCRIPTION
* Font families with full source info: 723 of 1901 (38.03% of GF Library)
* 28 more (1.47% more) than [yesterday](https://github.com/google/fonts/pull/9299)
* Progress is being tracked at https://docs.google.com/spreadsheets/d/1ao3k56FwQy6W0Ll5QbU_wpuKEvNPYcn8YyEU9_L8O4Q/edit?usp=sharing