### PR TITLE
Arsenal: add buildVariable: false to config.yaml

### DIFF
--- a/ofl/arsenal/config.yaml
+++ b/ofl/arsenal/config.yaml
@@ -1,3 +1,4 @@
+buildVariable: false
 sources:
   - sources/Arsenal.glyphs
   - sources/Arsenal-Italic.glyphs


### PR DESCRIPTION
## Summary

- Add `buildVariable: false` to Arsenal's override config.yaml. Arsenal is a static-only family (Regular, Bold, Italic, BoldItalic) with no variable font axes, so the builder should not attempt a variable font build.
- Without this flag, the builder defaults to `buildVariable: true` which causes build failures.
- Arsenal SC, which uses the same upstream repo (`alexeiva/Arsenal`) and sources, already has this flag set in its config.yaml.

## Context

This is part of an effort to ensure all override config.yaml files in google/fonts correctly specify build parameters so that fontc_crater (and gftools builder) can discover and build these families without errors.

## Test plan

- [ ] Verify `gftools builder` can build Arsenal from upstream with this config
- [ ] Confirm Arsenal SC continues to build correctly (same upstream repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)