### PR TITLE
report.yaml: add family_data.json

### DIFF
--- a/.ci/dashboard/src/data/versionhistory.json
+++ b/.ci/dashboard/src/data/versionhistory.json
@@ -5545,6 +5545,10 @@
       {
         "version": "Version 1.000; ttfautohint (v1.8.4)",
         "date": "2023-10-26T09:09:29.267337"
+      },
+      {
+        "version": "Version 2.000; ttfautohint (v1.8.4.7-5d5b)",
+        "date": "2025-07-03T13:40:42.823402"
       }
     ]
   },
@@ -8530,6 +8534,10 @@
       {
         "version": "Version 1.7",
         "date": "1970-01-01T00:00:00"
+      },
+      {
+        "version": "Version 1.899",
+        "date": "2025-07-03T13:40:43.626367"
       }
     ]
   },
@@ -12394,6 +12402,10 @@
       {
         "version": "Version 1.005",
         "date": "1970-01-01T00:00:00"
+      },
+      {
+        "version": "Version 1.899",
+        "date": "2025-07-03T13:40:42.970873"
       }
     ]
   },
@@ -27004,6 +27016,10 @@
       {
         "version": "Version 3.001",
         "date": "1970-01-01T00:00:00"
+      },
+      {
+        "version": "Version 3.002",
+        "date": "2025-07-03T13:40:43.283135"
       }
     ]
   },
@@ -30550,6 +30566,10 @@
       {
         "version": "Version 1.002",
         "date": "2025-03-19T02:12:24.428467"
+      },
+      {
+        "version": "Version 1.005",
+        "date": "2025-07-03T13:40:43.329911"
       }
     ]
   },
@@ -39354,6 +39374,12 @@
         "version": "Version 7.051;RELEASE",
         "date": "2025-06-23T17:08:55.433623"
       }
+    ],
+    "production": [
+      {
+        "version": "Version 7.051;RELEASE",
+        "date": "2025-07-03T13:40:43.006488"
+      }
     ]
   },
   "Roboto Mono": {
@@ -39435,6 +39461,12 @@
       {
         "version": "Version 7.051;RELEASE",
         "date": "2025-06-23T17:08:55.468091"
+      }
+    ],
+    "production": [
+      {
+        "version": "Version 7.051;RELEASE",
+        "date": "2025-07-03T13:40:42.921820"
       }
     ]
   },
@@ -39664,6 +39696,10 @@
       {
         "version": "Version 3.002",
         "date": "2025-05-22T01:57:26.330105"
+      },
+      {
+        "version": "Version 3.003",
+        "date": "2025-07-03T13:40:43.407755"
       }
     ],
     "sandbox": [
@@ -39739,6 +39775,12 @@
         "version": "Version 3.000; ttfautohint (v1.8.4.7-5d5b)",
         "date": "2025-06-06T03:38:15.748086"
       }
+    ],
+    "production": [
+      {
+        "version": "Version 3.000; ttfautohint (v1.8.4.7-5d5b)",
+        "date": "2025-07-03T13:40:43.146900"
+      }
     ]
   },
   "Menbere": {
@@ -39752,6 +39794,12 @@
       {
         "version": "Version 1.000",
         "date": "2025-06-20T12:43:38.767867"
+      }
+    ],
+    "production": [
+      {
+        "version": "Version 1.000",
+        "date": "2025-07-03T13:40:42.719994"
       }
     ]
   },
@@ -39781,6 +39829,12 @@
         "version": "Version 1.001",
         "date": "2025-06-20T12:43:38.543218"
       }
+    ],
+    "production": [
+      {
+        "version": "Version 1.001",
+        "date": "2025-07-03T13:40:42.913973"
+      }
     ]
   },
   "UoqMunThenKhung": {
@@ -39794,6 +39848,12 @@
       {
         "version": "Version 1.197",
         "date": "2025-06-20T12:43:38.579983"
+      }
+    ],
+    "production": [
+      {
+        "version": "Version 1.197",
+        "date": "2025-07-03T13:40:43.716293"
       }
     ]
   },
@@ -39837,6 +39897,12 @@
         "version": "Version 3.000",
         "date": "2025-06-20T12:43:38.855505"
       }
+    ],
+    "production": [
+      {
+        "version": "Version 3.000",
+        "date": "2025-07-03T13:40:42.713670"
+      }
     ]
   },
   "Noto Sans Sunuwar": {
@@ -39850,6 +39916,12 @@
       {
         "version": "Version 1.000; ttfautohint (v1.8.4.7-5d5b)",
         "date": "2025-06-20T12:43:38.966916"
+      }
+    ],
+    "production": [
+      {
+        "version": "Version 1.000; ttfautohint (v1.8.4.7-5d5b)",
+        "date": "2025-07-03T13:40:43.470194"
       }
     ]
   },
@@ -39878,6 +39950,52 @@
       {
         "version": "Version 2.525",
         "date": "2025-06-20T12:43:39.005216"
+      }
+    ],
+    "production": [
+      {
+        "version": "Version 2.525",
+        "date": "2025-07-03T13:40:42.667761"
+      }
+    ]
+  },
+  "Libertinus Sans": {
+    "dev": [
+      {
+        "version": "Version 7.051;RELEASE",
+        "date": "2025-07-03T13:40:42.802328"
+      }
+    ]
+  },
+  "Nata Sans": {
+    "dev": [
+      {
+        "version": "Version 1.001",
+        "date": "2025-07-03T13:40:43.257251"
+      }
+    ]
+  },
+  "Mozilla Headline": {
+    "dev": [
+      {
+        "version": "Version 1.000",
+        "date": "2025-07-03T13:40:43.387170"
+      }
+    ]
+  },
+  "Mozilla Text": {
+    "dev": [
+      {
+        "version": "Version 1.000",
+        "date": "2025-07-03T13:40:43.413023"
+      }
+    ]
+  },
+  "Libertinus Serif": {
+    "dev": [
+      {
+        "version": "Version 7.051;RELEASE",
+        "date": "2025-07-03T13:40:43.480346"
       }
     ]
   }

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -76,6 +76,7 @@ jobs:
           npm run build
           gftools compare-meta --meta -o build/meta.html
           cp ../tags.html build/tags.html
+          cp ../family_data.json build/family_data.json
           cp ../vf-tag-demo2.html build/vf-tag-demo2.html
         working-directory: .ci/dashboard
       - name: Upload build artifacts


### PR DESCRIPTION
Recent dashboard updates have stopped serving the `family_data.json`. This file is needed for the tagger, otherwise no tags load.

cc @simoncozens 