### PR TITLE
Add a PAT to the auto-commit-action

### DIFF
--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -55,6 +55,7 @@ jobs:
         name: Commit any updated data files
         with:
           file_pattern: ".ci/dashboard/src/data/"
+          token: ${{ secrets.GH_TOKEN }}
 
       # Now build the dashboard
       - name: Install Node.js


### PR DESCRIPTION
Now that `main` is protected (which is good!) our actions can't just auto-commit stuff to it anymore. Which is good, I guess, but a but annoying. So we need to do the commit as a user who has permission to bypass the branch protection rules. We have a `GH_TOKEN` secret defined already, which I *guess* is for admin, so that should do the job.