### PR TITLE
oldstandardtt: update upstream repo to active SourceHut fork

### DIFF
--- a/ofl/oldstandardtt/METADATA.pb
+++ b/ofl/oldstandardtt/METADATA.pb
@@ -36,5 +36,8 @@ subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 subsets: "vietnamese"
+source {
+  repository_url: "https://git.sr.ht/~ralessi/oldstandard"
+}
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/oldstandardtt/upstream_info.md
+++ b/ofl/oldstandardtt/upstream_info.md
@@ -1,15 +1,15 @@
 # Old Standard TT — Source Metadata Investigation
 
 **Model**: Claude Opus 4.6
-**Date**: 2026-03-12
+**Date**: 2026-03-19 (updated)
 
 ## Summary
 
-A canonical upstream repository was found at `akryukov/oldstand` on GitHub, owned by the designer Alexey Kryukov. However, the repository contains only SFD (FontForge) sources — no UFO or Glyphs format sources. Per policy, METADATA.pb was not updated because UFO/Glyphs sources are required for a source block addition.
+The upstream repository was updated to point to the actively maintained SourceHut fork at `https://git.sr.ht/~ralessi/oldstandard`, maintained by Robert Alessi. This replaces the dormant GitHub repository `akryukov/oldstand` (last updated 2017). The SourceHut fork has continued development through v2.7a with additional weights (Bold Italic) and a Math font variant. Sources remain SFD-only (no gftools-builder pipeline possible).
 
 ## Family Details
 
-- **Designer**: Alexey Kryukov
+- **Designer**: Alexey Kryukov (original), Robert Alessi & Antonis Tsolomitis (current maintainers)
 - **License**: OFL
 - **Category**: SERIF
 - **Google Fonts date added**: 2010-05-18
@@ -17,36 +17,40 @@ A canonical upstream repository was found at `akryukov/oldstand` on GitHub, owne
 
 ## Upstream Repository
 
+- **Active URL**: https://git.sr.ht/~ralessi/oldstandard (SourceHut)
+- **Maintainer**: Robert Alessi (alessi@robertalessi.net)
+- **Co-maintainer**: Antonis Tsolomitis (atsol@aegean.gr)
+- **Latest release**: v2.7a
+- **Bug tracker**: https://todo.sr.ht/~ralessi/oldstandard
+
+### Previous Repository (dormant)
+
 - **URL**: https://github.com/akryukov/oldstand
-- **Owner**: `akryukov` — Alexey Kryukov (confirmed via profile showing affiliation with Moscow State University and other font projects including Theano Classical Fonts)
-- **Description**: "Old Standard font family"
+- **Owner**: Alexey Kryukov (original designer)
 - **Last pushed**: 2017-03-31
+- **Status**: Dormant since 2013; the SourceHut fork continues active development
 
-The repository contains FontForge SFD sources:
-- `OldStandard-Regular.sfd`
-- `OldStandard-Italic.sfd`
-- `OldStandard-Bold.sfd`
-- `OldStandard.cfg` — a CacheTT configuration file
-- `genfonts.sh` — build script
-- `ost-generate.py` — Python generation script
-- GDL (Graphite Description Language) files for each weight
-- A `manual/` directory with source documentation
+## Source Files (SourceHut repo)
 
-## Commits
+The `src/` directory contains FontForge SFD sources:
+- `OldStandard-Regular.sfd` (2.0 MiB)
+- `OldStandard-Italic.sfd` (1.8 MiB)
+- `OldStandard-Bold.sfd` (1.7 MiB)
+- `OldStandard-BoldItalic.sfd` (2.2 MiB) — not in Google Fonts
+- `OldStandard-Math.sfd` (7.6 MiB) — not in Google Fonts
 
-The repository was last updated in August 2013. Three commits were found:
-- `f379c2c4` (2013-08-12): "A cfg filr for cachett"
-- `80f7b552` (2013-08-12): "Old Standard manual sources"
-- `6ab74e04` (2013-08-12): "pushing main font files"
+Build is driven by a `makefile` at the repo root.
 
-## Cached Upstream Repos
+## Actions Taken
 
-No cached clone was found in `/mnt/shared/upstream_repos/fontc_crater_cache/` for this family.
+- METADATA.pb `source.repository_url` was set to the SourceHut repo URL
+- No commit hash was recorded (SFD sources cannot go through gftools-builder)
+- No config.yaml was created (no modern build pipeline possible)
 
 ## Conclusion
 
-A canonical designer-owned repository exists at `akryukov/oldstand`. The sources are in FontForge SFD format only — no UFO or Glyphs sources are available. No METADATA.pb changes were made, as the policy requires UFO or Glyphs sources to justify a source block addition.
+The SourceHut fork is the actively maintained upstream. It contains expanded glyph coverage and additional weights beyond what Google Fonts currently ships. Sources are SFD-only, so reproducible builds via gftools-builder are not possible.
 
 ## Confidence
 
-**High** — The repository is owned by Alexey Kryukov (`akryukov`), whose email `amkryukov@gmail.com` matches the copyright string exactly. The font files in the repository match the names used in the Google Fonts release.
+**High** — Robert Alessi's fork is clearly a continuation of the original project, with proper attribution and OFL licensing. The SourceHut bug tracker is active.


### PR DESCRIPTION
> **Note**: This post was generated by an AI agent (Claude) working under the guidance of @felipesanches, but submitted **without human review**. @felipesanches himself would still need to participate in the PR thread if he wants to contribute to the review.

## Summary

- Update `METADATA.pb` `source.repository_url` to point to the actively maintained SourceHut fork: https://git.sr.ht/~ralessi/oldstandard
- Update `upstream_info.md` with current investigation findings

## Context

The previously recorded upstream (`akryukov/oldstand` on GitHub) has been dormant since 2017. Robert Alessi maintains an active fork on SourceHut with continued development through **v2.7a**, including additional weights (Bold Italic) and a Math font variant.

| | GitHub (old) | SourceHut (new) |
|---|---|---|
| **Maintainer** | Alexey Kryukov (original) | Robert Alessi |
| **Last active** | 2017 | ~2024 |
| **Weights** | Regular, Italic, Bold | Regular, Italic, Bold, BoldItalic, Math |
| **Latest version** | ~v2.2 | v2.7a |
| **Bug tracker** | — | https://todo.sr.ht/~ralessi/oldstandard |

Sources are SFD-only, so no `config.yaml` or commit hash is included (not compatible with gftools-builder).

## Test plan

- [ ] Verify METADATA.pb parses correctly
- [ ] Verify SourceHut repo URL is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)