### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -95,7 +95,7 @@ jobs:
           cp .ci/dashboard/build/_file/data/versionhistory.*.json .ci/dashboard/build/_file/data/versionhistory.json
       - name: Upload build artifacts
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/upload-pages-artifact@v3.0.1
+        uses: actions/upload-pages-artifact@v4.0.0
         with:
           path: .ci/dashboard/build
   deploy:


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/upload-pages-artifact` | [`v3.0.1`](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.1) | [`v4.0.0`](https://github.com/actions/upload-pages-artifact/releases/tag/v4.0.0) | [Release](https://github.com/actions/upload-pages-artifact/releases/tag/v4) | report.yaml |

## Breaking Changes

- **actions/upload-pages-artifact** (v3.0.1 → v4.0.0): Major version upgrade — review the [release notes](https://github.com/actions/upload-pages-artifact/releases) for breaking changes

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
