### PR TITLE
Update Chocolate Sans to 1.005

### DIFF
--- a/ofl/chocolateclassicalsans/METADATA.pb
+++ b/ofl/chocolateclassicalsans/METADATA.pb
@@ -19,11 +19,11 @@ subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
 source {
-  repository_url: "https://github.com/aaronbell/ChocolateSans"
-  commit: "91c9c5179adc1b2af2de1e3972d91e5e62c7bbc4"
+  repository_url: "https://github.com/MoonlitOwen/ChocolateSans"
+  commit: "0446a76d969f9788b0b339a9923f6541699df903"
   config_yaml: "sources/project.yaml"
   files {
-    source_file: "OFL.txt"
+    source_file: "license.md"
     dest_file: "OFL.txt"
   }
   files {


### PR DESCRIPTION
This is an update to the Chocolate Sans project with improvements made upstream since the original submission, but also now building with a new system per the upstream maintainer's preference. 



This version features a number of changes (some vs the original source):
- Bug fixes and other modifications to to TC source
- Integration of better latin coverage.
- vertical metrics updated to follow our new standard. 
- renamed some very long glyph names:
* katakanasmallhu_katakanahiraganasemivoicedsoundmarkcombkana.ccmp
* katakanasmallhu_katakanahiraganasemivoicedsoundmarkcombkana.ccmp.1

- Adjust anchor in glyphs and add anchors to dotted circle ($25CC)
* uni0300
* uni0301
* uni0307
* uni030C

- uni9E44 - fixed overlap issue due to overlapping contours where is quadratic and one is cubic.

- Cleared overlapping segments / duplicate contours on various glyphs
* uni50C6
* uni5966
* uni79BB
* uni7E34
* uni8506
* uni8867
* uni9C40

- Switching metadata to point to the upstream repository.