### PR TITLE
Resolve Python logger warnings

### DIFF
--- a/axisregistry/Lib/axisregistry/__init__.py
+++ b/axisregistry/Lib/axisregistry/__init__.py
@@ -96,7 +96,7 @@ class AxisRegistry:
         }
         for axis in axes_in_font:
             if axis not in self.keys():
-                log.warn(f"Axis {axis} not found in GF Axis Registry!")
+                log.warning(f"Axis {axis} not found in GF Axis Registry!")
                 continue
             for fallback in self[axis].fallback:
                 if (


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
