### PR TITLE
Raleway: fix incorrect source paths in config.yaml

### DIFF
--- a/ofl/raleway/config.yaml
+++ b/ofl/raleway/config.yaml
@@ -1,4 +1,4 @@
 buildVariable: true
 sources:
-  - source/Raleway-Roman.designspace
-  - source/Raleway-Italic.designspace
+  - sources/Raleway.designspace
+  - sources/Raleway-Italic.designspace


### PR DESCRIPTION
## Summary

- Fix two path errors in Raleway's override config.yaml:
  - Directory name: `source/` → `sources/` (the upstream repo uses `sources/`, plural)
  - Filename: `Raleway-Roman.designspace` → `Raleway.designspace` (no `-Roman` suffix in the actual file)
- The actual source files in `theleagueof/raleway` are `sources/Raleway.designspace` and `sources/Raleway-Italic.designspace`

## Context

The existing override config had incorrect paths that prevented fontc_crater (and gftools builder) from locating the source files. This fixes the paths to match the actual upstream repository structure.

## Test plan

- [ ] Verify `gftools builder` can build Raleway from upstream with the corrected config
- [ ] Confirm the designspace files exist at the specified paths in the upstream repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)