### PR TITLE
Updating Cactus Serif to version 1.005

### DIFF
--- a/ofl/cactusclassicalserif/METADATA.pb
+++ b/ofl/cactusclassicalserif/METADATA.pb
@@ -19,18 +19,8 @@ subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
 source {
-  repository_url: "https://github.com/aaronbell/CactusSerif"
-  commit: "1d5b4158aa0411f7b1279f4bfa3f49416ba0b15d"
-  config_yaml: "sources/project.yaml"
-  files {
-    source_file: "OFL.txt"
-    dest_file: "OFL.txt"
-  }
-  files {
-    source_file: "fonts/ttf/CactusClassicalSerif-Regular.ttf"
-    dest_file: "CactusClassicalSerif-Regular.ttf"
-  }
-  branch: "main"
+  repository_url: "https://github.com/MoonlitOwen/CactusSerif"
+  commit: "a267f9f32087eb9e6a9203c734cb952a64bc05be"
 }
 primary_script: "Hant"
 primary_language: "yue_Hant"


### PR DESCRIPTION
Fairly significant update to Cactus Classical Serif including expanded Latin language coverage, and bug fixes / improvements for the Chinese portion. 

Font is now building directly in the upstream repository (https://github.com/MoonlitOwen/CactusSerif) 
Thanks to @NightFurySL2001 for assistance in getting this project ready. 