### PR TITLE
Update METADATA.pb

### DIFF
--- a/ofl/gveretlevin/METADATA.pb
+++ b/ofl/gveretlevin/METADATA.pb
@@ -29,5 +29,5 @@ source {
   branch: "master"
 }
 primary_script: "hebr"
-stroke: "HANDWRITING"
 classifications: "DISPLAY"
+classifications: "HANDWRITING"


### PR DESCRIPTION
HANDWRITING is not a stroke—it is a classification.