### PR TITLE
Use primary_language instead of script for Kedebideri so that sample text will be chosen correctly.

### DIFF
--- a/ofl/kedebideri/METADATA.pb
+++ b/ofl/kedebideri/METADATA.pb
@@ -94,5 +94,5 @@ source {
   }
   branch: "main"
 }
-primary_script: "Berf"
+primary_language: "zag_Berf"
 stroke: "SANS_SERIF"


### PR DESCRIPTION
For #10103