### PR TITLE
Fixed broken link to Naipe Foundry website in designer profile (#9371)

### DIFF
--- a/catalog/designers/alvarofranca/bio.html
+++ b/catalog/designers/alvarofranca/bio.html
@@ -1,2 +1,2 @@
 <p>Álvaro Franca (Rio de Janeiro, 1991) has designed type since 2013. A graphic design graduate of ESDI (Rio de Janeiro), he worked at Hipertipo and Dalton Maag before completing Typeface Design masters degrees in Barcelona and Antwerp. Currently, he is Type Director at Vasava Studio, founder of Type Thursday Barcelona and the founder and of Naipe Foundry which he runs with Felipe Casaprima since 2018.</p>
-<p><a href="https://www.naipe.xyz">naipe.xyz</a></p>
+<p><a href="https://store.naipefoundry.com">store.naipefoundry.com</a></p>

--- a/catalog/designers/naipefoundry/bio.html
+++ b/catalog/designers/naipefoundry/bio.html
@@ -1,2 +1,2 @@
 <p>Naipe Foundry is the type design, lettering & font production practice of Álvaro Franca & Felipe Casaprima. Out of Rio de Janeiro, but based in Barcelona, Perth and everywhere in between, Naipe creates custom and retail typefaces for fun and for profit, ideally both. The company aims to tell latin american stories through letterforms, with a strong focus on Brazilian history and culture.</p>
-<p><a href="www.naipe.xyz">naipe.xyz</a>
+<p><a href="https://store.naipefoundry.com">store.naipefoundry.com</a>


### PR DESCRIPTION
**Issue (#9371) :**
Under the profiles of Alvaro Franca and Naipe Foundry the url is naipe.xyz which is now dead. It should be replaced with https://store.naipefoundry.com/

**Fixed :**
Changed the url in the profiles of Alvaro Franca and Naipe Foundry from naipe.xyz to store.naipefoundry.com. The link is working effectively.