### PR TITLE
families.csv: Add test VF tags

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -7817,6 +7817,8 @@ Matemasie,,/Quality/Spacing,90
 Matemasie,,/Quality/Wordspace,100
 Matemasie,,/Seasonal/Valentine's Day,65
 Maven Pro,,/Expressive/Calm,75
+Maven Pro,wght@400,/Expressive/Loud,3
+Maven Pro,wght@900,/Expressive/Loud,88
 Maven Pro,,/Expressive/Stiff,91
 Maven Pro,,/Quality/Concept,50
 Maven Pro,,/Quality/Drawing,60
@@ -10318,6 +10320,10 @@ Oooh Baby,,/Script/Informal,100
 Oooh Baby,,/Seasonal/Valentine's Day,85
 Open Sans,,/Expressive/Business,98.5
 Open Sans,,/Expressive/Calm,87.9
+Open Sans,"wght,wdth@600,75",/Expressive/Loud,21
+Open Sans,"wght,wdth@600,100",/Expressive/Loud,15
+Open Sans,"wght,wdth@800,75",/Expressive/Loud,80
+Open Sans,"wght,wdth@800,100",/Expressive/Loud,75
 Open Sans,,/Quality/Concept,70
 Open Sans,,/Quality/Drawing,70
 Open Sans,,/Quality/Spacing,80
@@ -13120,9 +13126,9 @@ STIX Two Text,,/Quality/Drawing,70
 STIX Two Text,,/Quality/Spacing,80
 STIX Two Text,,/Quality/Wordspace,80
 STIX Two Text,,/Serif/Transitional,100
-SUSE Mono,,/Monospace/Monospace,100
 SUSE Mono,,/Expressive/Calm,80
 SUSE Mono,,/Expressive/Futuristic,30
+SUSE Mono,,/Monospace/Monospace,100
 SUSE Mono,,/Quality/Concept,70
 SUSE Mono,,/Quality/Drawing,70
 SUSE Mono,,/Quality/Spacing,80


### PR DESCRIPTION
@nyshadhr9 This PR tests two families, Maven Pro and Open Sans. Open Sans has two axes that affect how loud the family is, hence the need for 4 tags. Maven Pro only has a weight axis so we only need 2 tags 

If I was tagging a family that had 3 axes that affected the Loud category, I'd need to add a minimum of 8 positions. Is the above logic sound?