### PR TITLE
Documenting Font Sources, 2025-05-06

### DIFF
--- a/ofl/notorashihebrew/METADATA.pb
+++ b/ofl/notorashihebrew/METADATA.pb
@@ -25,6 +25,7 @@ axes {
 source {
   repository_url: "https://github.com/notofonts/hebrew"
   commit: "02fcd18e295ebadcda7bcaa774c107538fe2a5ee"
+  config_yaml: "sources/config-rashi-hebrew.yaml"
   archive_url: "https://github.com/notofonts/hebrew/releases/download/NotoRashiHebrew-v1.007/NotoRashiHebrew-v1.007.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notosans/METADATA.pb
+++ b/ofl/notosans/METADATA.pb
@@ -43,6 +43,7 @@ axes {
 source {
   repository_url: "https://github.com/notofonts/latin-greek-cyrillic"
   commit: "c4a321e123e4d4ff315f57f4e0adf294fe3a95be"
+  config_yaml: "sources/config-sans.yaml"
   archive_url: "https://github.com/notofonts/latin-greek-cyrillic/releases/download/NotoSans-v2.015/NotoSans-v2.015.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notosansarabic/METADATA.pb
+++ b/ofl/notosansarabic/METADATA.pb
@@ -31,6 +31,8 @@ axes {
 source {
   repository_url: "https://github.com/notofonts/arabic"
   archive_url: "https://github.com/notofonts/arabic/releases/download/NotoSansArabic-v2.012/NotoSansArabic-v2.012.zip"
+  commit: "6c8320740db19efbb3127c3697b0ee5d0fa62319"
+  config_yaml: "sources/config-sans-arabic.yaml"
   files {
     source_file: "ARTICLE.en_us.html"
     dest_file: "article/ARTICLE.en_us.html"

--- a/ofl/notosansbengali/METADATA.pb
+++ b/ofl/notosansbengali/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/bengali"
+  commit: "020a5701f6fc6a363d5eccbae45e37714c0ad686"
+  config_yaml: "sources/config-sans-bengali.yaml"
   archive_url: "https://github.com/notofonts/bengali/releases/download/NotoSansBengali-v2.003/NotoSansBengali-v2.003.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notosansdevanagari/METADATA.pb
+++ b/ofl/notosansdevanagari/METADATA.pb
@@ -30,6 +30,7 @@ source {
   repository_url: "https://github.com/notofonts/devanagari"
   commit: "bb8d2566a1708ef2dcc6396ee2eb261a18967f76"
   archive_url: "https://github.com/notofonts/devanagari/releases/download/NotoSansDevanagari-v2.006/NotoSansDevanagari-v2.006.zip"
+  config_yaml: "sources/config-sans-devanagari.yaml"
   files {
     source_file: "DESCRIPTION.en_us.html"
     dest_file: "DESCRIPTION.en_us.html"

--- a/ofl/notosansethiopic/METADATA.pb
+++ b/ofl/notosansethiopic/METADATA.pb
@@ -28,7 +28,9 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/ethiopic"
+  commit: "1cc6933c58b7c42bbade15d6c7173897c24759e3"
   archive_url: "https://github.com/notofonts/ethiopic/releases/download/NotoSansEthiopic-v2.102/NotoSansEthiopic-v2.102.zip"
+  config_yaml: "sources/config-sans-ethiopic.yaml"
   files {
     source_file: "ARTICLE.en_us.html"
     dest_file: "article/ARTICLE.en_us.html"

--- a/ofl/notosansgrantha/METADATA.pb
+++ b/ofl/notosansgrantha/METADATA.pb
@@ -20,6 +20,7 @@ source {
   repository_url: "https://github.com/notofonts/grantha"
   commit: "6bb911fa061ee18766c677ffcbd844ac1041eb81"
   archive_url: "https://github.com/notofonts/grantha/releases/download/NotoSansGrantha-v2.005/NotoSansGrantha-v2.005.zip"
+  config_yaml: "sources/config-sans-grantha.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/notosansgujarati/METADATA.pb
+++ b/ofl/notosansgujarati/METADATA.pb
@@ -30,6 +30,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/gujarati"
+  commit: "825b7f9e39b0eea6f02a4646ffa4ce18d482250a"
+  config_yaml: "sources/config-sans-gujarati.yaml"
   archive_url: "https://github.com/notofonts/gujarati/releases/download/NotoSansGujarati-v2.106/NotoSansGujarati-v2.106.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notosansgurmukhi/METADATA.pb
+++ b/ofl/notosansgurmukhi/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/gurmukhi"
+  commit: "231c5c6e9c622c4ef3792ead7a91045af0ee610a"
+  config_yaml: "sources/config-sans-gurmukhi.yaml"
   archive_url: "https://github.com/notofonts/gurmukhi/releases/download/NotoSansGurmukhi-v2.004/NotoSansGurmukhi-v2.004.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notosanshebrew/METADATA.pb
+++ b/ofl/notosanshebrew/METADATA.pb
@@ -30,7 +30,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/hebrew"
-  commit: "036f3206f67caac235cf8546a7751d3440771a7e"
+  commit: "d2ce986faa9c149e8961c7bceddb8e376760541a"
+  config_yaml: "sources/config-sans-hebrew.yaml"
   archive_url: "https://github.com/notofonts/hebrew/releases/download/NotoSansHebrew-v3.001/NotoSansHebrew-v3.001.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notosanskannada/METADATA.pb
+++ b/ofl/notosanskannada/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/kannada"
+  commit: "6387faa16123c9becca4f0f3ca095189de5c61da"
+  config_yaml: "sources/config-sans-kannada.yaml"
   archive_url: "https://github.com/notofonts/kannada/releases/download/NotoSansKannada-v2.005/NotoSansKannada-v2.005.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notosanskhmer/METADATA.pb
+++ b/ofl/notosanskhmer/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/khmer"
+  commit: "5d2251a4e32635c6657967a157759aac7a662fc9"
+  config_yaml: "sources/config-sans-khmer.yaml"
   archive_url: "https://github.com/notofonts/khmer/releases/download/NotoSansKhmer-v2.004/NotoSansKhmer-v2.004.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notosansmalayalam/METADATA.pb
+++ b/ofl/notosansmalayalam/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/malayalam"
+  commit: "ea3898d22b4659221728ad8a854c076c57e33836"
+  config_yaml: "sources/config-sans-malayalam.yaml"
   archive_url: "https://github.com/notofonts/malayalam/releases/download/NotoSansMalayalam-v2.104/NotoSansMalayalam-v2.104.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notosansmath/METADATA.pb
+++ b/ofl/notosansmath/METADATA.pb
@@ -18,7 +18,8 @@ subsets: "math"
 subsets: "menu"
 source {
   repository_url: "https://www.github.com/notofonts/math"
-  commit: "00e9941d95b2a355399a66f3990ffde6e4985676"
+  commit: "4b78263eac2301b04367d600a07b521cfbff0867"
+  config_yaml: "sources/config-sans-math.yaml"
   archive_url: "https://github.com/notofonts/math/releases/download/NotoSansMath-v3.000/NotoSansMath-v3.000.zip"
   files {
     source_file: "fonts/ttf/NotoSansMath-Regular.ttf"

--- a/ofl/notosansmyanmar/METADATA.pb
+++ b/ofl/notosansmyanmar/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/myanmar"
+  commit: "bd348056676051ac9076de5737436f0308b0de29"
+  config_yaml: "sources/config-sans-myanmar.yaml"
   archive_url: "https://github.com/notofonts/myanmar/releases/download/NotoSansMyanmar-v2.107/NotoSansMyanmar-v2.107.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notosansnko/METADATA.pb
+++ b/ofl/notosansnko/METADATA.pb
@@ -18,6 +18,8 @@ subsets: "menu"
 subsets: "nko"
 source {
   repository_url: "https://github.com/notofonts/nko"
+  commit: "a5db712e48059443e873e60805458924ec36f87a"
+  config_yaml: "sources/config-sans-nko.yaml"
   archive_url: "https://github.com/notofonts/nko/releases/download/NotoSansNKo-v2.004/NotoSansNKo-v2.004.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notosansnkounjoined/METADATA.pb
+++ b/ofl/notosansnkounjoined/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/nko"
+  commit: "a5db712e48059443e873e60805458924ec36f87a"
+  config_yaml: "sources/config-sans-nko-unjoined.yaml"
   archive_url: "https://github.com/notofonts/nko/releases/download/NotoSansNKoUnjoined-v2.004/NotoSansNKoUnjoined-v2.004.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notosansnushu/METADATA.pb
+++ b/ofl/notosansnushu/METADATA.pb
@@ -18,6 +18,8 @@ subsets: "menu"
 subsets: "nushu"
 source {
   repository_url: "https://github.com/notofonts/nushu"
+  commit: "933f7be1e6083e9ead39e560fa0b526d491bec4b"
+  config_yaml: "sources/config-sans-nushu.yaml"
   archive_url: "https://github.com/notofonts/nushu/releases/download/NotoSansNushu-v1.003/NotoSansNushu-v1.003.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notosansoriya/METADATA.pb
+++ b/ofl/notosansoriya/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/oriya"
+  commit: "97abab82ec512f8a4a98c389352f194a03385ce2"
+  config_yaml: "sources/config-sans-oriya.yaml"
   archive_url: "https://github.com/notofonts/oriya/releases/download/NotoSansOriya-v2.006/NotoSansOriya-v2.006.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notosanssinhala/METADATA.pb
+++ b/ofl/notosanssinhala/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/sinhala"
+  commit: "66e5a2ed9797e575222d6e7c5b3710c7bf68be79"
+  config_yaml: "sources/config-sans-sinhala.yaml"
   archive_url: "https://github.com/notofonts/sinhala/releases/download/NotoSansSinhala-v2.006/NotoSansSinhala-v2.006.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notosanssymbols/METADATA.pb
+++ b/ofl/notosanssymbols/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/symbols"
+  commit: "b61fa7f86fb7d4163ee11d46d0977393f98d4f7a"
+  config_yaml: "sources/config-sans-symbols.yaml"
   archive_url: "https://github.com/notofonts/symbols/releases/download/NotoSansSymbols-v2.003/NotoSansSymbols-v2.003.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notosanssymbols2/METADATA.pb
+++ b/ofl/notosanssymbols2/METADATA.pb
@@ -21,6 +21,8 @@ subsets: "menu"
 subsets: "symbols"
 source {
   repository_url: "https://github.com/notofonts/symbols"
+  commit: "25b00f0d3f40873a005287514ba2a48558655314"
+  config_yaml: "sources/config-sans-symbols2.yaml"
   archive_url: "https://github.com/notofonts/symbols/releases/download/NotoSansSymbols2-v2.008/NotoSansSymbols2-v2.008.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notosanssyriac/METADATA.pb
+++ b/ofl/notosanssyriac/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/syriac"
+  commit: "baaf78934b2f547ed510ab5b4ca1632796385815"
+  config_yaml: "sources/config-sans-syriac.yaml"
   archive_url: "https://github.com/notofonts/syriac/releases/download/NotoSansSyriac-v3.000/NotoSansSyriac-v3.000.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notosanssyriaceastern/METADATA.pb
+++ b/ofl/notosanssyriaceastern/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/syriac"
+  commit: "11c7d5208e347bf59e1064253d3ec5916c1c2314"
+  config_yaml: "sources/config-sans-syriac-eastern.yaml"
   archive_url: "https://github.com/notofonts/syriac/releases/download/NotoSansSyriacEastern-v3.001/NotoSansSyriacEastern-v3.001.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notosanstamil/METADATA.pb
+++ b/ofl/notosanstamil/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/tamil"
+  commit: "626575fa0c68c81dee17a0342003c08c0ab8375e"
+  config_yaml: "sources/config-sans-tamil.yaml"
   archive_url: "https://github.com/notofonts/tamil/releases/download/NotoSansTamil-v2.004/NotoSansTamil-v2.004.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notosanstamilsupplement/METADATA.pb
+++ b/ofl/notosanstamilsupplement/METADATA.pb
@@ -18,6 +18,8 @@ subsets: "menu"
 subsets: "tamil-supplement"
 source {
   repository_url: "https://github.com/notofonts/tamil"
+  commit: "27af016af77aed49475014b9cfe2a46b8fe71966"
+  config_yaml: "sources/config-sans-tamil-supplement.yaml"
   archive_url: "https://github.com/notofonts/tamil/releases/download/NotoSansTamilSupplement-v2.001/NotoSansTamilSupplement-v2.001.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notosanstelugu/METADATA.pb
+++ b/ofl/notosanstelugu/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/telugu"
+  commit: "af5b949ed1906ead47608577d092fb013d3145d3"
+  config_yaml: "sources/config-sans-telugu.yaml"
   archive_url: "https://github.com/notofonts/telugu/releases/download/NotoSansTelugu-v2.005/NotoSansTelugu-v2.005.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notosansthai/METADATA.pb
+++ b/ofl/notosansthai/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/thai"
+  commit: "f8f3f024703f9d939d02f4e2fe16f1d5a39ca963"
+  config_yaml: "sources/config-sans-thai.yaml"
   archive_url: "https://github.com/notofonts/thai/releases/download/NotoSansThai-v2.002/NotoSansThai-v2.002.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notosansthailooped/METADATA.pb
+++ b/ofl/notosansthailooped/METADATA.pb
@@ -29,6 +29,7 @@ axes {
 source {
   repository_url: "https://github.com/notofonts/thai"
   commit: "c62000b1b2328aa5e08470c1924ac9987fdb83b9"
+  config_yaml: "sources/config-sans-thai-looped.yaml"
   archive_url: "https://github.com/notofonts/thai/releases/download/NotoSansThaiLooped-v2.000/NotoSansThaiLooped-v2.000.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notosansvithkuqi/METADATA.pb
+++ b/ofl/notosansvithkuqi/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/vithkuqi"
+  commit: "b1538fae374bd36a28c35d504ecea658dd015aaf"
+  config_yaml: "sources/config-sans-vithkuqi.yaml"
   archive_url: "https://github.com/notofonts/vithkuqi/releases/download/NotoSansVithkuqi-v1.001/NotoSansVithkuqi-v1.001.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notoserif/METADATA.pb
+++ b/ofl/notoserif/METADATA.pb
@@ -42,7 +42,9 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/latin-greek-cyrillic"
-  archive_url: "https://github.com/notofonts/latin-greek-cyrillic/releases/download/NotoSerif-v2.013/NotoSerif-v2.013.zip"
+  commit: "c4a321e123e4d4ff315f57f4e0adf294fe3a95be"
+  config_yaml: "sources/config-serif.yaml"
+  archive_url: "https://github.com/notofonts/latin-greek-cyrillic/releases/download/NotoSerif-v2.015/NotoSerif-v2.015.zip"
   files {
     source_file: "ARTICLE.en_us.html"
     dest_file: "article/ARTICLE.en_us.html"

--- a/ofl/notoserifbengali/METADATA.pb
+++ b/ofl/notoserifbengali/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/bengali"
+  commit: "020a5701f6fc6a363d5eccbae45e37714c0ad686"
+  config_yaml: "sources/config-serif-bengali.yaml"
   archive_url: "https://github.com/notofonts/bengali/releases/download/NotoSerifBengali-v2.003/NotoSerifBengali-v2.003.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notoserifdevanagari/METADATA.pb
+++ b/ofl/notoserifdevanagari/METADATA.pb
@@ -30,6 +30,7 @@ source {
   repository_url: "https://github.com/notofonts/devanagari"
   commit: "bb8d2566a1708ef2dcc6396ee2eb261a18967f76"
   archive_url: "https://github.com/notofonts/devanagari/releases/download/NotoSerifDevanagari-v2.006/NotoSerifDevanagari-v2.006.zip"
+  config_yaml: "sources/config-serif-devanagari.yaml"
   files {
     source_file: "DESCRIPTION.en_us.html"
     dest_file: "DESCRIPTION.en_us.html"

--- a/ofl/notoserifethiopic/METADATA.pb
+++ b/ofl/notoserifethiopic/METADATA.pb
@@ -28,7 +28,9 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/ethiopic"
+  commit: "1cc6933c58b7c42bbade15d6c7173897c24759e3"
   archive_url: "https://github.com/notofonts/ethiopic/releases/download/NotoSerifEthiopic-v2.102/NotoSerifEthiopic-v2.102.zip"
+  config_yaml: "sources/config-serif-ethiopic.yaml"
   files {
     source_file: "ARTICLE.en_us.html"
     dest_file: "article/ARTICLE.en_us.html"

--- a/ofl/notoserifgrantha/METADATA.pb
+++ b/ofl/notoserifgrantha/METADATA.pb
@@ -20,6 +20,7 @@ source {
   repository_url: "https://github.com/notofonts/grantha"
   commit: "6bb911fa061ee18766c677ffcbd844ac1041eb81"
   archive_url: "https://github.com/notofonts/grantha/releases/download/NotoSerifGrantha-v2.005/NotoSerifGrantha-v2.005.zip"
+  config_yaml: "sources/config-serif-grantha.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/notoserifgujarati/METADATA.pb
+++ b/ofl/notoserifgujarati/METADATA.pb
@@ -25,6 +25,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/gujarati"
+  commit: "825b7f9e39b0eea6f02a4646ffa4ce18d482250a"
+  config_yaml: "sources/config-serif-gujarati.yaml"
   archive_url: "https://github.com/notofonts/gujarati/releases/download/NotoSerifGujarati-v2.106/NotoSerifGujarati-v2.106.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notoserifgurmukhi/METADATA.pb
+++ b/ofl/notoserifgurmukhi/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/gurmukhi"
+  commit: "231c5c6e9c622c4ef3792ead7a91045af0ee610a"
+  config_yaml: "sources/config-serif-gurmukhi.yaml"
   archive_url: "https://github.com/notofonts/gurmukhi/releases/download/NotoSerifGurmukhi-v2.004/NotoSerifGurmukhi-v2.004.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notoserifhebrew/METADATA.pb
+++ b/ofl/notoserifhebrew/METADATA.pb
@@ -29,6 +29,7 @@ axes {
 source {
   repository_url: "https://github.com/notofonts/hebrew"
   commit: "02fcd18e295ebadcda7bcaa774c107538fe2a5ee"
+  config_yaml: "sources/config-serif-hebrew.yaml"
   archive_url: "https://github.com/notofonts/hebrew/releases/download/NotoSerifHebrew-v2.004/NotoSerifHebrew-v2.004.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notoserifkannada/METADATA.pb
+++ b/ofl/notoserifkannada/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/kannada"
+  commit: "b0e78acf3176fb4d30c95ece3825ef8561dbd7aa"
+  config_yaml: "sources/config-serif-kannada.yaml"
   archive_url: "https://github.com/notofonts/kannada/releases/download/NotoSerifKannada-v2.005/NotoSerifKannada-v2.005.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notoserifkhitansmallscript/METADATA.pb
+++ b/ofl/notoserifkhitansmallscript/METADATA.pb
@@ -18,6 +18,8 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/notofonts/khitan-small-script"
+  commit: "8769c8b092f7a228b69fe7420f8c714abb0bcd44"
+  config_yaml: "sources/config-serif.yaml"
   archive_url: "https://github.com/notofonts/khitan-small-script/releases/download/NotoSerifKhitanSmallScript-v1.000/NotoSerifKhitanSmallScript-v1.000.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notoserifkhmer/METADATA.pb
+++ b/ofl/notoserifkhmer/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/khmer"
+  commit: "5d2251a4e32635c6657967a157759aac7a662fc9"
+  config_yaml: "sources/config-serif-khmer.yaml"
   archive_url: "https://github.com/notofonts/khmer/releases/download/NotoSerifKhmer-v2.004/NotoSerifKhmer-v2.004.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notoserifmalayalam/METADATA.pb
+++ b/ofl/notoserifmalayalam/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/malayalam"
+  commit: "ea3898d22b4659221728ad8a854c076c57e33836"
+  config_yaml: "sources/config-serif-malayalam.yaml"
   archive_url: "https://github.com/notofonts/malayalam/releases/download/NotoSerifMalayalam-v2.104/NotoSerifMalayalam-v2.104.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notoseriforiya/METADATA.pb
+++ b/ofl/notoseriforiya/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/oriya"
+  commit: "795268df4e01d7869805c7af179e5038568212e9"
+  config_yaml: "sources/config-serif-oriya.yaml"
   archive_url: "https://github.com/notofonts/oriya/releases/download/NotoSerifOriya-v1.051/NotoSerifOriya-v1.051.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/notoserifsinhala/METADATA.pb
+++ b/ofl/notoserifsinhala/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/sinhala"
+  commit: "add62c1ebbbd54bcb291eb30aeea22400f839bfa"
+  config_yaml: "sources/config-serif-sinhala.yaml"
   archive_url: "https://github.com/notofonts/sinhala/releases/download/NotoSerifSinhala-v2.007/NotoSerifSinhala-v2.007.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notoseriftamil/METADATA.pb
+++ b/ofl/notoseriftamil/METADATA.pb
@@ -37,6 +37,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/tamil"
+  commit: "626575fa0c68c81dee17a0342003c08c0ab8375e"
+  config_yaml: "sources/config-serif-tamil.yaml"
   archive_url: "https://github.com/notofonts/tamil/releases/download/NotoSerifTamil-v2.004/NotoSerifTamil-v2.004.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notoseriftelugu/METADATA.pb
+++ b/ofl/notoseriftelugu/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/telugu"
+  commit: "af5b949ed1906ead47608577d092fb013d3145d3"
+  config_yaml: "sources/config-serif-telugu.yaml"
   archive_url: "https://github.com/notofonts/telugu/releases/download/NotoSerifTelugu-v2.005/NotoSerifTelugu-v2.005.zip"
   files {
     source_file: "ARTICLE.en_us.html"

--- a/ofl/notoserifthai/METADATA.pb
+++ b/ofl/notoserifthai/METADATA.pb
@@ -28,6 +28,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/thai"
+  commit: "f8f3f024703f9d939d02f4e2fe16f1d5a39ca963"
+  config_yaml: "sources/config-serif-thai.yaml"
   archive_url: "https://github.com/notofonts/thai/releases/download/NotoSerifThai-v2.002/NotoSerifThai-v2.002.zip"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/notoserifvithkuqi/METADATA.pb
+++ b/ofl/notoserifvithkuqi/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/vithkuqi"
+  commit: "b1538fae374bd36a28c35d504ecea658dd015aaf"
+  config_yaml: "sources/config-serif-vithkuqi.yaml"
   archive_url: "https://github.com/notofonts/vithkuqi/releases/download/NotoSerifVithkuqi-v1.005/NotoSerifVithkuqi-v1.005.zip"
   files {
     source_file: "OFL.txt"

--- a/ofl/nototraditionalnushu/METADATA.pb
+++ b/ofl/nototraditionalnushu/METADATA.pb
@@ -23,6 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/nushu"
+  commit: "836ef3cc41d6f95e6f64e3f4a46ad260eb7e9d9d"
+  config_yaml: "sources/config-traditional-nushu.yaml"
   archive_url: "https://github.com/notofonts/nushu/releases/download/NotoTraditionalNushu-v2.003/NotoTraditionalNushu-v2.003.zip"
   files {
     source_file: "OFL.txt"


### PR DESCRIPTION
* Font families with full source info: 779 of 1901 (40.98% of GF Library)
* 49 more (2.58% more) than [previous batch](https://github.com/google/fonts/pull/9323)
* Progress is being tracked at https://docs.google.com/spreadsheets/d/1ao3k56FwQy6W0Ll5QbU_wpuKEvNPYcn8YyEU9_L8O4Q/edit?usp=sharing