### PR TITLE
Lists of the 22th of May

### DIFF
--- a/to_production.txt
+++ b/to_production.txt
@@ -1,26 +1,42 @@
 # New
+ofl/astasans # https://github.com/google/fonts/pull/9413
+ofl/huninn # https://github.com/google/fonts/pull/9228
 ofl/notoserifdivesakuru # https://github.com/google/fonts/pull/9047
-ofl/wdxllubrifonttc # https://github.com/google/fonts/pull/9380
+ofl/savate # https://github.com/google/fonts/pull/9453
+ofl/wdxllubrifontjpn # https://github.com/google/fonts/pull/9294
+ofl/wdxllubrifontsc # https://github.com/google/fonts/pull/9292
 
 # Upgrade
-# Deleted: apache/robotomono # https://github.com/google/fonts/pull/9282
 ofl/baskervville # https://github.com/google/fonts/pull/9375
+ofl/baskervvillesc # https://github.com/google/fonts/pull/9376
+ofl/fustat # https://github.com/google/fonts/pull/9417
 ofl/kapakana # https://github.com/google/fonts/pull/8592
+ofl/nokora # https://github.com/google/fonts/pull/9412
 ofl/notosansthailooped # https://github.com/google/fonts/pull/9090
 ofl/sourcecodepro # https://github.com/google/fonts/pull/9362
 
 # Designer profile
+catalog/designers/alemetadesse # https://github.com/google/fonts/pull/9140
 catalog/designers/alistairmccready # https://github.com/google/fonts/pull/9327
+catalog/designers/alvarofranca # https://github.com/google/fonts/pull/9373
+catalog/designers/anrt # https://github.com/google/fonts/pull/9386
 catalog/designers/azzaalameddine # https://github.com/google/fonts/pull/9197
 # Deleted: catalog/designers/cal.com,inc. # https://github.com/google/fonts/pull/9250
 catalog/designers/cesarpuertas # https://github.com/google/fonts/pull/9307
+catalog/designers/columntype # https://github.com/google/fonts/pull/9140
 catalog/designers/gunjanpanchal # https://github.com/google/fonts/pull/9272
+catalog/designers/jeremyshellhorn # https://github.com/google/fonts/pull/9369
 catalog/designers/julianmoncada # https://github.com/google/fonts/pull/9307
+catalog/designers/maxesnee # https://github.com/google/fonts/pull/9445
+catalog/designers/naipefoundry # https://github.com/google/fonts/pull/9373
+catalog/designers/plombtype # https://github.com/google/fonts/pull/9446
+catalog/designers/raphaelalegbeleye # https://github.com/google/fonts/pull/9140
 catalog/designers/siringunkloy # https://github.com/google/fonts/pull/9199
 catalog/designers/tomgrace # https://github.com/google/fonts/pull/9206
 catalog/designers/unal # https://github.com/google/fonts/pull/9307
 catalog/designers/veraevstafieva # https://github.com/google/fonts/pull/9207
 catalog/designers/vivianamonsalve # https://github.com/google/fonts/pull/9307
+catalog/designers/yikunoamlakayalew # https://github.com/google/fonts/pull/9140
 
 # Knowledge
 cc-by-sa/knowledge/modules/readability_and_accessibility/lessons/how_type_influences_readability/content.md # https://github.com/google/fonts/pull/9322
@@ -33,14 +49,22 @@ ofl/alef # https://github.com/google/fonts/pull/9331
 ofl/andika # https://github.com/google/fonts/pull/9114
 ofl/arya # https://github.com/google/fonts/pull/9331
 ofl/asul # https://github.com/google/fonts/pull/9364
+ofl/cactusclassicalserif # https://github.com/google/fonts/pull/9298
+ofl/calsans # https://github.com/google/fonts/pull/9406
+ofl/cascadiacode # https://github.com/google/fonts/pull/9359
+ofl/cascadiamono # https://github.com/google/fonts/pull/9359
+ofl/chocolateclassicalsans # https://github.com/google/fonts/pull/9298
 ofl/climatecrisis # https://github.com/google/fonts/pull/9114
 ofl/danfo # https://github.com/google/fonts/pull/9114
 ofl/doto # https://github.com/google/fonts/pull/9114
 ofl/eczar # https://github.com/google/fonts/pull/9331
+ofl/eduauvicwantarrows # https://github.com/google/fonts/pull/9411
+ofl/eduauvicwantdots # https://github.com/google/fonts/pull/9411
 ofl/gamaamli # https://github.com/google/fonts/pull/9114
 ofl/gurajada # https://github.com/google/fonts/pull/9364
 ofl/hindmadurai # https://github.com/google/fonts/pull/9331
 ofl/italiana # https://github.com/google/fonts/pull/9364
+ofl/kablammo # https://github.com/google/fonts/pull/9372
 ofl/kurale # https://github.com/google/fonts/pull/9331
 ofl/laila # https://github.com/google/fonts/pull/9364
 ofl/lexend # https://github.com/google/fonts/pull/9114
@@ -51,10 +75,14 @@ ofl/lexendmega # https://github.com/google/fonts/pull/9114
 ofl/lexendpeta # https://github.com/google/fonts/pull/9114
 ofl/lexendtera # https://github.com/google/fonts/pull/9114
 ofl/lexendzetta # https://github.com/google/fonts/pull/9114
+ofl/librebarcode39 # https://github.com/google/fonts/pull/9411
+ofl/lxgwwenkaimonotc # https://github.com/google/fonts/pull/9298
+ofl/lxgwwenkaitc # https://github.com/google/fonts/pull/9298
 ofl/matemasie # https://github.com/google/fonts/pull/9114
 ofl/mingzat # https://github.com/google/fonts/pull/9114
 ofl/miriamlibre # https://github.com/google/fonts/pull/9331
 ofl/narnoor # https://github.com/google/fonts/pull/9364
+ofl/nationalpark # https://github.com/google/fonts/pull/9368
 ofl/notoserif # https://github.com/google/fonts/pull/9263
 ofl/ojuju # https://github.com/google/fonts/pull/9114
 ofl/onest # https://github.com/google/fonts/pull/9114
@@ -79,6 +107,7 @@ ofl/tiltneon # https://github.com/google/fonts/pull/9114
 ofl/tiltprism # https://github.com/google/fonts/pull/9114
 ofl/tiltwarp # https://github.com/google/fonts/pull/9114
 ofl/trainone # https://github.com/google/fonts/pull/9331
+ofl/wdxllubrifonttc # https://github.com/google/fonts/pull/9463
 ofl/winkyrough # https://github.com/google/fonts/pull/9340
 ofl/yujiboku # https://github.com/google/fonts/pull/9331
 ofl/yujimai # https://github.com/google/fonts/pull/9331
@@ -111,3 +140,9 @@ lang/languages/tum_Latn.textproto # https://github.com/google/fonts/pull/9054
 lang/languages/wdt_Latn.textproto # https://github.com/google/fonts/pull/9054
 lang/languages/yo_Latn.textproto # https://github.com/google/fonts/pull/9054
 lang/scripts/Diak.textproto # https://github.com/google/fonts/pull/9054
+
+# Other
+ofl/kumaroneoutline # https://github.com/google/fonts/pull/9332
+ofl/mplusrounded1c # https://github.com/google/fonts/pull/9332
+ofl/notoznamennymusicalnotation # https://github.com/google/fonts/pull/9337
+ofl/sawarabigothic # https://github.com/google/fonts/pull/9332

--- a/to_production.txt
+++ b/to_production.txt
@@ -1,10 +1,7 @@
 # New
 ofl/astasans # https://github.com/google/fonts/pull/9413
-ofl/huninn # https://github.com/google/fonts/pull/9228
 ofl/notoserifdivesakuru # https://github.com/google/fonts/pull/9047
 ofl/savate # https://github.com/google/fonts/pull/9453
-ofl/wdxllubrifontjpn # https://github.com/google/fonts/pull/9294
-ofl/wdxllubrifontsc # https://github.com/google/fonts/pull/9292
 
 # Upgrade
 ofl/baskervville # https://github.com/google/fonts/pull/9375

--- a/to_sandbox.txt
+++ b/to_sandbox.txt
@@ -1,46 +1,31 @@
 # New
-ofl/astasans # https://github.com/google/fonts/pull/9413
-ofl/savate # https://github.com/google/fonts/pull/9453
-ofl/wdxllubrifontjpn # https://github.com/google/fonts/pull/9294
-ofl/wdxllubrifontsc # https://github.com/google/fonts/pull/9292
+ofl/chironsunghk # https://github.com/google/fonts/pull/9478
+ofl/lxgwmarkergothic # https://github.com/google/fonts/pull/9429
+ofl/matangi # https://github.com/google/fonts/pull/9481
 
 # Upgrade
-ofl/baskervvillesc # https://github.com/google/fonts/pull/9376
-ofl/fustat # https://github.com/google/fonts/pull/9417
-ofl/nokora # https://github.com/google/fonts/pull/9412
+ofl/gidugu # https://github.com/google/fonts/pull/9426
+ofl/hanuman # https://github.com/google/fonts/pull/9469
 
 # Designer profile
-catalog/designers/alemetadesse # https://github.com/google/fonts/pull/9140
-catalog/designers/alvarofranca # https://github.com/google/fonts/pull/9373
-catalog/designers/anrt # https://github.com/google/fonts/pull/9386
-catalog/designers/columntype # https://github.com/google/fonts/pull/9140
 catalog/designers/contrastfoundry(cofo) # https://github.com/google/fonts/pull/9326
 catalog/designers/grillitype # https://github.com/google/fonts/pull/9325
-catalog/designers/jeremyshellhorn # https://github.com/google/fonts/pull/9369
-catalog/designers/maxesnee # https://github.com/google/fonts/pull/9445
-catalog/designers/naipefoundry # https://github.com/google/fonts/pull/9373
-catalog/designers/plombtype # https://github.com/google/fonts/pull/9446
-catalog/designers/raphaelalegbeleye # https://github.com/google/fonts/pull/9140
+catalog/designers/thegraphicant # https://github.com/google/fonts/pull/9482
 catalog/designers/typenetwork # https://github.com/google/fonts/pull/9324
-catalog/designers/yikunoamlakayalew # https://github.com/google/fonts/pull/9140
 
 # Metadata / Description / License
-ofl/cactusclassicalserif # https://github.com/google/fonts/pull/9298
-ofl/calsans # https://github.com/google/fonts/pull/9406
-ofl/cascadiacode # https://github.com/google/fonts/pull/9359
-ofl/cascadiamono # https://github.com/google/fonts/pull/9359
-ofl/chocolateclassicalsans # https://github.com/google/fonts/pull/9298
-ofl/eduauvicwantarrows # https://github.com/google/fonts/pull/9411
-ofl/eduauvicwantdots # https://github.com/google/fonts/pull/9411
-ofl/huninn # https://github.com/google/fonts/pull/9384
-ofl/kablammo # https://github.com/google/fonts/pull/9372
-ofl/librebarcode39 # https://github.com/google/fonts/pull/9411
-ofl/lxgwwenkaimonotc # https://github.com/google/fonts/pull/9298
-ofl/lxgwwenkaitc # https://github.com/google/fonts/pull/9298
-ofl/nationalpark # https://github.com/google/fonts/pull/9368
+ofl/cactusclassicalserif # https://github.com/google/fonts/pull/9451
+ofl/chocolateclassicalsans # https://github.com/google/fonts/pull/9451
+ofl/iansui # https://github.com/google/fonts/pull/9451
+ofl/qahiri # https://github.com/google/fonts/pull/9480
+ofl/spacemono # https://github.com/google/fonts/pull/9483
 
-# Other
-ofl/kumaroneoutline # https://github.com/google/fonts/pull/9332
-ofl/mplusrounded1c # https://github.com/google/fonts/pull/9332
-ofl/notoznamennymusicalnotation # https://github.com/google/fonts/pull/9337
-ofl/sawarabigothic # https://github.com/google/fonts/pull/9332
+# Sample texts
+lang/languages/bal_Arab.textproto # https://github.com/google/fonts/pull/9461
+lang/languages/ff_Adlm.textproto # https://github.com/google/fonts/pull/9461
+lang/languages/kab_Latn.textproto # https://github.com/google/fonts/pull/9461
+lang/languages/kk_Arab.textproto # https://github.com/google/fonts/pull/9461
+lang/languages/kpz_Latn.textproto # https://github.com/google/fonts/pull/9461
+lang/languages/mgz_Latn.textproto # https://github.com/google/fonts/pull/9461
+lang/languages/prs_Arab.textproto # https://github.com/google/fonts/pull/9461
+lang/languages/so_Arab.textproto # https://github.com/google/fonts/pull/9461


### PR DESCRIPTION
@chrissimpkins Here you can find the lists!

@evanwadams, some notes for you:
- Savate (font + designers) needs to reach prod before the 18th of June
- [Chiron Sung HK](https://github.com/google/fonts/pull/9478) needs to stay in Sandbox once it's pushed in it
- 42dot has to be delisted, since it will be replaced by #9413
- We have an issue with https://github.com/google/fonts/pull/9380: Primary_script should be `Hant` and not `Hani`. It has been changed here, but not pushed, unlike the other ones: https://github.com/google/fonts/pull/9463/files

Let me know if you have any questions!