### PR TITLE
Documenting Font Sources, 2025-04-09

### DIFF
--- a/ofl/notosansadlam/METADATA.pb
+++ b/ofl/notosansadlam/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/adlam"
+  commit: "581ccd2bf966d0b79a5285be7ea328f112beda7e"
+  config_yaml: "sources/config-sans-adlam.yaml"
   archive_url: "https://github.com/notofonts/adlam/releases/download/NotoSansAdlam-v3.001/NotoSansAdlam-v3.001.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notosansadlamunjoined/METADATA.pb
+++ b/ofl/notosansadlamunjoined/METADATA.pb
@@ -24,6 +24,7 @@ axes {
 source {
   repository_url: "https://github.com/notofonts/adlam"
   commit: "66c3f0126b2a54f51f6a902d5a33106a833c91d8"
+  config_yaml: "sources/config-sans-adlam-unjoined.yaml"
   archive_url: "https://github.com/notofonts/adlam/releases/download/NotoSansAdlamUnjoined-v3.003/NotoSansAdlamUnjoined-v3.003.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notosansgeorgian/METADATA.pb
+++ b/ofl/notosansgeorgian/METADATA.pb
@@ -32,6 +32,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/georgian"
+  commit: "c02e5483c2dd63c5cf223845010ebd6e6dc56aec"
+  config_yaml: "sources/config-sans-georgian.yaml"
   archive_url: "https://github.com/notofonts/georgian/releases/download/NotoSansGeorgian-v2.005/NotoSansGeorgian-v2.005.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notosanslao/METADATA.pb
+++ b/ofl/notosanslao/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/lao"
+  commit: "ab77daf4d8d6d9564da2dae84ae31bd9c971090f"
+  config_yaml: "sources/config-sans-lao.yaml"
   archive_url: "https://github.com/notofonts/lao/releases/download/NotoSansLao-v2.003/NotoSansLao-v2.003.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notosanslaolooped/METADATA.pb
+++ b/ofl/notosanslaolooped/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/lao"
+  commit: "ab77daf4d8d6d9564da2dae84ae31bd9c971090f"
+  config_yaml: "sources/config-sans-lao-looped.yaml"
   archive_url: "https://github.com/notofonts/lao/releases/download/NotoSansLaoLooped-v1.002/NotoSansLaoLooped-v1.002.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notoserifgeorgian/METADATA.pb
+++ b/ofl/notoserifgeorgian/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/georgian"
+  commit: "d0d6ca54c3809bdb8f20bbbd46760d068d2bfe0e"
+  config_yaml: "sources/config-serif-georgian.yaml"
   archive_url: "https://github.com/notofonts/georgian/releases/download/NotoSerifGeorgian-v2.003/NotoSerifGeorgian-v2.003.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notoseriflao/METADATA.pb
+++ b/ofl/notoseriflao/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/lao"
+  commit: "ab77daf4d8d6d9564da2dae84ae31bd9c971090f"
+  config_yaml: "sources/config-serif-lao.yaml"
   archive_url: "https://github.com/notofonts/lao/releases/download/NotoSerifLao-v2.003/NotoSerifLao-v2.003.zip"
   files {
     source_file: "ARTICLE.en_us.html"


### PR DESCRIPTION
* Font families with full source info: 730 of 1901 (38.40% of GF Library)
* 7 more (0.37% more) than [previous batch](https://github.com/google/fonts/pull/9318)
* Progress is being tracked at https://docs.google.com/spreadsheets/d/1ao3k56FwQy6W0Ll5QbU_wpuKEvNPYcn8YyEU9_L8O4Q/edit?usp=sharing