### PR TITLE
Add override config.yaml for 50 font families

### DIFF
--- a/ofl/abyssinicasil/config.yaml
+++ b/ofl/abyssinicasil/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - source/AbyssinicaSIL.designspace
+familyName: Abyssinica SIL
+buildStatic: true
+buildOTF: false

--- a/ofl/akatab/config.yaml
+++ b/ofl/akatab/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - source/akatab.designspace
+familyName: Akatab
+buildStatic: true
+buildOTF: false

--- a/ofl/amiri/config.yaml
+++ b/ofl/amiri/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Amiri.glyphspackage
+familyName: Amiri
+buildStatic: true
+buildOTF: false

--- a/ofl/amiriquran/config.yaml
+++ b/ofl/amiriquran/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Amiri.glyphspackage
+familyName: Amiri Quran
+buildStatic: true
+buildOTF: false

--- a/ofl/bitcountgriddouble/config.yaml
+++ b/ofl/bitcountgriddouble/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Bitcount_Template.designspace
+familyName: Bitcount Grid Double
+buildVariable: true
+buildOTF: false

--- a/ofl/bitcountgriddoubleink/config.yaml
+++ b/ofl/bitcountgriddoubleink/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Bitcount_Template.designspace
+familyName: Bitcount Grid Double Ink
+buildVariable: true
+buildOTF: false

--- a/ofl/bitcountgridsingle/config.yaml
+++ b/ofl/bitcountgridsingle/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Bitcount_Template.designspace
+familyName: Bitcount Grid Single
+buildVariable: true
+buildOTF: false

--- a/ofl/bitcountgridsingleink/config.yaml
+++ b/ofl/bitcountgridsingleink/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Bitcount_Template.designspace
+familyName: Bitcount Grid Single Ink
+buildVariable: true
+buildOTF: false

--- a/ofl/bitcountink/config.yaml
+++ b/ofl/bitcountink/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Bitcount_Template.designspace
+familyName: Bitcount Ink
+buildVariable: true
+buildOTF: false

--- a/ofl/bitcountpropdouble/config.yaml
+++ b/ofl/bitcountpropdouble/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Bitcount_Template.designspace
+familyName: Bitcount Prop Double
+buildVariable: true
+buildOTF: false

--- a/ofl/bitcountpropdoubleink/config.yaml
+++ b/ofl/bitcountpropdoubleink/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Bitcount_Template.designspace
+familyName: Bitcount Prop Double Ink
+buildVariable: true
+buildOTF: false

--- a/ofl/bitcountpropsingle/config.yaml
+++ b/ofl/bitcountpropsingle/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Bitcount_Template.designspace
+familyName: Bitcount Prop Single
+buildVariable: true
+buildOTF: false

--- a/ofl/bitcountsingle/config.yaml
+++ b/ofl/bitcountsingle/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Bitcount_Template.designspace
+familyName: Bitcount Single
+buildVariable: true
+buildOTF: false

--- a/ofl/bizudgothic/config.yaml
+++ b/ofl/bizudgothic/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/extensions/BIZ-UDGothicExt.glyphs
+familyName: BIZ UDGothic
+buildStatic: true
+buildOTF: false

--- a/ofl/bizudmincho/config.yaml
+++ b/ofl/bizudmincho/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/extensions/BIZ-UDMinchoExt.glyphs
+familyName: BIZ UDMincho
+buildStatic: true
+buildOTF: false

--- a/ofl/bizudpgothic/config.yaml
+++ b/ofl/bizudpgothic/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/extensions/BIZ-UDPGothicExt.glyphs
+familyName: BIZ UDPGothic
+buildStatic: true
+buildOTF: false

--- a/ofl/bizudpmincho/config.yaml
+++ b/ofl/bizudpmincho/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/extensions/BIZ-UDPMinchoExt.glyphs
+familyName: BIZ UDPMincho
+buildStatic: true
+buildOTF: false

--- a/ofl/blackopsone/config.yaml
+++ b/ofl/blackopsone/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/BlackOpsOne.glyphs
+familyName: Black Ops One
+buildStatic: true
+buildOTF: false

--- a/ofl/bungee/config.yaml
+++ b/ofl/bungee/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/1-drawing/Bungee-Regular.ufo
+familyName: Bungee
+buildStatic: true
+buildOTF: false

--- a/ofl/bungeecolor/config.yaml
+++ b/ofl/bungeecolor/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/2-build/Bungee_Color/Bungee_Color-Regular.ufo
+familyName: Bungee Color
+buildStatic: true
+buildOTF: false

--- a/ofl/bungeehairline/config.yaml
+++ b/ofl/bungeehairline/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/2-build/Bungee_Basic/Bungee-Hairline.ufo
+familyName: Bungee Hairline
+buildStatic: true
+buildOTF: false

--- a/ofl/bungeeinline/config.yaml
+++ b/ofl/bungeeinline/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/2-build/Bungee_Basic/Bungee-Inline.ufo
+familyName: Bungee Inline
+buildStatic: true
+buildOTF: false

--- a/ofl/bungeeoutline/config.yaml
+++ b/ofl/bungeeoutline/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/2-build/Bungee_Basic/Bungee-Outline.ufo
+familyName: Bungee Outline
+buildStatic: true
+buildOTF: false

--- a/ofl/bungeeshade/config.yaml
+++ b/ofl/bungeeshade/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/2-build/Bungee_Basic/Bungee-Shade.ufo
+familyName: Bungee Shade
+buildStatic: true
+buildOTF: false

--- a/ofl/bungeespice/config.yaml
+++ b/ofl/bungeespice/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/2-build/Bungee_Color/Bungee_Color-Regular.ufo
+familyName: Bungee Spice
+buildStatic: true
+buildOTF: false

--- a/ofl/cormorantupright/config.yaml
+++ b/ofl/cormorantupright/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - 4. Glyphs Source Files/CormorantUpright.glyphs
+familyName: Cormorant Upright
+buildStatic: true
+buildOTF: false

--- a/ofl/harmattan/config.yaml
+++ b/ofl/harmattan/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - source/Harmattan.designspace
+familyName: Harmattan
+buildStatic: true
+buildOTF: false

--- a/ofl/ibmplexmono/config.yaml
+++ b/ofl/ibmplexmono/config.yaml
@@ -1,0 +1,6 @@
+sources:
+  - IBM-Plex-Mono/sources/masters/IBM Plex Mono Roman.designspace
+  - IBM-Plex-Mono/sources/masters/IBM Plex Mono Italic.designspace
+familyName: IBM Plex Mono
+buildStatic: true
+buildOTF: false

--- a/ofl/ibmplexsansjp/config.yaml
+++ b/ofl/ibmplexsansjp/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - IBM-Plex-Sans-JP/sources/masters/IBM Plex Sans JP.glyphs
+familyName: IBM Plex Sans JP
+buildStatic: true
+buildOTF: false

--- a/ofl/inter/config.yaml
+++ b/ofl/inter/config.yaml
@@ -1,0 +1,6 @@
+sources:
+  - src/Inter-Roman.glyphspackage
+  - src/Inter-Italic.glyphspackage
+familyName: Inter
+buildVariable: true
+buildOTF: false

--- a/ofl/lateef/config.yaml
+++ b/ofl/lateef/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - source/lateef-edit.designspace
+familyName: Lateef
+buildStatic: true
+buildOTF: false

--- a/ofl/opensans/config.yaml
+++ b/ofl/opensans/config.yaml
@@ -1,0 +1,6 @@
+sources:
+  - sources/OpenSans-Roman.designspace
+  - sources/OpenSans-Italic.designspace
+familyName: Open Sans
+buildVariable: true
+buildOTF: false

--- a/ofl/publicsans/config.yaml
+++ b/ofl/publicsans/config.yaml
@@ -1,0 +1,6 @@
+sources:
+  - sources/PublicSans.glyphs
+  - sources/PublicSans-Italic.glyphs
+familyName: Public Sans
+buildVariable: true
+buildOTF: false

--- a/ofl/recursive/config.yaml
+++ b/ofl/recursive/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - src/ufo/recursive-MONO_CASL_wght_slnt_ital--full_gsub.designspace
+familyName: Recursive
+buildVariable: true
+buildOTF: false

--- a/ofl/reemkufi/config.yaml
+++ b/ofl/reemkufi/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/ReemKufi.glyphspackage
+familyName: Reem Kufi
+buildVariable: true
+buildOTF: false

--- a/ofl/reemkufifun/config.yaml
+++ b/ofl/reemkufifun/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/ReemKufi.glyphspackage
+familyName: Reem Kufi Fun
+buildStatic: true
+buildOTF: false

--- a/ofl/reemkufiink/config.yaml
+++ b/ofl/reemkufiink/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/ReemKufi.glyphspackage
+familyName: Reem Kufi Ink
+buildStatic: true
+buildOTF: false

--- a/ofl/roboto/config.yaml
+++ b/ofl/roboto/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Roboto.designspace
+familyName: Roboto
+buildVariable: true
+buildOTF: false

--- a/ofl/scheherazadenew/config.yaml
+++ b/ofl/scheherazadenew/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - source/ScheherazadeNew.designspace
+familyName: Scheherazade New
+buildStatic: true
+buildOTF: false

--- a/ofl/sen/config.yaml
+++ b/ofl/sen/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/sen.glyphs
+familyName: Sen
+buildVariable: true
+buildOTF: false

--- a/ofl/shantellsans/config.yaml
+++ b/ofl/shantellsans/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/shantell_sans-ital_wght_BNCE_INFM_SPAC-simplified.designspace
+familyName: Shantell Sans
+buildVariable: true
+buildOTF: false

--- a/ofl/sigmar/config.yaml
+++ b/ofl/sigmar/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - archive/Sigmar.glyphs
+familyName: Sigmar
+buildStatic: true
+buildOTF: false

--- a/ofl/tiltneon/config.yaml
+++ b/ofl/tiltneon/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Tilt Neon/Rotated/TiltNeon[XROT,YROT].designspace
+familyName: Tilt Neon
+buildVariable: true
+buildOTF: false

--- a/ofl/tiltprism/config.yaml
+++ b/ofl/tiltprism/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Tilt Prism/Rotated 01 Inline/Tilt-Prism.designspace
+familyName: Tilt Prism
+buildVariable: true
+buildOTF: false

--- a/ofl/tiltwarp/config.yaml
+++ b/ofl/tiltwarp/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Tilt Warp/Rotated/TiltWarp[XROT,YROT].designspace
+familyName: Tilt Warp
+buildVariable: true
+buildOTF: false

--- a/ofl/tirra/config.yaml
+++ b/ofl/tirra/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - source/tirra.designspace
+familyName: Tirra
+buildStatic: true
+buildOTF: false

--- a/ofl/trocchi/config.yaml
+++ b/ofl/trocchi/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/Trocchi.glyphs
+familyName: Trocchi
+buildStatic: true
+buildOTF: false

--- a/ofl/vazirmatn/config.yaml
+++ b/ofl/vazirmatn/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - scripts/Vazirmatn.designspace
+familyName: Vazirmatn
+buildVariable: true
+buildOTF: false

--- a/ofl/yaldevicolombo/config.yaml
+++ b/ofl/yaldevicolombo/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - sources/glyphs/final/AyannaNarrow-all.glyphs
+familyName: Yaldevi Colombo
+buildStatic: true
+buildOTF: false

--- a/ofl/zain/config.yaml
+++ b/ofl/zain/config.yaml
@@ -1,0 +1,5 @@
+sources:
+  - Source/1-Drawings/Zain-Regular.glyphs
+familyName: Zain
+buildStatic: true
+buildOTF: false


### PR DESCRIPTION
> **Note**: This PR was generated by an AI agent (Claude) working under the guidance of @felipesanches, but submitted **without human review**. @felipesanches himself would still need to participate in the PR thread if he wants to contribute to the review.

## Summary

Add gftools-builder `config.yaml` override files for 50 font families whose upstream repositories have font sources but no `config.yaml` at the recorded onboarding commit.

Each config file:
- Points to source files verified to exist at the recorded commit in the upstream repo
- Correctly reflects whether the font was onboarded as variable or static (based on the `.ttf` files present in google/fonts)
- Is placed in the google/fonts family directory as a local override

## Families updated

**SIL International fonts (6):** Abyssinica SIL, Akatab, Harmattan, Lateef, Scheherazade New, Tirra

**Amiri (2):** Amiri, Amiri Quran

**Bitcount (9):** Grid Double, Grid Double Ink, Grid Single, Grid Single Ink, Ink, Prop Double, Prop Double Ink, Prop Single, Single

**BIZ UD (4):** BIZ UDGothic, BIZ UDMincho, BIZ UDPGothic, BIZ UDPMincho

**Bungee (7):** Bungee, Bungee Color, Bungee Hairline, Bungee Inline, Bungee Outline, Bungee Shade, Bungee Spice

**IBM Plex (2):** IBM Plex Mono, IBM Plex Sans JP

**Reem Kufi (3):** Reem Kufi, Reem Kufi Fun, Reem Kufi Ink

**Tilt (3):** Tilt Neon, Tilt Prism, Tilt Warp

**Other (14):** Black Ops One, Cormorant Upright, Inter, Open Sans, Public Sans, Recursive, Roboto, Sen, Shantell Sans, Sigmar, Trocchi, Vazirmatn, Yaldevi Colombo, Zain

## Purpose

With these overrides, `google-fonts-sources` can detect these fonts as `fontc_crater` build targets, increasing fontc compiler test coverage.

## Not included (28 families)

The following families were investigated but not included because they have no buildable source files at their recorded onboarding commits (repos only contain pre-built binaries):

- Korean fonts: Batang, BatangChe, Dotum, DotumChe, Gulim, GulimChe, Gungsuh, GungsuhChe
- Libertinus: Keyboard, Math, Mono, Sans, Serif, Serif Display
- Noto Serif CJK: HK, JP, KR, SC, TC
- IBM Plex: Sans, Sans Arabic
- WDXL Lubrifont: JP N, SC, TC
- Other: Bungee Tint, Carlito, Castoro, Castoro Titling

🤖 Generated with [Claude Code](https://claude.com/claude-code)