### PR TITLE
Documenting Font Sources, 2025-05-22

### DIFF
--- a/ofl/abhayalibre/METADATA.pb
+++ b/ofl/abhayalibre/METADATA.pb
@@ -54,7 +54,7 @@ subsets: "menu"
 subsets: "sinhala"
 source {
   repository_url: "https://github.com/mooniak/abhaya-libre-font"
-  commit: "ade314aa678ceb44f892ed58169c6b270c775d02"
+  commit: "f53da70786fe1dba6193bdbd45a2c4159e511079"
   config_yaml: "sources/config.yaml"
 }
 primary_script: "Sinh"

--- a/ofl/adlamdisplay/METADATA.pb
+++ b/ofl/adlamdisplay/METADATA.pb
@@ -32,6 +32,6 @@ source {
     dest_file: "ADLaMDisplay-Regular.ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 primary_script: "Adlm"

--- a/ofl/afacadflux/METADATA.pb
+++ b/ofl/afacadflux/METADATA.pb
@@ -38,6 +38,6 @@ source {
     dest_file: "AfacadFlux[slnt,wght].ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "sources/config_flux.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/alkatra/METADATA.pb
+++ b/ofl/alkatra/METADATA.pb
@@ -39,5 +39,5 @@ source {
     dest_file: "DESCRIPTION.en_us.html"
   }
   branch: "master"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }

--- a/ofl/ancizarsans/METADATA.pb
+++ b/ofl/ancizarsans/METADATA.pb
@@ -33,6 +33,7 @@ axes {
 source {
   repository_url: "https://github.com/UNAL-OMD/UNAL-Ancizar"
   commit: "54a5aa2153b4485ff2710612d47183c346e6b842"
+  config_yaml: "sources/config-sans.yaml"
   files {
     source_file: "article/ARTICLE.en_us.html"
     dest_file: "article/ARTICLE.en_us.html"

--- a/ofl/ancizarserif/METADATA.pb
+++ b/ofl/ancizarserif/METADATA.pb
@@ -33,6 +33,7 @@ axes {
 source {
   repository_url: "https://github.com/UNAL-OMD/UNAL-Ancizar"
   commit: "063bdd3121fef76289b035226acdc1b4e885f31a"
+  config_yaml: "sources/config-serif.yaml"
   files {
     source_file: "article/ARTICLE.en_us.html"
     dest_file: "article/ARTICLE.en_us.html"

--- a/ofl/antonio/METADATA.pb
+++ b/ofl/antonio/METADATA.pb
@@ -36,7 +36,7 @@ source {
     dest_file: "Antonio[wght].ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/anybody/METADATA.pb
+++ b/ofl/anybody/METADATA.pb
@@ -52,7 +52,7 @@ source {
     dest_file: "Anybody-Italic[wdth,wght].ttf"
   }
   branch: "master"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/bagelfatone/METADATA.pb
+++ b/ofl/bagelfatone/METADATA.pb
@@ -32,6 +32,6 @@ source {
     dest_file: "BagelFatOne-Regular.ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 primary_script: "Kore"

--- a/ofl/diphylleia/METADATA.pb
+++ b/ofl/diphylleia/METADATA.pb
@@ -32,6 +32,6 @@ source {
     dest_file: "Diphylleia-Regular.ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 primary_script: "Kore"

--- a/ofl/gasoekone/METADATA.pb
+++ b/ofl/gasoekone/METADATA.pb
@@ -32,7 +32,7 @@ source {
     dest_file: "GasoekOne-Regular.ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 primary_script: "Kore"
 stroke: "SANS_SERIF"

--- a/ofl/gluten/METADATA.pb
+++ b/ofl/gluten/METADATA.pb
@@ -38,7 +38,7 @@ source {
     dest_file: "Gluten[slnt,wght].ttf"
   }
   branch: "master"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 classifications: "DISPLAY"
 classifications: "HANDWRITING"

--- a/ofl/grandifloraone/METADATA.pb
+++ b/ofl/grandifloraone/METADATA.pb
@@ -32,7 +32,7 @@ source {
     dest_file: "GrandifloraOne-Regular.ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 primary_script: "Kore"
 classifications: "DISPLAY"

--- a/ofl/grandstander/METADATA.pb
+++ b/ofl/grandstander/METADATA.pb
@@ -33,7 +33,7 @@ axes {
 source {
   repository_url: "https://github.com/Etcetera-Type-Co/Grandstander"
   commit: "0bf9e31d529d7a67b23510b841cb3597db0cb130"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 minisite_url: "https://etceteratype.co/grandstander"
 classifications: "DISPLAY"

--- a/ofl/hanuman/METADATA.pb
+++ b/ofl/hanuman/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 source {
   repository_url: "https://github.com/danhhong/Hanuman"
   commit: "7188b3c0e5722ad0126f045d4eeb895176e12c14"
+  config_yaml: "Source/builder.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/karantina/METADATA.pb
+++ b/ofl/karantina/METADATA.pb
@@ -58,6 +58,6 @@ source {
     dest_file: "Karantina-Bold.ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 primary_script: "Hebr"

--- a/ofl/matangi/METADATA.pb
+++ b/ofl/matangi/METADATA.pb
@@ -23,7 +23,8 @@ axes {
 }
 source {
   repository_url: "https://github.com/thegraphicant/Matangi"
-  commit: "81c68488ff396d1264c6e9d195f106ff85e124ec"
+  commit: "c67a7d9b7d52f4582b7167131d46e2992563ea66"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/moiraione/METADATA.pb
+++ b/ofl/moiraione/METADATA.pb
@@ -32,6 +32,6 @@ source {
     dest_file: "MoiraiOne-Regular.ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 primary_script: "Kore"

--- a/ofl/nokora/METADATA.pb
+++ b/ofl/nokora/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 source {
   repository_url: "https://github.com/danhhong/Nokora"
   commit: "9c5f991b700b9be3519315a854a7b986e6877ace"
+  config_yaml: "Source/builder.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/notosansarmenian/METADATA.pb
+++ b/ofl/notosansarmenian/METADATA.pb
@@ -28,6 +28,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/armenian"
+  commit: "6eda0736b79b405c7151fd558c83ecec1c9c534c"
   archive_url: "https://github.com/notofonts/armenian/releases/download/NotoSansArmenian-v2.008/NotoSansArmenian-v2.008.zip"
   config_yaml: "sources/config-sans-armenian.yaml"
   files {

--- a/ofl/notoserifarmenian/METADATA.pb
+++ b/ofl/notoserifarmenian/METADATA.pb
@@ -29,6 +29,7 @@ axes {
 source {
   repository_url: "https://github.com/notofonts/armenian"
   archive_url: "https://github.com/notofonts/armenian/releases/download/NotoSerifArmenian-v2.008/NotoSerifArmenian-v2.008.zip"
+  commit: "6eda0736b79b405c7151fd558c83ecec1c9c534c"
   config_yaml: "sources/config-serif-armenian.yaml"
   files {
     source_file: "DESCRIPTION.en_us.html"

--- a/ofl/orbit/METADATA.pb
+++ b/ofl/orbit/METADATA.pb
@@ -32,6 +32,6 @@ source {
     dest_file: "Orbit-Regular.ttf"
   }
   branch: "main"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 primary_script: "Kore"

--- a/ofl/savate/METADATA.pb
+++ b/ofl/savate/METADATA.pb
@@ -31,6 +31,7 @@ axes {
 }
 source {
   repository_url: "https://github.com/maxesnee/savate"
+  config_yaml: "sources/config.yaml"
   commit: "ca21a81c2b28507638e9290e9d2c26ff863dd32d"
   files {
     source_file: "OFL.txt"

--- a/ofl/tourney/METADATA.pb
+++ b/ofl/tourney/METADATA.pb
@@ -51,7 +51,7 @@ source {
     dest_file: "Tourney[wdth,wght].ttf"
   }
   branch: "master"
-  config_yaml: "sources/config.yaml"
+  config_yaml: "Sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
This is a small batch, which includes updated font-sources repository info for families onboarded in the past few weeks as well as some fixes to issues pointed out by @cmyr in the process of reviewing https://github.com/googlefonts/google-fonts-sources/pull/59

## Stats summary
* Font families with full source info: 786 of 1906 (41.24% of GF Library)
* 7 more (0.26% more) than [previous batch](https://github.com/google/fonts/pull/9422)
* Progress is being tracked at https://docs.google.com/spreadsheets/d/1ao3k56FwQy6W0Ll5QbU_wpuKEvNPYcn8YyEU9_L8O4Q/edit?usp=sharing