### PR TITLE
Add config_yaml to METADATA.pb for 15 font families

### DIFF
--- a/ofl/amarna/METADATA.pb
+++ b/ofl/amarna/METADATA.pb
@@ -32,6 +32,7 @@ axes {
 source {
   repository_url: "https://github.com/ijvanl/Amarna"
   commit: "22819bafba78c7f3e4644b6f68683773180a5965"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/bigshoulders/METADATA.pb
+++ b/ofl/bigshoulders/METADATA.pb
@@ -29,6 +29,7 @@ axes {
 source {
   repository_url: "https://github.com/xotypeco/big_shoulders"
   commit: "8ba99c9e347396d828b263b8b818269cb99eb27c"
+  config_yaml: "Big-Shoulders/sources/config.yml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/bigshouldersinline/METADATA.pb
+++ b/ofl/bigshouldersinline/METADATA.pb
@@ -29,6 +29,7 @@ axes {
 source {
   repository_url: "https://github.com/xotypeco/big_shoulders"
   commit: "8ba99c9e347396d828b263b8b818269cb99eb27c"
+  config_yaml: "Big-Shoulders-Inline/sources/config.yml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/bigshouldersstencil/METADATA.pb
+++ b/ofl/bigshouldersstencil/METADATA.pb
@@ -29,6 +29,7 @@ axes {
 source {
   repository_url: "https://github.com/xotypeco/big_shoulders"
   commit: "8ba99c9e347396d828b263b8b818269cb99eb27c"
+  config_yaml: "Big-Shoulders-Stencil/sources/config.yml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cossettetexte/METADATA.pb
+++ b/ofl/cossettetexte/METADATA.pb
@@ -27,6 +27,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/cossette-fonts"
   commit: "ee99cea3c23039e31865c3c37bd7d716278e546b"
+  config_yaml: "sources/config-texte.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/geom/METADATA.pb
+++ b/ofl/geom/METADATA.pb
@@ -33,6 +33,7 @@ axes {
 source {
   repository_url: "https://github.com/ThanosPoulakidas/Geom"
   commit: "c20a14c68c717e28fdb6e1cc7cc6b453fef5fef7"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/gveretlevin/METADATA.pb
+++ b/ofl/gveretlevin/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/AlefAlefAlef/gveret-levin"
   commit: "b383a9c00863837b1b88b4d0365f43a304007dae"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/momosignature/METADATA.pb
+++ b/ofl/momosignature/METADATA.pb
@@ -19,6 +19,7 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/typeassociates/MomoSignature"
   commit: "c3ba208abfc2d6e661da920121653f0557bae611"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/momotrustdisplay/METADATA.pb
+++ b/ofl/momotrustdisplay/METADATA.pb
@@ -19,6 +19,7 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/typeassociates/MomoTrustDisplay"
   commit: "33a85fe93dfe2ee4ee1cc0fe853f08b6a12d1815"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/momotrustsans/METADATA.pb
+++ b/ofl/momotrustsans/METADATA.pb
@@ -24,6 +24,7 @@ axes {
 source {
   repository_url: "https://github.com/typeassociates/MomoTrustSans"
   commit: "35a9521152ca14fd2a4300902519a3c00706dd5b"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/sekuya/METADATA.pb
+++ b/ofl/sekuya/METADATA.pb
@@ -18,6 +18,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/kevinnseptian/SEKUYA"
   commit: "74983eccdc3ee4233b3729132398e78eac409d04"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/snpro/METADATA.pb
+++ b/ofl/snpro/METADATA.pb
@@ -35,6 +35,7 @@ axes {
 source {
   repository_url: "https://github.com/supernotes/sn-pro"
   commit: "e025ac4755352167a4b160bfb77c72068b04b55c"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/tasaorbiter/METADATA.pb
+++ b/ofl/tasaorbiter/METADATA.pb
@@ -23,6 +23,7 @@ axes {
 source {
   repository_url: "https://github.com/localremotetw/TASA-Typeface-Collection"
   commit: "659e7c4a05cfa1e22b4317303fcd40d5ff3587a2"
+  config_yaml: "sources/config-TASAOrbiter.yaml"
   archive_url: "https://github.com/localremotetw/TASA-Typeface-Collection/releases/download/v2.011/TASA-Typeface-Collection-v2.011.zip"
   files {
     source_file: "TASA-Typeface-Collection-v2.011/OFL.txt"

--- a/ofl/tiny5/METADATA.pb
+++ b/ofl/tiny5/METADATA.pb
@@ -21,6 +21,7 @@ subsets: "menu"
 source {
   repository_url: "https://github.com/Gissio/font_tiny5"
   commit: "1d6e16fe1ffe3f91def8cf512ae45188503f7685"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/varelaround/METADATA.pb
+++ b/ofl/varelaround/METADATA.pb
@@ -20,6 +20,7 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/m4rc1e/Varela-Round-Hebrew"
   commit: "9bb2c89690095dd41f0f74d4954d3196eeaed68e"
+  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"


### PR DESCRIPTION
> **Note**: This PR was generated by an AI agent (Claude) working under the guidance of @felipesanches, but submitted **without human review**. @felipesanches himself would still need to participate in the PR thread if he wants to contribute to the review.

## Summary

- Add the `config_yaml` field to the `source {}` block in METADATA.pb for 15 font families that already had `repository_url` and `commit` but were missing `config_yaml`
- Each `config_yaml` value has been verified to exist at the recorded commit in the upstream repository and confirmed to contain valid gftools-builder configuration (has `sources` key)

## Families updated

| Family | config_yaml |
|--------|-------------|
| Amarna | `sources/config.yaml` |
| Big Shoulders | `Big-Shoulders/sources/config.yml` |
| Big Shoulders Inline | `Big-Shoulders-Inline/sources/config.yml` |
| Big Shoulders Stencil | `Big-Shoulders-Stencil/sources/config.yml` |
| Cossette Texte | `sources/config-texte.yaml` |
| Geom | `sources/config.yaml` |
| Gveret Levin | `sources/config.yaml` |
| Momo Signature | `sources/config.yaml` |
| Momo Trust Display | `sources/config.yaml` |
| Momo Trust Sans | `sources/config.yaml` |
| Sekuya | `sources/config.yaml` |
| SN Pro | `sources/config.yaml` |
| TASA Orbiter | `sources/config-TASAOrbiter.yaml` |
| Tiny5 | `sources/config.yaml` |
| Varela Round | `sources/config.yaml` |

## Purpose

This enables `google-fonts-sources` / `fontc_crater` to discover these fonts as build targets, increasing fontc compiler test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)