### PR TITLE
Add designer bio for Nicole Fally

### DIFF
--- a/catalog/designers/nicolefally/bio.html
+++ b/catalog/designers/nicolefally/bio.html
@@ -1,0 +1,2 @@
+<p>Nicole Fally is a type designer from Austria/Germany. She graduated from the prestigious MA Typeface Design (MATD) program at the University of Reading in 2010, where she designed "Miss Informed" as her thesis typeface.</p><p>She has collaborated extensively with Sorkin Type Co (Eben Sorkin) to create display typefaces for Google Fonts. Her work spans a variety of styles including Western-inspired display faces (Rye), Art Deco geometric sans serifs (Limelight), and elegant scripts (Pinyon Script).</p>
+<p><a href="https://www.t-g-d.at">www.t-g-d.at</a></p>


### PR DESCRIPTION
## Summary
Added biography for **Nicole Fally**, an Austrian/German type designer.

**Background:**
- Graduated from MA Typeface Design (MATD) at University of Reading in 2010
- Thesis typeface: "Miss Informed"
- Has collaborated extensively with Sorkin Type Co (Eben Sorkin)

**Notable fonts on Google Fonts:**
- Hammersmith One
- Limelight
- Ovo
- Pinyon Script
- Rye
- Vast Shadow

## Sources
- Google Fonts FONTLOG files
- University of Reading MATD database (typefacedesign.org)

## Test plan
- [ ] Verify bio.html renders correctly on fonts.google.com
- [ ] Check link to www.t-g-d.at is valid

🤖 Generated with [Claude Code](https://claude.ai/code)