### PR TITLE
Add config_yaml enrichment for 82 font families

### DIFF
--- a/ofl/alansans/METADATA.pb
+++ b/ofl/alansans/METADATA.pb
@@ -32,6 +32,7 @@ source {
     dest_file: "AlanSans[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 minisite_url: "https://typeface.alan.com"

--- a/ofl/alkalami/config.yaml
+++ b/ofl/alkalami/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - source/Alkalami.designspace

--- a/ofl/amaranth/config.yaml
+++ b/ofl/amaranth/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - sources/Amaranth-Roman.glyphs
+  - sources/Amaranth-Italic.glyphs

--- a/ofl/amethysta/config.yaml
+++ b/ofl/amethysta/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Amethysta-Regular.glyphs

--- a/ofl/aoboshione/config.yaml
+++ b/ofl/aoboshione/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/aoboshi.glyphs

--- a/ofl/arsenal/config.yaml
+++ b/ofl/arsenal/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - sources/Arsenal.glyphs
+  - sources/Arsenal-Italic.glyphs

--- a/ofl/assistant/config.yaml
+++ b/ofl/assistant/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Assistant.designspace

--- a/ofl/baijamjuree/config.yaml
+++ b/ofl/baijamjuree/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - source/Baijam.glyphs

--- a/ofl/bbhbartle/METADATA.pb
+++ b/ofl/bbhbartle/METADATA.pb
@@ -25,5 +25,6 @@ source {
     dest_file: "BBHBartle-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/bbhbogle/METADATA.pb
+++ b/ofl/bbhbogle/METADATA.pb
@@ -25,5 +25,6 @@ source {
     dest_file: "BBHBogle-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/bbhhegarty/METADATA.pb
+++ b/ofl/bbhhegarty/METADATA.pb
@@ -25,5 +25,6 @@ source {
     dest_file: "BBHHegarty-Regular.ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/bebasneue/config.yaml
+++ b/ofl/bebasneue/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/BebasNeueV2.0(2018).glyphs

--- a/ofl/castoro/config.yaml
+++ b/ofl/castoro/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - source/Castoro-Roman.designspace
+  - source/Castoro-Italic.designspace

--- a/ofl/cause/METADATA.pb
+++ b/ofl/cause/METADATA.pb
@@ -33,6 +33,7 @@ source {
     dest_file: "Cause[wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "HANDWRITING"

--- a/ofl/chakrapetch/config.yaml
+++ b/ofl/chakrapetch/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - source/Chakra Petch.glyphs

--- a/ofl/charmonman/config.yaml
+++ b/ofl/charmonman/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - source/Charmonman.glyphs

--- a/ofl/courierprime/config.yaml
+++ b/ofl/courierprime/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - sources/Courier Prime.glyphs
+  - sources/Courier Prime Italic.glyphs

--- a/ofl/delagothicone/config.yaml
+++ b/ofl/delagothicone/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Sources/DelaGothic.glyphs

--- a/ofl/dmmono/config.yaml
+++ b/ofl/dmmono/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - source/DMMono-MASTER.glyphs
+  - source/DMMono-Italics-MASTER.glyphs

--- a/ofl/dotgothic16/config.yaml
+++ b/ofl/dotgothic16/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/DotGothic16.glyphs

--- a/ofl/enriqueta/config.yaml
+++ b/ofl/enriqueta/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - source/enriqueta_masters_GOOGLE.glyphs

--- a/ofl/federant/config.yaml
+++ b/ofl/federant/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - src/Federant-Regular.glyphs

--- a/ofl/firacode/config.yaml
+++ b/ofl/firacode/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - FiraCode.glyphs

--- a/ofl/flowcircular/METADATA.pb
+++ b/ofl/flowcircular/METADATA.pb
@@ -29,6 +29,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "main"
+  config_yaml: "Circular/sources/config.yaml"
 }
 classifications: "DISPLAY"
 classifications: "SYMBOLS"

--- a/ofl/flowrounded/METADATA.pb
+++ b/ofl/flowrounded/METADATA.pb
@@ -29,6 +29,7 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "main"
+  config_yaml: "Rounded/sources/config.yaml"
 }
 classifications: "DISPLAY"
 classifications: "SYMBOLS"

--- a/ofl/hachimarupop/config.yaml
+++ b/ofl/hachimarupop/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/HachiMaruPop.glyphs

--- a/ofl/heptaslab/config.yaml
+++ b/ofl/heptaslab/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/HeptaSlab.glyphs

--- a/ofl/hindcolombo/config.yaml
+++ b/ofl/hindcolombo/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - masters/HindColombo.glyphs

--- a/ofl/hindguntur/config.yaml
+++ b/ofl/hindguntur/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - masters/HindGuntur.glyphs

--- a/ofl/hindjalandhar/config.yaml
+++ b/ofl/hindjalandhar/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - masters/HindJalandhar.glyphs

--- a/ofl/hindkochi/config.yaml
+++ b/ofl/hindkochi/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - masters/HindKochi.glyphs

--- a/ofl/hindmadurai/config.yaml
+++ b/ofl/hindmadurai/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - masters/HindMadurai.glyphs

--- a/ofl/hindmysuru/config.yaml
+++ b/ofl/hindmysuru/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - masters/HindMysuru.glyphs

--- a/ofl/hindsiliguri/config.yaml
+++ b/ofl/hindsiliguri/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - masters/HindiSiliguri.glyphs

--- a/ofl/hindvadodara/config.yaml
+++ b/ofl/hindvadodara/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - masters/HindVadodara.glyphs

--- a/ofl/intelonemono/config.yaml
+++ b/ofl/intelonemono/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - sources/masters/IntelOneMono-Roman.designspace
+  - sources/masters/IntelOneMono-Italic.designspace

--- a/ofl/jacquesfrancois/config.yaml
+++ b/ofl/jacquesfrancois/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/JacquesFrancois.glyphs

--- a/ofl/jacquesfrancoisshadow/config.yaml
+++ b/ofl/jacquesfrancoisshadow/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/JacquesFrancoisShadow.glyphs

--- a/ofl/josefinsans/config.yaml
+++ b/ofl/josefinsans/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - sources/JosefinSans.designspace
+  - sources/JosefinSans-Italic.designspace

--- a/ofl/lalezar/config.yaml
+++ b/ofl/lalezar/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Lalezar.glyphs

--- a/ofl/librecaslontext/config.yaml
+++ b/ofl/librecaslontext/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - sources/LibreCaslonText.glyphs
+  - sources/LibreCaslonText-Italic.glyphs

--- a/ofl/lilex/METADATA.pb
+++ b/ofl/lilex/METADATA.pb
@@ -50,6 +50,7 @@ source {
     dest_file: "Lilex-Italic[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/Lilex/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "MONOSPACE"

--- a/ofl/lineseedjp/METADATA.pb
+++ b/ofl/lineseedjp/METADATA.pb
@@ -47,5 +47,6 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/line/seed"
+  config_yaml: "LINESeedJP/sources/config.yaml"
 }
 primary_script: "Jpan"

--- a/ofl/liujianmaocao/config.yaml
+++ b/ofl/liujianmaocao/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/LiuJianMaoCao.glyphs

--- a/ofl/lobster/config.yaml
+++ b/ofl/lobster/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Lobster.glyphs

--- a/ofl/mali/config.yaml
+++ b/ofl/mali/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - source/Mali-Master.glyphs

--- a/ofl/merriweathersans/config.yaml
+++ b/ofl/merriweathersans/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - sources/MerriweatherSans.designspace
+  - sources/MerriweatherSans-Italic.designspace

--- a/ofl/mingzat/config.yaml
+++ b/ofl/mingzat/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - source/Mingzat.designspace

--- a/ofl/moul/config.yaml
+++ b/ofl/moul/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - Source/Moul.glyphs

--- a/ofl/nabla/config.yaml
+++ b/ofl/nabla/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Nabla.glyphs

--- a/ofl/natasans/METADATA.pb
+++ b/ofl/natasans/METADATA.pb
@@ -36,6 +36,7 @@ source {
     dest_file: "NataSans[wght].ttf"
   }
   branch: "main"
+  config_yaml: "config.yaml"
 }
 stroke: "SANS_SERIF"
 minisite_url: "https://dnlzqn.xyz/nata/"

--- a/ofl/palettemosaic/config.yaml
+++ b/ofl/palettemosaic/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/PaletteMosaic.glyphs

--- a/ofl/playwritenzbasic/METADATA.pb
+++ b/ofl/playwritenzbasic/METADATA.pb
@@ -46,6 +46,7 @@ source {
     dest_file: "article/Playwrite_NZ-Basic_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite New Zealand Basic"
 minisite_url: "https://primarium.info/countries/new-zealand"

--- a/ofl/playwritenzbasicguides/METADATA.pb
+++ b/ofl/playwritenzbasicguides/METADATA.pb
@@ -37,6 +37,7 @@ source {
     dest_file: "article/Playwrite-NZ-Basic-Guides_3.png"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 display_name: "Playwrite New Zealand Basic Guides"
 minisite_url: "https://primarium.info/countries/new-zealand"

--- a/ofl/quicksand/config.yaml
+++ b/ofl/quicksand/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Quicksand.glyphs

--- a/ofl/rowdies/config.yaml
+++ b/ofl/rowdies/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Rowdies.glyphs

--- a/ofl/ruwudu/config.yaml
+++ b/ofl/ruwudu/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - source/Ruwudu.designspace

--- a/ofl/sansitaswashed/config.yaml
+++ b/ofl/sansitaswashed/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/SansitaSwashed.glyphs

--- a/ofl/sarabun/config.yaml
+++ b/ofl/sarabun/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - source/Sarabun.glyphs

--- a/ofl/sciencegothic/METADATA.pb
+++ b/ofl/sciencegothic/METADATA.pb
@@ -50,5 +50,6 @@ source {
     dest_file: "ScienceGothic[CTRS,slnt,wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/build-config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/shipporiantique/config.yaml
+++ b/ofl/shipporiantique/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/ShipporiAntique.glyphs

--- a/ofl/shipporiantiqueb1/config.yaml
+++ b/ofl/shipporiantiqueb1/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/ShipporiAntique.glyphs

--- a/ofl/shizuru/config.yaml
+++ b/ofl/shizuru/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/ShizuruFont.glyphs

--- a/ofl/slacksideone/config.yaml
+++ b/ofl/slacksideone/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - source/SlacksideOne.glyphs

--- a/ofl/solway/config.yaml
+++ b/ofl/solway/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Solway.glyphs

--- a/ofl/srisakdi/config.yaml
+++ b/ofl/srisakdi/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - source/Srisakdi.glyphs

--- a/ofl/staatliches/config.yaml
+++ b/ofl/staatliches/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Staatliches-Regular.glyphs

--- a/ofl/stick/config.yaml
+++ b/ofl/stick/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Stick.glyphs

--- a/ofl/thasadith/config.yaml
+++ b/ofl/thasadith/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - source/Thasadith_Master.glyphs

--- a/ofl/trainone/config.yaml
+++ b/ofl/trainone/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/TrainOne.glyphs

--- a/ofl/tsukimirounded/config.yaml
+++ b/ofl/tsukimirounded/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/tsukimi_rounded.glyphs

--- a/ofl/turretroad/config.yaml
+++ b/ofl/turretroad/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/turret-road.glyphs

--- a/ofl/viaodalibre/config.yaml
+++ b/ofl/viaodalibre/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Viaoda Libre.glyphs

--- a/ofl/vibes/config.yaml
+++ b/ofl/vibes/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - vibes-typeface.glyphs

--- a/ofl/vollkorn/config.yaml
+++ b/ofl/vollkorn/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - sources/Vollkorn.designspace
+  - sources/Vollkorn-Italic.designspace

--- a/ofl/xanhmono/config.yaml
+++ b/ofl/xanhmono/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - source/XanhMono.glyphs
+  - source/XanhMono-Italic.glyphs

--- a/ofl/yomogi/config.yaml
+++ b/ofl/yomogi/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Yomogi.glyphs

--- a/ofl/yuseimagic/config.yaml
+++ b/ofl/yuseimagic/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/YuseiMagic.glyphs

--- a/ofl/zcoolkuaile/METADATA.pb
+++ b/ofl/zcoolkuaile/METADATA.pb
@@ -17,5 +17,6 @@ subsets: "latin"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/zcool-kuaile"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Hans"

--- a/ofl/zcoolqingkehuangyou/config.yaml
+++ b/ofl/zcoolqingkehuangyou/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/zcool-qingke-huangyou.glyphs

--- a/ofl/zcoolxiaowei/config.yaml
+++ b/ofl/zcoolxiaowei/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/xiaowei.glyphs

--- a/ofl/zenkurenaido/config.yaml
+++ b/ofl/zenkurenaido/config.yaml
@@ -1,0 +1,2 @@
+sources:
+  - sources/Kurenaido.glyphs


### PR DESCRIPTION
> **Note**: This PR was generated by an AI agent (Claude) working under the guidance of @felipesanches, but submitted **without human review**. @felipesanches himself would still need to participate in the PR thread if he wants to contribute to the review.

## Summary

- Add `config_yaml` field to METADATA.pb for **14 families** that have verified gftools-builder config files in their upstream repos
- Create override `config.yaml` files for **68 families** where upstream repos have source files but no gftools-builder config

This continues the config_yaml enrichment work from PRs #10234 and #10235.

## Part 1: METADATA.pb `config_yaml` additions (14 families)

These families have genuine gftools-builder config.yaml files in their upstream repositories at HEAD. Each config was verified to contain valid gftools-builder configuration with correct source references.

| Family | config_yaml path |
|--------|-----------------|
| Alan Sans | `sources/config.yaml` |
| BBH Bartle | `sources/config.yaml` |
| BBH Bogle | `sources/config.yaml` |
| BBH Hegarty | `sources/config.yaml` |
| Cause | `sources/config.yaml` |
| Flow Circular | `Circular/sources/config.yaml` |
| Flow Rounded | `Rounded/sources/config.yaml` |
| Lilex | `sources/Lilex/config.yaml` |
| LINE Seed JP | `LINESeedJP/sources/config.yaml` |
| Nata Sans | `config.yaml` |
| Playwrite NZ Basic | `sources/config.yaml` |
| Playwrite NZ Basic Guides | `sources/config.yaml` |
| Science Gothic | `sources/build-config.yaml` |
| ZCOOL KuaiLe | `sources/config.yaml` |

## Part 2: Override config.yaml files (68 families)

For these families, the upstream repository has source files but no gftools-builder config.yaml. Override config.yaml files are created in the google/fonts family directory.

**Single-source families (57):**
Alkalami, Amethysta, Aoboshi One, Assistant, Bai Jamjuree, Bebas Neue, Chakra Petch, Charmonman, Dela Gothic One, DotGothic16, Enriqueta, Federant, Fira Code, Hachi Maru Pop, Hepta Slab, Hind Colombo, Hind Guntur, Hind Jalandhar, Hind Kochi, Hind Madurai, Hind Mysuru, Hind Siliguri, Hind Vadodara, Jacques Francois, Jacques Francois Shadow, Lalezar, Liu Jian Mao Cao, Lobster, Mali, Mingzat, Moul, Nabla, Palette Mosaic, Quicksand, Rowdies, Ruwudu, Sansita Swashed, Sarabun, Shippori Antique, Shippori Antique B1, Shizuru, Slackside One, Solway, Srisakdi, Staatliches, Stick, Thasadith, Train One, Tsukimi Rounded, Turret Road, Viaoda Libre, Vibes, Yomogi, Yusei Magic, Zen Kurenaido, ZCOOL QingKe HuangYou, ZCOOL XiaoWei

**Two-source families (Roman + Italic, 11):**
Amaranth, Arsenal, Castoro, Courier Prime, DM Mono, Intel One Mono, Josefin Sans, Libre Caslon Text, Merriweather Sans, Vollkorn, Xanh Mono

## Verification

- All 14 METADATA.pb edits verified: `config_yaml` field correctly placed inside `source { }` block
- All 68 override config.yaml source file paths verified to exist in the upstream repository cache
- No existing files were accidentally modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)