### PR TITLE
Update primary script for CJK fonts

### DIFF
--- a/ofl/wdxllubrifontjpn/METADATA.pb
+++ b/ofl/wdxllubrifontjpn/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "symbols2"
-primary_script: "Hant"
+primary_script: "Jpan"
 source {
   repository_url: "https://github.com/NightFurySL2001/WD-XL-font"
   commit: "75c4a3bb2fffefa0f0aae470c2c0a73d6f79d0b9"

--- a/ofl/wdxllubrifontsc/METADATA.pb
+++ b/ofl/wdxllubrifontsc/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "symbols2"
-primary_script: "Hani"
+primary_script: "Hant"
 source {
   repository_url: "https://github.com/NightFurySL2001/WD-XL-font"
   commit: "75c4a3bb2fffefa0f0aae470c2c0a73d6f79d0b9"

--- a/ofl/wdxllubrifontsc/METADATA.pb
+++ b/ofl/wdxllubrifontsc/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "symbols2"
-primary_script: "Hant"
+primary_script: "Hans"
 source {
   repository_url: "https://github.com/NightFurySL2001/WD-XL-font"
   commit: "75c4a3bb2fffefa0f0aae470c2c0a73d6f79d0b9"

--- a/ofl/wdxllubrifonttc/METADATA.pb
+++ b/ofl/wdxllubrifonttc/METADATA.pb
@@ -18,7 +18,7 @@ subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "symbols2"
-primary_script: "Hani"
+primary_script: "Hant"
 source {
   repository_url: "https://github.com/NightFurySL2001/WD-XL-font"
   commit: "75c4a3bb2fffefa0f0aae470c2c0a73d6f79d0b9"


### PR DESCRIPTION
cc @aaronbell @chrissimpkins @garretrieger 

Update `primary_script`: `hani` -> `hunt` for **WDXL Lubrifont SC** and **WDXL Lubrifont TC**

This solved the specimen issue we had with **WDXL Lubrifont JP N**.


<img width="834" alt="Screenshot 2025-05-16 at 10 14 16" src="https://github.com/user-attachments/assets/4552f12e-b476-4a8c-9928-9bdedc9ddcc1" />


But, @aaronbell, maybe we should use different primary scripts for these 3 different fonts?