### PR TITLE
Fixing license in Roboto Mono

### DIFF
--- a/ofl/robotomono/METADATA.pb
+++ b/ofl/robotomono/METADATA.pb
@@ -1,6 +1,6 @@
 name: "Roboto Mono"
 designer: "Christian Robertson"
-license: "APACHE2"
+license: "OFL"
 category: "MONOSPACE"
 date_added: "2015-05-13"
 fonts {


### PR DESCRIPTION
Listed as "Apache2" but is an OFL font. 