### PR TITLE
Add `primary_language` field to Chiron fonts

### DIFF
--- a/ofl/chirongoroundtc/METADATA.pb
+++ b/ofl/chirongoroundtc/METADATA.pb
@@ -29,3 +29,4 @@ source {
   branch: "source"
 }
 primary_script: "Hant"
+primary_language: "yue_Hant"

--- a/ofl/chironheihk/METADATA.pb
+++ b/ofl/chironheihk/METADATA.pb
@@ -43,3 +43,4 @@ source {
   branch: "source"
 }
 primary_script: "Hant"
+primary_language: "yue_Hant"

--- a/ofl/chironsunghk/METADATA.pb
+++ b/ofl/chironsunghk/METADATA.pb
@@ -41,3 +41,4 @@ source {
   branch: "source"
 }
 primary_script: "Hant"
+primary_language: "yue_Hant"


### PR DESCRIPTION
I am the author of *Chiron Hei HK*, *Chiron Sung HK*, and *Chiron GoRound TC*. Currently, the sample text of these fonts is shown in Min Chinese by default. I'd like the sample text to be in Cantonese by default, and the fonts also be listed under the *Cantonese (Traditional)* language. With reference to https://github.com/google/fonts/pull/7792, this PR updates the metadata file of the three fonts with the `primary_language` field set to `yue_Hant`.
