### PR TITLE
Documenting Font Sources, 2025-04-01

### DIFF
--- a/ofl/42dotsans/METADATA.pb
+++ b/ofl/42dotsans/METADATA.pb
@@ -23,5 +23,7 @@ axes {
 primary_script: "Kore"
 source {
   repository_url: "https://github.com/42dot/42dot-Sans"
+  commit: "d23e87fe44d5b4f5afaa9dca9d5926d7c414d625"
   branch: "main"
+  config_yaml: "sources/config_variable.yaml"
 }

--- a/ofl/abhayalibre/METADATA.pb
+++ b/ofl/abhayalibre/METADATA.pb
@@ -54,7 +54,7 @@ subsets: "menu"
 subsets: "sinhala"
 source {
   repository_url: "https://github.com/mooniak/abhaya-libre-font"
-  commit: "edaabf89929778cb947bbd230a257c2a3bbd9979"
+  commit: "ade314aa678ceb44f892ed58169c6b270c775d02"
   config_yaml: "sources/config.yaml"
 }
 primary_script: "Sinh"

--- a/ofl/abhayalibre/config.yaml
+++ b/ofl/abhayalibre/config.yaml
@@ -1,0 +1,4 @@
+sources:
+  - sources/glyphs/Abhaya-Masters.glyphs
+buildStatic: true
+buildVariable: false

--- a/ofl/akshar/METADATA.pb
+++ b/ofl/akshar/METADATA.pb
@@ -24,6 +24,7 @@ axes {
 source {
   repository_url: "https://github.com/tallchai/akshar-type"
   commit: "0c6de5ef9cef264b3b3f958e772b3a371f92d083"
+  config_yaml: "sources/builder.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/alice/METADATA.pb
+++ b/ofl/alice/METADATA.pb
@@ -19,7 +19,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/cyrealtype/Alice"
-  commit: "19421efc21eeeb872773006539ddcd743fb72440"
+  commit: "13be04734d33464e627bd201d35aa9697feed289"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/alumnisans/METADATA.pb
+++ b/ofl/alumnisans/METADATA.pb
@@ -34,7 +34,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/alumni"
-  commit: "44a7998fa2bfa1b3e119983cdc565dd7f0f03bda"
+  commit: "28754a9295db605d4e4ffc7bf60b4a8301eef9ab"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/andadapro/METADATA.pb
+++ b/ofl/andadapro/METADATA.pb
@@ -32,6 +32,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/huertatipografica/Andada-Pro"
+  commit: "a0b87b947003dee6c615809d3eebc8c1334dc575"
+  config_yaml: "sources/build.yaml"
   files {
     source_file: "fonts/variable/AndadaPro[wght].ttf"
     dest_file: "AndadaPro[wght].ttf"

--- a/ofl/artifika/METADATA.pb
+++ b/ofl/artifika/METADATA.pb
@@ -16,7 +16,7 @@ subsets: "latin"
 subsets: "menu"
 source {
   repository_url: "https://github.com/cyrealtype/Artifika"
-  commit: "50137a4bf13c4918f78d4b566d14ae3dde703456"
+  commit: "c317fd292b4e15dc5f42f91c3ec9dff3f7654535"
   config_yaml: "sources/builder.yaml"
   files {
     source_file: "OFL.txt"

--- a/ofl/bakbakone/METADATA.pb
+++ b/ofl/bakbakone/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/bakbak"
+  commit: "b53b9c31c16f0021b7c206a57a8f04a4d382bc67"
   files {
     source_file: "fonts/ttf/BakbakOne-Regular.ttf"
     dest_file: "BakbakOne-Regular.ttf"
@@ -27,6 +28,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/builder.yaml"
 }
 primary_script: "Deva"
 stroke: "SANS_SERIF"

--- a/ofl/calsans/METADATA.pb
+++ b/ofl/calsans/METADATA.pb
@@ -28,5 +28,6 @@ source {
     dest_file: "CalSans-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/cascadiacode/METADATA.pb
+++ b/ofl/cascadiacode/METADATA.pb
@@ -39,4 +39,5 @@ axes {
 }
 source {
   repository_url: "https://github.com/microsoft/cascadia-code"
+  commit: "56bcca3f2c1e4cb19458954f0e2bb4635960df91"
 }

--- a/ofl/cascadiacode/config.yaml
+++ b/ofl/cascadiacode/config.yaml
@@ -1,0 +1,4 @@
+buildVariable: true
+sources:
+  - sources/CascadiaCode_variable.designspace
+  - sources/CascadiaCode_variable_italic.designspace

--- a/ofl/cascadiamono/METADATA.pb
+++ b/ofl/cascadiamono/METADATA.pb
@@ -39,4 +39,5 @@ axes {
 }
 source {
   repository_url: "https://github.com/microsoft/cascadia-code"
+  commit: "56bcca3f2c1e4cb19458954f0e2bb4635960df91"
 }

--- a/ofl/cascadiamono/config.yaml
+++ b/ofl/cascadiamono/config.yaml
@@ -1,0 +1,4 @@
+buildVariable: true
+sources:
+  - sources/CascadiaCode_variable.designspace
+  - sources/CascadiaCode_variable_italic.designspace

--- a/ofl/eczar/METADATA.pb
+++ b/ofl/eczar/METADATA.pb
@@ -26,6 +26,7 @@ axes {
 source {
   repository_url: "https://github.com/rosettatype/eczar"
   commit: "f248ec9c0c5e3a9442d22824cc1cba6c713725d5"
+  config_yaml: "sources/builder.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/gemunulibre/METADATA.pb
+++ b/ofl/gemunulibre/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/mooniak/gemunu-libre-font"
+  commit: "8a8867dd893adb9e82baef9d85ccbc3764a55b0c"
+  config_yaml: "sources/builder.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/georama/METADATA.pb
+++ b/ofl/georama/METADATA.pb
@@ -37,6 +37,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/productiontype/Georama"
+  commit: "1b063b6256c228a56d13b8b2f8f1d807f41467f8"
+  config_yaml: "sources/builder.yaml"
   files {
     source_file: "ofl.txt"
     dest_file: "OFL.txt"

--- a/ofl/lexend/METADATA.pb
+++ b/ofl/lexend/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/lexend"
+  commit: "20491885ca2cf7ffc556432973e7bdbc701952b5"
+  config_yaml: "sources/lexend.yaml"
   files {
     source_file: "fonts/lexend/variable/Lexend[wght].ttf"
     dest_file: "Lexend[wght].ttf"

--- a/ofl/lexenddeca/METADATA.pb
+++ b/ofl/lexenddeca/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/lexend"
+  commit: "20491885ca2cf7ffc556432973e7bdbc701952b5"
+  config_yaml: "sources/deca.yaml"
   files {
     source_file: "fonts/deca/variable/LexendDeca[wght].ttf"
     dest_file: "LexendDeca[wght].ttf"

--- a/ofl/lexendexa/METADATA.pb
+++ b/ofl/lexendexa/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/lexend"
+  commit: "20491885ca2cf7ffc556432973e7bdbc701952b5"
+  config_yaml: "sources/exa.yaml"
   files {
     source_file: "fonts/exa/variable/LexendExa[wght].ttf"
     dest_file: "LexendExa[wght].ttf"

--- a/ofl/lexendgiga/METADATA.pb
+++ b/ofl/lexendgiga/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/lexend"
+  commit: "20491885ca2cf7ffc556432973e7bdbc701952b5"
+  config_yaml: "sources/giga.yaml"
   files {
     source_file: "fonts/giga/variable/LexendGiga[wght].ttf"
     dest_file: "LexendGiga[wght].ttf"

--- a/ofl/lexendmega/METADATA.pb
+++ b/ofl/lexendmega/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/lexend"
+  commit: "20491885ca2cf7ffc556432973e7bdbc701952b5"
+  config_yaml: "sources/mega.yaml"
   files {
     source_file: "fonts/mega/variable/LexendMega[wght].ttf"
     dest_file: "LexendMega[wght].ttf"

--- a/ofl/lexendpeta/METADATA.pb
+++ b/ofl/lexendpeta/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/lexend"
+  commit: "20491885ca2cf7ffc556432973e7bdbc701952b5"
+  config_yaml: "sources/peta.yaml"
   files {
     source_file: "fonts/peta/variable/LexendPeta[wght].ttf"
     dest_file: "LexendPeta[wght].ttf"

--- a/ofl/lexendtera/METADATA.pb
+++ b/ofl/lexendtera/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/lexend"
+  commit: "20491885ca2cf7ffc556432973e7bdbc701952b5"
+  config_yaml: "sources/tera.yaml"
   files {
     source_file: "fonts/tera/variable/LexendTera[wght].ttf"
     dest_file: "LexendTera[wght].ttf"

--- a/ofl/lexendzetta/METADATA.pb
+++ b/ofl/lexendzetta/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/googlefonts/lexend"
+  commit: "20491885ca2cf7ffc556432973e7bdbc701952b5"
+  config_yaml: "sources/zetta.yaml"
   files {
     source_file: "fonts/zetta/variable/LexendZetta[wght].ttf"
     dest_file: "LexendZetta[wght].ttf"

--- a/ofl/nationalpark/METADATA.pb
+++ b/ofl/nationalpark/METADATA.pb
@@ -33,5 +33,6 @@ source {
     dest_file: "NationalPark[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/playpensansarabic/METADATA.pb
+++ b/ofl/playpensansarabic/METADATA.pb
@@ -25,7 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playpen-Sans"
-  commit: "c85bb380b56b2009e7c9bff11f573a3028034161"
+  commit: "a4829cda744ea7e9ae73c14468a8a5672809f525"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -35,7 +35,7 @@ source {
     dest_file: "PlaypenSansArabic[wght].ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yml"
+  config_yaml: "sources/config-Arabic.yaml"
 }
 minisite_url: "https://www.type-together.com/making-playpen-sans"
 primary_script: "Arab"

--- a/ofl/playpensansdeva/METADATA.pb
+++ b/ofl/playpensansdeva/METADATA.pb
@@ -24,7 +24,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playpen-Sans"
-  commit: "c85bb380b56b2009e7c9bff11f573a3028034161"
+  commit: "12483714650a12591e1914cad7d123e2cadc45e9"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -34,7 +34,7 @@ source {
     dest_file: "PlaypenSansDeva[wght].ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yml"
+  config_yaml: "sources/config-Deva.yaml"
 }
 minisite_url: "https://www.type-together.com/making-playpen-sans"
 primary_script: "Deva"

--- a/ofl/playpensanshebrew/METADATA.pb
+++ b/ofl/playpensanshebrew/METADATA.pb
@@ -25,7 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playpen-Sans"
-  commit: "c85bb380b56b2009e7c9bff11f573a3028034161"
+  commit: "12483714650a12591e1914cad7d123e2cadc45e9"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -35,7 +35,7 @@ source {
     dest_file: "PlaypenSansHebrew[wght].ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yml"
+  config_yaml: "sources/config-Hebrew.yaml"
 }
 minisite_url: "https://www.type-together.com/making-playpen-sans"
 primary_script: "Hebr"

--- a/ofl/playpensansthai/METADATA.pb
+++ b/ofl/playpensansthai/METADATA.pb
@@ -25,7 +25,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/TypeTogether/Playpen-Sans"
-  commit: "c85bb380b56b2009e7c9bff11f573a3028034161"
+  commit: "edaffec145577d12d6b5439ecb954b9f76a4a9a5"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
@@ -35,7 +35,7 @@ source {
     dest_file: "PlaypenSansThai[wght].ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yml"
+  config_yaml: "sources/config-Thai.yaml"
 }
 minisite_url: "https://www.type-together.com/making-playpen-sans"
 primary_script: "Thai"

--- a/ofl/redditmono/METADATA.pb
+++ b/ofl/redditmono/METADATA.pb
@@ -24,6 +24,7 @@ axes {
 source {
   repository_url: "https://github.com/reddit/redditsans"
   commit: "60e19b50bde6de34b695591a8a047a6a3618a37c"
+  config_yaml: "sources/mono.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/redditsans/METADATA.pb
+++ b/ofl/redditsans/METADATA.pb
@@ -33,6 +33,7 @@ axes {
 source {
   repository_url: "https://github.com/reddit/redditsans"
   commit: "60e19b50bde6de34b695591a8a047a6a3618a37c"
+  config_yaml: "sources/sans.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/redditsanscondensed/METADATA.pb
+++ b/ofl/redditsanscondensed/METADATA.pb
@@ -24,6 +24,7 @@ axes {
 source {
   repository_url: "https://github.com/reddit/redditsans"
   commit: "60e19b50bde6de34b695591a8a047a6a3618a37c"
+  config_yaml: "sources/sanscondensed.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/specialgothic/METADATA.pb
+++ b/ofl/specialgothic/METADATA.pb
@@ -27,5 +27,6 @@ source {
     dest_file: "SpecialGothic-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/specialgothiccondensedone/METADATA.pb
+++ b/ofl/specialgothiccondensedone/METADATA.pb
@@ -27,5 +27,6 @@ source {
     dest_file: "SpecialGothicCondensedOne-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-condensed.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/specialgothicexpandedone/METADATA.pb
+++ b/ofl/specialgothicexpandedone/METADATA.pb
@@ -27,5 +27,6 @@ source {
     dest_file: "SpecialGothicExpandedOne-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config-expanded.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/winkyrough/METADATA.pb
+++ b/ofl/winkyrough/METADATA.pb
@@ -32,6 +32,7 @@ axes {
 source {
   repository_url: "https://github.com/typofactur/winkyrough"
   commit: "505f77bdee3b09d4290a9a6813d1eded2dea81b5"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/yaldevi/METADATA.pb
+++ b/ofl/yaldevi/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/mooniak/yaldevi-font"
+  commit: "187eddeb8dae00acd11f2b96e0c74ea3d70ed302"
+  config_yaml: "sources/builder.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"


### PR DESCRIPTION
originally posted 6 days ago at https://github.com/google/fonts/pull/9293
----

* Font families with full source info: 683 of 1901 (35.93% of GF Library)
* Progress is being tracked at https://docs.google.com/spreadsheets/d/1ao3k56FwQy6W0Ll5QbU_wpuKEvNPYcn8YyEU9_L8O4Q/edit?usp=sharing