### PR TITLE
sources info for Stick No Bills

### DIFF
--- a/ofl/sticknobills/METADATA.pb
+++ b/ofl/sticknobills/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/mooniak/stick-no-bills-font"
+  commit: "b7d7f0ce678b7785a3271586d9e59f26dc0f6e7e"
+  config_yaml: "sources/builder.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"


### PR DESCRIPTION
This one has an ERROR on the **ligature_carets** check which is a just fontbakery bug.

I've split out this commit from https://github.com/google/fonts/pull/9317 so that we can get a clean green build on that larger PR while here we can more safely merge this single family metadata update while ignoring the silly fontbakery bug. 

(PR #3571)