### PR TITLE
Remove Roboto from font upgrade list

### DIFF
--- a/to_production.txt
+++ b/to_production.txt
@@ -15,7 +15,6 @@ ofl/ramsina # https://github.com/google/fonts/pull/10143
 ofl/gveretlevin # https://github.com/google/fonts/pull/10169
 ofl/mashanzheng # https://github.com/google/fonts/pull/10153
 ofl/notosansoriya # https://github.com/google/fonts/pull/10180
-ofl/roboto # https://github.com/google/fonts/pull/10158
 ofl/zcoolkuaile # https://github.com/google/fonts/pull/10018
 
 # Designer profile


### PR DESCRIPTION
Removed Roboto font from the upgrade list.
Eng team needs to make sure Roboto doesn't break screenshot tests. 