### PR TITLE
tags: rm families that won't make it to prod

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -1,9 +1,3 @@
-42dot Sans,/Expressive/Business,80
-42dot Sans,/Expressive/Calm,80
-42dot Sans,/Quality/Concept,60
-42dot Sans,/Quality/Drawing,100
-42dot Sans,/Quality/Spacing,100
-42dot Sans,/Sans/Grotesque,100
 ABeeZee,/Expressive/Calm,91.6
 ABeeZee,/Purpose/Easy Reading,100
 ABeeZee,/Sans/Geometric,10
@@ -61,7 +55,6 @@ Adamina,/Expressive/Business,46
 Adamina,/Expressive/Sincere,93
 Adamina,/Expressive/Vintage,71.7
 Adamina,/Serif/Old Style Garalde,80
-Adobe Blank,/Monospace/Monospace,100
 Advent Pro,/Expressive/Calm,54
 Advent Pro,/Expressive/Playful,31
 Advent Pro,/Quality/Spacing,20
@@ -558,12 +551,6 @@ Asul,/Sans/Glyphic,100
 Athiti,/Expressive/Calm,93.8
 Athiti,/Sans/Geometric,20
 Athiti,/Sans/Humanist,70
-Atkinson Hyperlegible Mono,/Expressive/Business,95
-Atkinson Hyperlegible Mono,/Expressive/Calm,95
-Atkinson Hyperlegible Mono,/Expressive/Competent,100
-Atkinson Hyperlegible Mono,/Monospace/Monospace,100
-Atkinson Hyperlegible Mono,/Sans/Geometric,20
-Atkinson Hyperlegible Mono,/Sans/Grotesque,70
 Atkinson Hyperlegible Next,/Expressive/Business,95
 Atkinson Hyperlegible Next,/Expressive/Calm,95
 Atkinson Hyperlegible Next,/Expressive/Competent,100
@@ -876,12 +863,6 @@ Bevan,/Expressive/Vintage,79.8
 Bevan,/Serif/Fat Face,60
 Bevan,/Slab/Geometric,40
 Bevan,/Slab/Humanist,60
-Bhavuka,/Expressive/Calm,52
-Bhavuka,/Expressive/Childlike,10
-Bhavuka,/Expressive/Cute,56
-Bhavuka,/Expressive/Playful,32
-Bhavuka,/Sans/Geometric,20
-Bhavuka,/Sans/Humanist,80
 BhuTuka Expanded One,/Expressive/Happy,19
 BhuTuka Expanded One,/Expressive/Playful,41
 BhuTuka Expanded One,/Expressive/Sincere,50.1
@@ -1160,10 +1141,6 @@ Buenard,/Expressive/Sincere,97
 Buenard,/Expressive/Vintage,78.9
 Buenard,/Serif/Humanist Venetian,40
 Buenard,/Serif/Old Style Garalde,90
-Bungee Color,/Quality/Drawing,100
-Bungee Color,/Quality/Spacing,100
-Bungee Color,/Theme/Inline,100
-Bungee Color,/Theme/Woodtype,10
 Bungee Hairline,/Expressive/Playful,32
 Bungee Hairline,/Expressive/Stiff,97
 Bungee Hairline,/Expressive/Vintage,71.2
@@ -1872,17 +1849,6 @@ Crafty Girls,/Quality/Drawing,30
 Crafty Girls,/Script/Handwritten,100
 Crafty Girls,/Script/Informal,100
 Crafty Girls,/Theme/Brush,100
-Creepster Caps,/Expressive/Awkward,78
-Creepster Caps,/Expressive/Excited,57
-Creepster Caps,/Expressive/Innovative,93
-Creepster Caps,/Expressive/Playful,47
-Creepster Caps,/Expressive/Rugged,88
-Creepster Caps,/Expressive/Vintage,73.4
-Creepster Caps,/Quality/Drawing,100
-Creepster Caps,/Quality/Spacing,100
-Creepster Caps,/Theme/Blobby,5
-Creepster Caps,/Theme/Distressed,80
-Creepster Caps,/Theme/Wacky,20
 Creepster,/Expressive/Awkward,78
 Creepster,/Expressive/Excited,57
 Creepster,/Expressive/Innovative,93
@@ -2078,23 +2044,12 @@ Dhurjati,/Expressive/Calm,79
 Dhurjati,/Expressive/Stiff,58
 Dhurjati,/Sans/Superellipse,50
 Dhurjati,/Theme/Woodtype,60
-Dhyana,/Expressive/Business,68.4
-Dhyana,/Expressive/Calm,64
-Dhyana,/Expressive/Stiff,42
-Dhyana,/Sans/Humanist,100
 Didact Gothic,/Expressive/Business,34
 Didact Gothic,/Expressive/Calm,92.5
 Didact Gothic,/Expressive/Vintage,84.5
 Didact Gothic,/Quality/Drawing,50
 Didact Gothic,/Quality/Spacing,50
 Didact Gothic,/Sans/Geometric,100
-Digital Numbers,/Expressive/Futuristic,20
-Digital Numbers,/Expressive/Innovative,73
-Digital Numbers,/Expressive/Loud,51
-Digital Numbers,/Expressive/Playful,11
-Digital Numbers,/Expressive/Vintage,84.5
-Digital Numbers,/Monospace/Monospace,100
-Digital Numbers,/Theme/Techno,100
 Diphylleia,/Expressive/Cute,31
 Diphylleia,/Expressive/Playful,11
 Diphylleia,/Expressive/Vintage,75.4
@@ -2328,11 +2283,6 @@ Edu VIC WA NT Beginner,/Quality/Drawing,100
 Edu VIC WA NT Beginner,/Quality/Spacing,100
 Edu VIC WA NT Beginner,/Script/Handwritten,100
 Edu VIC WA NT Beginner,/Script/Informal,60
-Ek Mukta,/Expressive/Business,89
-Ek Mukta,/Expressive/Calm,94
-Ek Mukta,/Expressive/Competent,41
-Ek Mukta,/Expressive/Stiff,53
-Ek Mukta,/Sans/Humanist,100
 El Messiri,/Expressive/Calm,73
 El Messiri,/Sans/Glyphic,80
 Electrolize,/Expressive/Calm,59
@@ -3252,10 +3202,6 @@ Hepta Slab,/Expressive/Business,56.9
 Hepta Slab,/Expressive/Calm,79
 Hepta Slab,/Expressive/Sincere,60
 Hepta Slab,/Slab/Geometric,90
-Hermeneus One,/Expressive/Business,54.7
-Hermeneus One,/Expressive/Sincere,80
-Hermeneus One,/Expressive/Stiff,30
-Hermeneus One,/Serif/Transitional,80
 Herr Von Muellerhoff,/Expressive/Artistic,80
 Herr Von Muellerhoff,/Expressive/Fancy,58
 Herr Von Muellerhoff,/Expressive/Sincere,70.1
@@ -3271,14 +3217,8 @@ Hi Melody,/Theme/Brush,60
 Hina Mincho,/Expressive/Sincere,35
 Hina Mincho,/Serif/Scotch,60
 Hina Mincho,/Serif/Transitional,60
-Hind Colombo,/Expressive/Business,69.9
-Hind Colombo,/Sans/Humanist,100
 Hind Guntur,/Expressive/Business,69.9
 Hind Guntur,/Sans/Humanist,100
-Hind Jalandhar,/Expressive/Business,69.9
-Hind Jalandhar,/Sans/Humanist,100
-Hind Kochi,/Expressive/Business,69.9
-Hind Kochi,/Sans/Humanist,100
 Hind Madurai,/Expressive/Business,69.9
 Hind Madurai,/Sans/Humanist,100
 Hind Mysuru,/Expressive/Business,69.9
@@ -3434,14 +3374,6 @@ IM Fell Great Primer,/Expressive/Sincere,98
 IM Fell Great Primer,/Expressive/Vintage,89
 IM Fell Great Primer,/Quality/Drawing,90
 IM Fell Great Primer,/Quality/Spacing,100
-Iansui,/Expressive/Active,80
-Iansui,/Expressive/Cute,20
-Iansui,/Expressive/Happy,50
-Iansui,/Quality/Concept,100
-Iansui,/Quality/Drawing,50
-Iansui,/Quality/Spacing,100
-Iansui,/Script/Upright Script,100
-Iansui,/Theme/Brush,100
 Ibarra Real Nova,/Expressive/Business,71.8
 Ibarra Real Nova,/Expressive/Sincere,94
 Ibarra Real Nova,/Expressive/Vintage,68.4
@@ -3792,8 +3724,6 @@ Kameron,/Expressive/Stiff,10
 Kameron,/Expressive/Vintage,74.5
 Kameron,/Slab/Clarendon,60
 Kameron,/Slab/Geometric,30
-Kanchenjunga,/Expressive/Calm,80
-Kanchenjunga,/Sans/Glyphic,100
 Kanit,/Expressive/Business,15
 Kanit,/Expressive/Calm,88
 Kanit,/Expressive/Futuristic,28
@@ -3807,11 +3737,6 @@ Kantumruy Pro,/Expressive/Calm,87.3
 Kantumruy Pro,/Expressive/Stiff,52
 Kantumruy Pro,/Expressive/Vintage,13
 Kantumruy Pro,/Sans/Grotesque,100
-Kapakana,/Expressive/Artistic,100
-Kapakana,/Expressive/Fancy,79
-Kapakana,/Expressive/Sophisticated,100
-Kapakana,/Expressive/Vintage,96
-Kapakana,/Script/Formal,100
 Karantina,/Expressive/Awkward,31
 Karantina,/Expressive/Competent,79.7
 Karantina,/Expressive/Loud,96
@@ -4710,13 +4635,6 @@ Meow Script,/Script/Handwritten,20
 Meow Script,/Script/Informal,100
 Meow Script,/Seasonal/Valentine's Day,67
 Meow Script,/Theme/Brush,100
-Merge One,/Expressive/Calm,54
-Merge One,/Expressive/Competent,52
-Merge One,/Expressive/Cute,14
-Merge One,/Expressive/Stiff,60
-Merge One,/Expressive/Vintage,16.5
-Merge One,/Sans/Humanist,100
-Merge One,/Sans/Rounded,50
 Merienda,/Expressive/Active,22
 Merienda,/Expressive/Excited,10
 Merienda,/Expressive/Happy,34
@@ -4743,12 +4661,6 @@ Merriweather,/Quality/Spacing,100
 Merriweather,/Serif/Humanist Venetian,20
 Merriweather,/Serif/Old Style Garalde,40
 Merriweather,/Serif/Transitional,20
-Mervale Script,/Expressive/Active,25
-Mervale Script,/Expressive/Artistic,57
-Mervale Script,/Expressive/Cute,32
-Mervale Script,/Expressive/Sophisticated,73
-Mervale Script,/Expressive/Vintage,49.6
-Mervale Script,/Script/Formal,30
 Metal Mania,/Expressive/Awkward,13
 Metal Mania,/Expressive/Excited,72
 Metal Mania,/Expressive/Innovative,94
@@ -4770,11 +4682,6 @@ Metrophobic,/Expressive/Calm,77
 Metrophobic,/Expressive/Competent,78.4
 Metrophobic,/Expressive/Stiff,79
 Metrophobic,/Sans/Superellipse,100
-Miama,/Expressive/Artistic,60
-Miama,/Expressive/Loud,22
-Miama,/Expressive/Sophisticated,24
-Miama,/Expressive/Vintage,78.7
-Miama,/Script/Formal,50
 Michroma,/Expressive/Competent,95.8
 Michroma,/Expressive/Futuristic,100
 Michroma,/Expressive/Stiff,98
@@ -4966,7 +4873,6 @@ Montez,/Seasonal/Diwali,80
 Montez,/Seasonal/Valentine's Day,76
 Montserrat Alternates,/Expressive/Calm,98.3
 Montserrat Alternates,/Sans/Geometric,100
-Montserrat Subrayada,/Sans/Geometric,100
 Montserrat Underline,/Sans/Geometric,100
 Montserrat,/Expressive/Business,56.6
 Montserrat,/Expressive/Calm,98.3
@@ -5126,10 +5032,6 @@ Mystery Quest,/Expressive/Vintage,73
 Mystery Quest,/Quality/Drawing,50
 Mystery Quest,/Seasonal/Halloween,100
 Mystery Quest,/Theme/Wacky,100
-NATS,/Expressive/Business,80.2
-NATS,/Expressive/Calm,83.6
-NATS,/Expressive/Stiff,51
-NATS,/Sans/Geometric,100
 NTR,/Expressive/Calm,68
 NTR,/Expressive/Cute,32
 NTR,/Expressive/Vintage,74.3
@@ -5264,13 +5166,6 @@ Norican,/Expressive/Sophisticated,24
 Norican,/Expressive/Vintage,59
 Norican,/Quality/Drawing,50
 Norican,/Script/Formal,50
-Nosifer Caps,/Expressive/Excited,34
-Nosifer Caps,/Expressive/Innovative,76
-Nosifer Caps,/Expressive/Loud,99
-Nosifer Caps,/Expressive/Stiff,55
-Nosifer Caps,/Quality/Drawing,50
-Nosifer Caps,/Quality/Spacing,50
-Nosifer Caps,/Theme/Wacky,100
 Nosifer,/Expressive/Excited,34
 Nosifer,/Expressive/Innovative,76
 Nosifer,/Expressive/Loud,99
@@ -5296,7 +5191,6 @@ Nothing You Could Do,/Script/Informal,100
 Noticia Text,/Expressive/Business,79
 Noticia Text,/Expressive/Sincere,97
 Noticia Text,/Slab/Humanist,100
-Noto Color Emoji Compat Test,/Special use/Symbols,100
 Noto Color Emoji,/Special use/Symbols,100
 Noto Emoji Color,/Special use/Symbols,100
 Noto Emoji,/Special use/Symbols,100
@@ -5314,7 +5208,6 @@ Noto Sans Adlam,/Expressive/Business,58
 Noto Sans Adlam,/Sans/Humanist,100
 Noto Sans Anatolian Hieroglyphs,/Expressive/Business,58
 Noto Sans Anatolian Hieroglyphs,/Sans/Humanist,100
-Noto Sans Arabic UI,/Sans/Humanist,100
 Noto Sans Arabic,/Sans/Humanist,100
 Noto Sans Armenian,/Expressive/Business,58
 Noto Sans Armenian,/Sans/Humanist,100
@@ -5328,8 +5221,6 @@ Noto Sans Bassa Vah,/Expressive/Business,58
 Noto Sans Bassa Vah,/Sans/Humanist,100
 Noto Sans Batak,/Expressive/Business,58
 Noto Sans Batak,/Sans/Humanist,100
-Noto Sans Bengali UI,/Expressive/Business,58
-Noto Sans Bengali UI,/Sans/Humanist,100
 Noto Sans Bengali,/Expressive/Business,58
 Noto Sans Bengali,/Sans/Humanist,100
 Noto Sans Bhaiksuki,/Expressive/Business,58
@@ -5364,8 +5255,6 @@ Noto Sans Cypro Minoan,/Expressive/Business,58
 Noto Sans Cypro Minoan,/Sans/Humanist,100
 Noto Sans Deseret,/Expressive/Business,58
 Noto Sans Deseret,/Sans/Humanist,100
-Noto Sans Devanagari UI,/Expressive/Business,58
-Noto Sans Devanagari UI,/Sans/Humanist,100
 Noto Sans Devanagari,/Expressive/Business,58
 Noto Sans Devanagari,/Sans/Humanist,100
 Noto Sans Display,/Expressive/Business,58
@@ -5389,14 +5278,10 @@ Noto Sans Gothic,/Expressive/Business,58
 Noto Sans Gothic,/Sans/Humanist,100
 Noto Sans Grantha,/Expressive/Business,58
 Noto Sans Grantha,/Sans/Humanist,100
-Noto Sans Gujarati UI,/Expressive/Business,58
-Noto Sans Gujarati UI,/Sans/Humanist,100
 Noto Sans Gujarati,/Expressive/Business,58
 Noto Sans Gujarati,/Sans/Humanist,100
 Noto Sans Gunjala Gondi,/Expressive/Business,58
 Noto Sans Gunjala Gondi,/Sans/Humanist,100
-Noto Sans Gurmukhi UI,/Expressive/Business,58
-Noto Sans Gurmukhi UI,/Sans/Humanist,100
 Noto Sans Gurmukhi,/Expressive/Business,58
 Noto Sans Gurmukhi,/Sans/Humanist,100
 Noto Sans HK,/Expressive/Business,58
@@ -5425,8 +5310,6 @@ Noto Sans KR,/Expressive/Business,58
 Noto Sans KR,/Sans/Humanist,100
 Noto Sans Kaithi,/Expressive/Business,58
 Noto Sans Kaithi,/Sans/Humanist,100
-Noto Sans Kannada UI,/Expressive/Business,58
-Noto Sans Kannada UI,/Sans/Humanist,100
 Noto Sans Kannada,/Expressive/Business,58
 Noto Sans Kannada,/Sans/Humanist,100
 Noto Sans Kawi,/Expressive/Business,58
@@ -5435,8 +5318,6 @@ Noto Sans Kayah Li,/Expressive/Business,58
 Noto Sans Kayah Li,/Sans/Humanist,100
 Noto Sans Kharoshthi,/Expressive/Business,58
 Noto Sans Kharoshthi,/Sans/Humanist,100
-Noto Sans Khmer UI,/Expressive/Business,58
-Noto Sans Khmer UI,/Sans/Humanist,100
 Noto Sans Khmer,/Expressive/Business,58
 Noto Sans Khmer,/Sans/Humanist,100
 Noto Sans Khojki,/Expressive/Business,58
@@ -5445,7 +5326,6 @@ Noto Sans Khudawadi,/Expressive/Business,58
 Noto Sans Khudawadi,/Sans/Humanist,100
 Noto Sans Lao Looped,/Expressive/Business,58
 Noto Sans Lao Looped,/Sans/Humanist,100
-Noto Sans Lao UI,/Sans/Humanist,100
 Noto Sans Lao,/Expressive/Business,58
 Noto Sans Lao,/Sans/Humanist,100
 Noto Sans Lepcha,/Expressive/Business,58
@@ -5463,7 +5343,6 @@ Noto Sans Lydian,/Expressive/Business,58
 Noto Sans Lydian,/Sans/Humanist,100
 Noto Sans Mahajani,/Expressive/Business,58
 Noto Sans Mahajani,/Sans/Humanist,100
-Noto Sans Malayalam UI,/Sans/Humanist,100
 Noto Sans Malayalam,/Expressive/Business,58
 Noto Sans Malayalam,/Sans/Humanist,100
 Noto Sans Mandaic,/Expressive/Business,58
@@ -5499,7 +5378,6 @@ Noto Sans Mro,/Expressive/Business,58
 Noto Sans Mro,/Sans/Humanist,100
 Noto Sans Multani,/Expressive/Business,58
 Noto Sans Multani,/Sans/Humanist,100
-Noto Sans Myanmar UI,/Sans/Humanist,100
 Noto Sans Myanmar,/Sans/Humanist,100
 Noto Sans NKo Unjoined,/Expressive/Business,58
 Noto Sans NKo Unjoined,/Sans/Humanist,100
@@ -5537,7 +5415,6 @@ Noto Sans Old South Arabian,/Expressive/Business,58
 Noto Sans Old South Arabian,/Sans/Humanist,100
 Noto Sans Old Turkic,/Expressive/Business,58
 Noto Sans Old Turkic,/Sans/Humanist,100
-Noto Sans Oriya UI,/Sans/Humanist,100
 Noto Sans Oriya,/Expressive/Business,58
 Noto Sans Oriya,/Sans/Humanist,100
 Noto Sans Osage,/Expressive/Business,58
@@ -5550,8 +5427,6 @@ Noto Sans Palmyrene,/Expressive/Business,58
 Noto Sans Palmyrene,/Sans/Humanist,100
 Noto Sans Pau Cin Hau,/Expressive/Business,58
 Noto Sans Pau Cin Hau,/Sans/Humanist,100
-Noto Sans Phags Pa,/Expressive/Business,58
-Noto Sans Phags Pa,/Sans/Humanist,100
 Noto Sans PhagsPa,/Expressive/Business,58
 Noto Sans PhagsPa,/Sans/Humanist,100
 Noto Sans Phoenician,/Expressive/Business,58
@@ -5578,7 +5453,6 @@ Noto Sans Siddham,/Sans/Humanist,100
 Noto Sans SignWriting,/Expressive/Business,58
 Noto Sans SignWriting,/Quality/Drawing,100
 Noto Sans SignWriting,/Sans/Humanist,100
-Noto Sans Sinhala UI,/Sans/Humanist,100
 Noto Sans Sinhala,/Expressive/Business,58
 Noto Sans Sinhala,/Sans/Humanist,100
 Noto Sans Sogdian,/Expressive/Business,58
@@ -5615,19 +5489,16 @@ Noto Sans Takri,/Expressive/Business,58
 Noto Sans Takri,/Sans/Humanist,100
 Noto Sans Tamil Supplement,/Expressive/Business,58
 Noto Sans Tamil Supplement,/Sans/Humanist,100
-Noto Sans Tamil UI,/Sans/Humanist,100
 Noto Sans Tamil,/Expressive/Business,58
 Noto Sans Tamil,/Sans/Humanist,100
 Noto Sans Tangsa,/Expressive/Business,58
 Noto Sans Tangsa,/Sans/Humanist,100
-Noto Sans Telugu UI,/Sans/Humanist,100
 Noto Sans Telugu,/Expressive/Business,58
 Noto Sans Telugu,/Sans/Humanist,100
 Noto Sans Thaana,/Expressive/Business,58
 Noto Sans Thaana,/Sans/Humanist,100
 Noto Sans Thai Looped,/Expressive/Business,58
 Noto Sans Thai Looped,/Sans/Humanist,100
-Noto Sans Thai UI,/Sans/Humanist,100
 Noto Sans Thai,/Expressive/Business,58
 Noto Sans Thai,/Sans/Humanist,100
 Noto Sans Tifinagh,/Expressive/Business,58
@@ -5667,12 +5538,6 @@ Noto Serif HK,/Expressive/Loud,25
 Noto Serif HK,/Seasonal/Lunar New Year,66
 Noto Serif HK,/Serif/Transitional,100
 Noto Serif Hebrew,/Serif/Transitional,100
-Noto Serif Hentaigana,/Expressive/Artistic,80
-Noto Serif Hentaigana,/Expressive/Sincere,50
-Noto Serif Hentaigana,/Quality/Concept,100
-Noto Serif Hentaigana,/Quality/Drawing,100
-Noto Serif Hentaigana,/Quality/Spacing,100
-Noto Serif Hentaigana,/Theme/Brush,100
 Noto Serif JP,/Expressive/Loud,25
 Noto Serif JP,/Serif/Transitional,100
 Noto Serif KR,/Expressive/Loud,25
@@ -5688,7 +5553,6 @@ Noto Serif Malayalam,/Seasonal/Diwali,92
 Noto Serif Malayalam,/Serif/Transitional,100
 Noto Serif Myanmar,/Serif/Transitional,100
 Noto Serif NP Hmong,/Serif/Transitional,100
-Noto Serif Nyiakeng Puachue Hmong,/Serif/Transitional,100
 Noto Serif Old Uyghur,/Expressive/Business,98.9
 Noto Serif Old Uyghur,/Expressive/Competent,98.9
 Noto Serif Old Uyghur,/Expressive/Sincere,91
@@ -5708,10 +5572,6 @@ Noto Serif Tangut,/Serif/Transitional,100
 Noto Serif Telugu,/Serif/Transitional,100
 Noto Serif Thai,/Serif/Transitional,100
 Noto Serif Tibetan,/Serif/Transitional,100
-Noto Serif Todhri,/Expressive/Competent,100
-Noto Serif Todhri,/Quality/Concept,100
-Noto Serif Todhri,/Quality/Drawing,100
-Noto Serif Todhri,/Quality/Spacing,100
 Noto Serif Toto,/Serif/Transitional,100
 Noto Serif Vithkuqi,/Serif/Transitional,100
 Noto Serif Yezidi,/Serif/Transitional,100
@@ -5778,10 +5638,6 @@ Nunito,/Sans/Rounded,100
 Nuosu SIL,/Expressive/Business,98
 Nuosu SIL,/Serif/Old Style Garalde,50
 Nuosu SIL,/Serif/Transitional,50
-OFL Sorts Mill Goudy TT,/Expressive/Business,67.9
-OFL Sorts Mill Goudy TT,/Expressive/Sincere,99
-OFL Sorts Mill Goudy TT,/Expressive/Vintage,72.5
-OFL Sorts Mill Goudy TT,/Serif/Old Style Garalde,100
 Odibee Sans,/Expressive/Futuristic,80
 Odibee Sans,/Expressive/Stiff,97
 Odibee Sans,/Quality/Spacing,15
@@ -5907,11 +5763,6 @@ Oswald,/Expressive/Competent,99.9
 Oswald,/Expressive/Stiff,91
 Oswald,/Expressive/Vintage,41.2
 Oswald,/Sans/Grotesque,100
-Otomanopee One,/Expressive/Excited,54
-Otomanopee One,/Expressive/Happy,21
-Otomanopee One,/Expressive/Loud,55
-Otomanopee One,/Sans/Humanist,80
-Otomanopee One,/Theme/Wacky,60
 Outfit,/Expressive/Business,61.2
 Outfit,/Expressive/Calm,99.2
 Outfit,/Sans/Geometric,100
@@ -6915,11 +6766,6 @@ Pompiere,/Seasonal/Valentine's Day,62
 Pompiere,/Theme/Art Deco,50
 Ponnala,/Expressive/Loud,99
 Ponnala,/Seasonal/Holi,96
-Ponomar,/Expressive/Sincere,9
-Ponomar,/Quality/Concept,80
-Ponomar,/Quality/Drawing,50
-Ponomar,/Quality/Spacing,50
-Ponomar,/Slab/Humanist,30
 Pontano Sans,/Expressive/Business,91.1
 Pontano Sans,/Expressive/Calm,81.9
 Pontano Sans,/Expressive/Competent,38
@@ -6946,16 +6792,7 @@ Port Lligat Slab,/Expressive/Playful,12
 Port Lligat Slab,/Expressive/Sincere,9
 Port Lligat Slab,/Serif/Humanist Venetian,50
 Port Lligat Slab,/Slab/Humanist,20
-Porter Sans Block,/Expressive/Business,49
-Porter Sans Block,/Expressive/Innovative,93
-Porter Sans Block,/Expressive/Stiff,91
-Porter Sans Block,/Expressive/Vintage,92
-Porter Sans Block,/Theme/Inline,100
-Porter Sans Block,/Theme/Shaded,100
-Porter Sans Block,/Theme/Woodtype,100
 Post No Bills Colombo Medium,/Expressive/Stiff,92
-Post No Bills Jaffna,/Expressive/Innovative,32
-Post No Bills Jaffna,/Expressive/Stiff,92
 Potta One,/Expressive/Awkward,95
 Potta One,/Expressive/Innovative,14
 Potta One,/Expressive/Playful,58
@@ -7585,9 +7422,6 @@ Rubik Moonrocks,/Expressive/Innovative,99
 Rubik Moonrocks,/Expressive/Playful,99.7
 Rubik Moonrocks,/Quality/Concept,40
 Rubik Moonrocks,/Seasonal/Christmas,71
-Rubik One,/Expressive/Stiff,97
-Rubik One,/Sans/Neo Grotesque,100
-Rubik One,/Theme/Woodtype,60
 Rubik Pixels,/Expressive/Awkward,100
 Rubik Pixels,/Expressive/Excited,69
 Rubik Pixels,/Expressive/Innovative,99
@@ -7708,10 +7542,6 @@ Rye,/Expressive/Vintage,93
 Rye,/Theme/Inline,20
 Rye,/Theme/Tuscan,100
 Rye,/Theme/Woodtype,100
-STIX Two Math,/Expressive/Business,99.1
-STIX Two Math,/Expressive/Stiff,70
-STIX Two Math,/Expressive/Vintage,81
-STIX Two Math,/Serif/Transitional,100
 STIX Two Text,/Expressive/Business,99.1
 STIX Two Text,/Expressive/Stiff,70
 STIX Two Text,/Expressive/Vintage,81
@@ -7781,20 +7611,11 @@ Sancreek,/Theme/Woodtype,90
 Sankofa Display,/Expressive/Innovative,91
 Sankofa Display,/Expressive/Playful,70.5
 Sankofa Display,/Seasonal/Kwanzaa,87
-Sansation,/Expressive/Business,80
-Sansation,/Quality/Concept,100
-Sansation,/Quality/Drawing,80
-Sansation,/Quality/Spacing,100
-Sansation,/Sans/Humanist,100
 Sansational,/Expressive/Calm,79
 Sansational,/Expressive/Futuristic,88
 Sansational,/Expressive/Stiff,83
 Sansational,/Sans/Humanist,50
 Sansational,/Sans/Superellipse,70
-Sansita One,/Expressive/Competent,79.6
-Sansita One,/Expressive/Cute,61
-Sansita One,/Expressive/Loud,71
-Sansita One,/Expressive/Stiff,50
 Sansita Swashed,/Expressive/Active,72
 Sansita Swashed,/Expressive/Cute,15
 Sansita Swashed,/Expressive/Happy,21
@@ -7941,10 +7762,6 @@ Shadows Into Light,/Quality/Drawing,50
 Shadows Into Light,/Script/Handwritten,100
 Shadows Into Light,/Script/Informal,100
 Shadows Into Light,/Seasonal/Halloween,90
-Shafarik,/Quality/Concept,50
-Shafarik,/Quality/Drawing,80
-Shafarik,/Quality/Spacing,50
-Shafarik,/Slab/Clarendon,80
 Shalimar,/Expressive/Artistic,59
 Shalimar,/Expressive/Excited,56
 Shalimar,/Expressive/Loud,42
@@ -8058,13 +7875,6 @@ Sigmar,/Quality/Drawing,50
 Sigmar,/Sans/Humanist,100
 Sigmar,/Seasonal/Kwanzaa,93
 Sigmar,/Theme/Woodtype,20
-Signika Negative SC,/Expressive/Business,55.9
-Signika Negative SC,/Expressive/Calm,66
-Signika Negative SC,/Expressive/Competent,78.2
-Signika Negative SC,/Expressive/Stiff,71
-Signika Negative SC,/Expressive/Vintage,14.5
-Signika Negative SC,/Quality/Drawing,50
-Signika Negative SC,/Sans/Humanist,100
 Signika Negative,/Expressive/Business,55.9
 Signika Negative,/Expressive/Calm,66
 Signika Negative,/Expressive/Competent,78.2
@@ -8072,13 +7882,6 @@ Signika Negative,/Expressive/Stiff,74
 Signika Negative,/Expressive/Vintage,14.5
 Signika Negative,/Quality/Drawing,50
 Signika Negative,/Sans/Humanist,100
-Signika SC,/Expressive/Business,55.9
-Signika SC,/Expressive/Calm,66
-Signika SC,/Expressive/Competent,78.2
-Signika SC,/Expressive/Stiff,71
-Signika SC,/Expressive/Vintage,14.5
-Signika SC,/Quality/Drawing,50
-Signika SC,/Sans/Humanist,100
 Signika,/Expressive/Business,55.9
 Signika,/Expressive/Calm,66
 Signika,/Expressive/Competent,78.2
@@ -8489,12 +8292,6 @@ Strait,/Sans/Geometric,10
 Strait,/Sans/Humanist,50
 Strait,/Sans/Neo Grotesque,20
 Strait,/Sans/Superellipse,60
-Strong,/Expressive/Calm,85.9
-Strong,/Expressive/Competent,79.4
-Strong,/Expressive/Futuristic,97
-Strong,/Expressive/Stiff,99
-Strong,/Sans/Geometric,10
-Strong,/Sans/Humanist,60
 Style Script,/Expressive/Artistic,80
 Style Script,/Expressive/Fancy,74
 Style Script,/Expressive/Loud,23
@@ -8606,13 +8403,6 @@ Tac One,/Expressive/Awkward,95
 Tac One,/Expressive/Loud,100
 Tac One,/Expressive/Stiff,97
 Tac One,/Quality/Drawing,100
-Tagesschrift,/Expressive/Happy,30
-Tagesschrift,/Expressive/Rugged,60
-Tagesschrift,/Quality/Concept,100
-Tagesschrift,/Quality/Drawing,90
-Tagesschrift,/Quality/Spacing,100
-Tagesschrift,/Script/Upright Script,80
-Tagesschrift,/Theme/Brush,80
 Tai Heritage Pro,/Expressive/Business,98.8
 Tai Heritage Pro,/Expressive/Stiff,60
 Tai Heritage Pro,/Expressive/Vintage,76
@@ -8689,10 +8479,6 @@ Texturina,/Expressive/Sincere,37
 Texturina,/Expressive/Stiff,71
 Texturina,/Expressive/Vintage,98
 Texturina,/Theme/Blackletter,80
-Thabit,/Expressive/Sincere,65
-Thabit,/Expressive/Stiff,81
-Thabit,/Expressive/Vintage,78.3
-Thabit,/Slab/Geometric,100
 Thasadith,/Expressive/Business,38
 Thasadith,/Expressive/Calm,74
 Thasadith,/Expressive/Competent,56
@@ -8871,12 +8657,6 @@ Tsukimi Rounded,/Sans/Geometric,80
 Tsukimi Rounded,/Sans/Rounded,100
 Tsukimi Rounded,/Theme/Techno,10
 Tsukimi Rounded,/Theme/Wacky,10
-Tuffy,/Expressive/Business,53.1
-Tuffy,/Expressive/Calm,65
-Tuffy,/Expressive/Stiff,72
-Tuffy,/Expressive/Vintage,62
-Tuffy,/Sans/Grotesque,40
-Tuffy,/Sans/Neo Grotesque,80
 Tulpen One,/Expressive/Futuristic,82
 Tulpen One,/Expressive/Stiff,100
 Tulpen One,/Sans/Geometric,80
@@ -9259,12 +9039,6 @@ Xanh Mono,/Expressive/Stiff,60
 Xanh Mono,/Expressive/Vintage,83
 Xanh Mono,/Monospace/Monospace,100
 Xanh Mono,/Serif/Modern,100
-Yaldevi Colombo,/Expressive/Business,69.1
-Yaldevi Colombo,/Expressive/Calm,84.5
-Yaldevi Colombo,/Expressive/Competent,79.1
-Yaldevi Colombo,/Expressive/Stiff,62
-Yaldevi Colombo,/Sans/Humanist,20
-Yaldevi Colombo,/Sans/Neo Grotesque,80
 Yaldevi,/Expressive/Business,69.1
 Yaldevi,/Expressive/Calm,84.7
 Yaldevi,/Expressive/Competent,89.1

--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -551,6 +551,12 @@ Asul,/Sans/Glyphic,100
 Athiti,/Expressive/Calm,93.8
 Athiti,/Sans/Geometric,20
 Athiti,/Sans/Humanist,70
+Atkinson Hyperlegible Mono,/Expressive/Business,95
+Atkinson Hyperlegible Mono,/Expressive/Calm,95
+Atkinson Hyperlegible Mono,/Expressive/Competent,100
+Atkinson Hyperlegible Mono,/Monospace/Monospace,100
+Atkinson Hyperlegible Mono,/Sans/Geometric,20
+Atkinson Hyperlegible Mono,/Sans/Grotesque,70
 Atkinson Hyperlegible Next,/Expressive/Business,95
 Atkinson Hyperlegible Next,/Expressive/Calm,95
 Atkinson Hyperlegible Next,/Expressive/Competent,100
@@ -3374,6 +3380,14 @@ IM Fell Great Primer,/Expressive/Sincere,98
 IM Fell Great Primer,/Expressive/Vintage,89
 IM Fell Great Primer,/Quality/Drawing,90
 IM Fell Great Primer,/Quality/Spacing,100
+Iansui,/Expressive/Active,80
+Iansui,/Expressive/Cute,20
+Iansui,/Expressive/Happy,50
+Iansui,/Quality/Concept,100
+Iansui,/Quality/Drawing,50
+Iansui,/Quality/Spacing,100
+Iansui,/Script/Upright Script,100
+Iansui,/Theme/Brush,100
 Ibarra Real Nova,/Expressive/Business,71.8
 Ibarra Real Nova,/Expressive/Sincere,94
 Ibarra Real Nova,/Expressive/Vintage,68.4
@@ -3724,6 +3738,8 @@ Kameron,/Expressive/Stiff,10
 Kameron,/Expressive/Vintage,74.5
 Kameron,/Slab/Clarendon,60
 Kameron,/Slab/Geometric,30
+Kanchenjunga,/Expressive/Calm,80
+Kanchenjunga,/Sans/Glyphic,100
 Kanit,/Expressive/Business,15
 Kanit,/Expressive/Calm,88
 Kanit,/Expressive/Futuristic,28
@@ -3737,6 +3753,11 @@ Kantumruy Pro,/Expressive/Calm,87.3
 Kantumruy Pro,/Expressive/Stiff,52
 Kantumruy Pro,/Expressive/Vintage,13
 Kantumruy Pro,/Sans/Grotesque,100
+Kapakana,/Expressive/Artistic,100
+Kapakana,/Expressive/Fancy,79
+Kapakana,/Expressive/Sophisticated,100
+Kapakana,/Expressive/Vintage,96
+Kapakana,/Script/Formal,100
 Karantina,/Expressive/Awkward,31
 Karantina,/Expressive/Competent,79.7
 Karantina,/Expressive/Loud,96
@@ -5538,6 +5559,12 @@ Noto Serif HK,/Expressive/Loud,25
 Noto Serif HK,/Seasonal/Lunar New Year,66
 Noto Serif HK,/Serif/Transitional,100
 Noto Serif Hebrew,/Serif/Transitional,100
+Noto Serif Hentaigana,/Expressive/Artistic,80
+Noto Serif Hentaigana,/Expressive/Sincere,50
+Noto Serif Hentaigana,/Quality/Concept,100
+Noto Serif Hentaigana,/Quality/Drawing,100
+Noto Serif Hentaigana,/Quality/Spacing,100
+Noto Serif Hentaigana,/Theme/Brush,100
 Noto Serif JP,/Expressive/Loud,25
 Noto Serif JP,/Serif/Transitional,100
 Noto Serif KR,/Expressive/Loud,25
@@ -5553,6 +5580,7 @@ Noto Serif Malayalam,/Seasonal/Diwali,92
 Noto Serif Malayalam,/Serif/Transitional,100
 Noto Serif Myanmar,/Serif/Transitional,100
 Noto Serif NP Hmong,/Serif/Transitional,100
+Noto Serif Nyiakeng Puachue Hmong,/Serif/Transitional,100
 Noto Serif Old Uyghur,/Expressive/Business,98.9
 Noto Serif Old Uyghur,/Expressive/Competent,98.9
 Noto Serif Old Uyghur,/Expressive/Sincere,91
@@ -5572,6 +5600,10 @@ Noto Serif Tangut,/Serif/Transitional,100
 Noto Serif Telugu,/Serif/Transitional,100
 Noto Serif Thai,/Serif/Transitional,100
 Noto Serif Tibetan,/Serif/Transitional,100
+Noto Serif Todhri,/Expressive/Competent,100
+Noto Serif Todhri,/Quality/Concept,100
+Noto Serif Todhri,/Quality/Drawing,100
+Noto Serif Todhri,/Quality/Spacing,100
 Noto Serif Toto,/Serif/Transitional,100
 Noto Serif Vithkuqi,/Serif/Transitional,100
 Noto Serif Yezidi,/Serif/Transitional,100
@@ -5763,6 +5795,11 @@ Oswald,/Expressive/Competent,99.9
 Oswald,/Expressive/Stiff,91
 Oswald,/Expressive/Vintage,41.2
 Oswald,/Sans/Grotesque,100
+Otomanopee One,/Expressive/Excited,54
+Otomanopee One,/Expressive/Happy,21
+Otomanopee One,/Expressive/Loud,55
+Otomanopee One,/Sans/Humanist,80
+Otomanopee One,/Theme/Wacky,60
 Outfit,/Expressive/Business,61.2
 Outfit,/Expressive/Calm,99.2
 Outfit,/Sans/Geometric,100
@@ -6766,6 +6803,11 @@ Pompiere,/Seasonal/Valentine's Day,62
 Pompiere,/Theme/Art Deco,50
 Ponnala,/Expressive/Loud,99
 Ponnala,/Seasonal/Holi,96
+Ponomar,/Expressive/Sincere,9
+Ponomar,/Quality/Concept,80
+Ponomar,/Quality/Drawing,50
+Ponomar,/Quality/Spacing,50
+Ponomar,/Slab/Humanist,30
 Pontano Sans,/Expressive/Business,91.1
 Pontano Sans,/Expressive/Calm,81.9
 Pontano Sans,/Expressive/Competent,38
@@ -7762,6 +7804,10 @@ Shadows Into Light,/Quality/Drawing,50
 Shadows Into Light,/Script/Handwritten,100
 Shadows Into Light,/Script/Informal,100
 Shadows Into Light,/Seasonal/Halloween,90
+Shafarik,/Quality/Concept,50
+Shafarik,/Quality/Drawing,80
+Shafarik,/Quality/Spacing,50
+Shafarik,/Slab/Clarendon,80
 Shalimar,/Expressive/Artistic,59
 Shalimar,/Expressive/Excited,56
 Shalimar,/Expressive/Loud,42
@@ -8403,6 +8449,13 @@ Tac One,/Expressive/Awkward,95
 Tac One,/Expressive/Loud,100
 Tac One,/Expressive/Stiff,97
 Tac One,/Quality/Drawing,100
+Tagesschrift,/Expressive/Happy,30
+Tagesschrift,/Expressive/Rugged,60
+Tagesschrift,/Quality/Concept,100
+Tagesschrift,/Quality/Drawing,90
+Tagesschrift,/Quality/Spacing,100
+Tagesschrift,/Script/Upright Script,80
+Tagesschrift,/Theme/Brush,80
 Tai Heritage Pro,/Expressive/Business,98.8
 Tai Heritage Pro,/Expressive/Stiff,60
 Tai Heritage Pro,/Expressive/Vintage,76


### PR DESCRIPTION
Here's a pr to remove all tags for families that we don't plan to serve. This has been scripted so it is picking up some families that we will eventually serve so I'll readd these in further commits.

Fixes https://github.com/google/fonts/issues/8031#issuecomment-2879251975

cc @davelab6 @EbenSorkin 