### PR TITLE
oldstandardtt: restore original repo details in upstream_info.md

### DIFF
--- a/ofl/oldstandardtt/upstream_info.md
+++ b/ofl/oldstandardtt/upstream_info.md
@@ -23,12 +23,28 @@ The upstream repository was updated to point to the actively maintained SourceHu
 - **Latest release**: v2.7a
 - **Bug tracker**: https://todo.sr.ht/~ralessi/oldstandard
 
-### Previous Repository (dormant)
+### Original Repository (dormant)
 
 - **URL**: https://github.com/akryukov/oldstand
-- **Owner**: Alexey Kryukov (original designer)
+- **Owner**: Alexey Kryukov (original designer, `amkryukov@gmail.com`)
+- **Description**: "Old Standard font family"
 - **Last pushed**: 2017-03-31
 - **Status**: Dormant since 2013; the SourceHut fork continues active development
+
+The original repository contains FontForge SFD sources:
+- `OldStandard-Regular.sfd`
+- `OldStandard-Italic.sfd`
+- `OldStandard-Bold.sfd`
+- `OldStandard.cfg` — a CacheTT configuration file
+- `genfonts.sh` — build script
+- `ost-generate.py` — Python generation script
+- GDL (Graphite Description Language) files for each weight
+- A `manual/` directory with source documentation
+
+Notable commits:
+- `f379c2c4` (2013-08-12): "A cfg filr for cachett"
+- `80f7b552` (2013-08-12): "Old Standard manual sources"
+- `6ab74e04` (2013-08-12): "pushing main font files"
 
 ## Source Files (SourceHut repo)
 


### PR DESCRIPTION
> **Note**: This post was generated by an AI agent (Claude) working under the guidance of @felipesanches, but submitted **without human review**. @felipesanches himself would still need to participate in the PR thread if he wants to contribute to the review.

## Summary

Follow-up to #10363 — restores the full details of the original `akryukov/oldstand` GitHub repository in upstream_info.md. This information was lost because #10363 was merged before the follow-up commit landed.

Added back:
- Original repo file listing (SFD sources, build scripts, GDL files, manual)
- Owner email and description
- Notable commit history (3 initial commits from 2013)

## Test plan

- [ ] Verify upstream_info.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)