### PR TITLE
Designer: update Google profile

### DIFF
--- a/catalog/designers/google/bio.html
+++ b/catalog/designers/google/bio.html
@@ -5,3 +5,4 @@ This vision continues to guide all of us at Google.
 We believe in technology’s power and potential to have a profoundly positive impact across the world.
 </p>
 
+<p><a href="https://about.google">about.google</a></p>

--- a/catalog/designers/google/info.pb
+++ b/catalog/designers/google/info.pb
@@ -1,5 +1,5 @@
 designer: "Google"
-link: "https://about.google"
+link: ""
 avatar {
   file_name: "google.png"
 }


### PR DESCRIPTION
@davelab6 

We don't usually fill that `link:""` field, but since it was for Google, I though it was a special process and I merged your PR to see how it looks in dev. No bug, but now we have this kind of **WARN** in PRs:

```
⚠️ WARN METADATA.pb: Designers are listed correctly on the Google Fonts catalog? (googlefonts/metadata/designer_profiles)
⚠️ WARN Currently the link field is not used by the GFonts API. Designer webpage links should, for now, be placed directly on the bio.html file. [code: link-field]
```

So I removed the link from **info.pb** and added it in **bio.html**