### PR TITLE
METADATA fix for Gveret Levin

### DIFF
--- a/ofl/gveretlevin/METADATA.pb
+++ b/ofl/gveretlevin/METADATA.pb
@@ -28,6 +28,6 @@ source {
   }
   branch: "master"
 }
-primary_script: "hebr"
+primary_script: "Hebr"
 classifications: "DISPLAY"
 classifications: "HANDWRITING"


### PR DESCRIPTION
Invalid script ID likely causing mis-assignment of languages on the specimen page. 