### PR TITLE
Remove redundant font entries from families.csv

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -16232,17 +16232,6 @@ Noto Serif NP Hmong,,/Quality/Spacing,70
 Noto Serif NP Hmong,,/Quality/Wordspace,100
 Noto Serif NP Hmong,,/Serif/Transitional,100
 Noto Serif NP Hmong,,/Expressive/Sincere,75
-Noto Serif Nyiakeng Puachue Hmong,,/Expressive/Business,90
-Noto Serif Nyiakeng Puachue Hmong,,/Expressive/Competent,80
-Noto Serif Nyiakeng Puachue Hmong,,/Expressive/Loud,40
-Noto Serif Nyiakeng Puachue Hmong,,/Expressive/Rugged,40
-Noto Serif Nyiakeng Puachue Hmong,,/Expressive/Vintage,40
-Noto Serif Nyiakeng Puachue Hmong,,/Quality/Concept,70
-Noto Serif Nyiakeng Puachue Hmong,,/Quality/Drawing,70
-Noto Serif Nyiakeng Puachue Hmong,,/Quality/Spacing,80
-Noto Serif Nyiakeng Puachue Hmong,,/Quality/Wordspace,100
-Noto Serif Nyiakeng Puachue Hmong,,/Serif/Transitional,100
-Noto Serif Nyiakeng Puachue Hmong,,/Expressive/Sincere,75
 Noto Serif Old Uyghur,,/Expressive/Business,90
 Noto Serif Old Uyghur,,/Expressive/Competent,80
 Noto Serif Old Uyghur,,/Expressive/Loud,40


### PR DESCRIPTION
Removed multiple entries for Ek Mukta, Noto Sans Arabic UI, Noto Sans Bengali UI, Noto Sans Devanagari UI, Noto Sans Gujarati UI, Noto Sans Gurmukhi UI, Noto Sans Kannada UI, Noto Sans Kharoshthi, and Noto.