### PR TITLE
Remove "cherokee" from subset and "Cher" from primary_script for Genos

### DIFF
--- a/ofl/genos/METADATA.pb
+++ b/ofl/genos/METADATA.pb
@@ -21,7 +21,6 @@ fonts {
   full_name: "Genos Thin Italic"
   copyright: "Copyright 2011 The Genos Project Authors (https://github.com/googlefonts/genos)"
 }
-subsets: "cherokee"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
@@ -53,6 +52,5 @@ source {
   branch: "master"
   config_yaml: "sources/config.yml"
 }
-primary_script: "Cher"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
Half of the base characters from Cherokee [METADATA](https://github.com/google/fonts/blob/zhao_genos/lang/Lib/gflanguages/data/languages/chr_Cher.textproto) are not supported in Genos. You can go to the [specimen page](https://fonts.google.com/specimen/Genos?preview.text=%E1%8E%A0%E1%8E%A1%E1%8E%A2%E1%8E%A3%E1%8E%A4%E1%8E%A5%E1%8E%A6%E1%8E%A7%E1%8E%A8%E1%8E%A9%E1%8E%AA%E1%8E%AB%E1%8E%AC%E1%8E%AD%E1%8E%AE%E1%8E%AF%E1%8E%B0%E1%8E%B1%E1%8E%B2%E1%8E%B3%E1%8E%B4%E1%8E%B5%E1%8E%B6%E1%8E%B7%E1%8E%B8%E1%8E%B9%E1%8E%BA%E1%8E%BB%E1%8E%BC%E1%8E%BD%E1%8E%BE%E1%8E%BF%E1%8F%80%E1%8F%81%E1%8F%82%E1%8F%83%E1%8F%84%E1%8F%85%E1%8F%86%E1%8F%87%E1%8F%88%E1%8F%89%E1%8F%8A%E1%8F%8B%E1%8F%8C%E1%8F%8D%E1%8F%8E%E1%8F%8F%E1%8F%90%E1%8F%91%E1%8F%92%E1%8F%93%E1%8F%94%E1%8F%95%E1%8F%96%E1%8F%97%E1%8F%98%E1%8F%99%E1%8F%9A%E1%8F%9B%E1%8F%9C%E1%8F%9D%E1%8F%9E%E1%8F%9F%E1%8F%A0%E1%8F%A1%E1%8F%A2%E1%8F%A3%E1%8F%A4%E1%8F%A5%E1%8F%A6%E1%8F%A7%E1%8F%A8%E1%8F%A9%E1%8F%AA%E1%8F%AB%E1%8F%AC%E1%8F%AD%E1%8F%AE%E1%8F%AF%E1%8F%B0%E1%8F%B1%E1%8F%B2%E1%8F%B3%E1%8F%B4%EA%AD%B0%EA%AD%B1%EA%AD%B2%EA%AD%B3%EA%AD%B4%EA%AD%B5%EA%AD%B6%EA%AD%B7%EA%AD%B8%EA%AD%B9%EA%AD%BA%EA%AD%BB%EA%AD%BC%EA%AD%BD%EA%AD%BE%EA%AD%BF%EA%AE%80%EA%AE%81%EA%AE%82%EA%AE%83%EA%AE%84%EA%AE%85%EA%AE%86%EA%AE%87%EA%AE%88%EA%AE%89%EA%AE%8A%EA%AE%8B%EA%AE%8C%EA%AE%8D%EA%AE%8E%EA%AE%8F%EA%AE%90%EA%AE%91%EA%AE%92%EA%AE%93%EA%AE%94%EA%AE%95%EA%AE%96%EA%AE%97%EA%AE%98%EA%AE%99%EA%AE%9A%EA%AE%9B%EA%AE%9C%EA%AE%9D%EA%AE%9E%EA%AE%9F%EA%AE%A0%EA%AE%A1%EA%AE%A2%EA%AE%A3%EA%AE%A4%EA%AE%A5%EA%AE%A6%EA%AE%A7%EA%AE%A8%EA%AE%A9%EA%AE%AA%EA%AE%AB%EA%AE%AC%EA%AE%AD%EA%AE%AE%EA%AE%AF%EA%AE%B0%EA%AE%B1%EA%AE%B2%EA%AE%B3%EA%AE%B4%EA%AE%B5%EA%AE%B6%EA%AE%B7%EA%AE%B8%EA%AE%B9%EA%AE%BA%EA%AE%BB%EA%AE%BC%EA%AE%BD%EA%AE%BE%EA%AE%BF%E1%8F%B8%E1%8F%B9%E1%8F%BA%E1%8F%BB%E1%8F%BC) and click one of the style block and you will see half of them are tofus.

<img width="976" height="1462" alt="genos_tofus" src="https://github.com/user-attachments/assets/ec02013c-c75d-4ba9-8a8c-9e078fb241dc" />

So removing "cherokee" from subset and "Cher" from primary_script seems like the right move.
