### PR TITLE
Fix source paths in 25 override config.yaml files

### DIFF
--- a/ofl/leckerlione/config.yaml
+++ b/ofl/leckerlione/config.yaml
@@ -1,2 +1,2 @@
 sources:
-  - LeckerliOne-Regular.ufo
+  - ofl/leckerlione/src/LeckerliOne-Regular.ufo

--- a/ofl/lilyscriptone/config.yaml
+++ b/ofl/lilyscriptone/config.yaml
@@ -1,2 +1,2 @@
 sources:
-  - LilyScriptOne-Regular.glyphs
+  - ofl/lilyscriptone/src/LilyScriptOne-Regular.glyphs

--- a/ofl/notonaskharabicui/config.yaml
+++ b/ofl/notonaskharabicui/config.yaml
@@ -12,4 +12,4 @@ familyName: Noto Naskh Arabic UI
 googleFonts: true
 recipeProvider: noto
 sources:
-- NotoNaskhArabicUI.glyphspackage
+- sources/NotoNaskhArabicUI.glyphspackage

--- a/ofl/notosansarabicui/config.yaml
+++ b/ofl/notosansarabicui/config.yaml
@@ -13,4 +13,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSansArabicUI.glyphs
+- sources/NotoSansArabicUI.glyphs

--- a/ofl/notosansbengaliui/config.yaml
+++ b/ofl/notosansbengaliui/config.yaml
@@ -17,4 +17,4 @@ includeSubsets:
       end: 0x35B
 recipeProvider: noto
 sources:
-- NotoSansBengali.glyphspackage
+- sources/NotoSansBengali.glyphspackage

--- a/ofl/notosansdevanagariui/config.yaml
+++ b/ofl/notosansdevanagariui/config.yaml
@@ -10,4 +10,4 @@ familyName: Noto Sans Devanagari UI
 googleFonts: true
 recipeProvider: noto
 sources:
-- NotoSansDevanagariUI.glyphspackage
+- sources/NotoSansDevanagariUI.glyphspackage

--- a/ofl/notosansdisplay/config.yaml
+++ b/ofl/notosansdisplay/config.yaml
@@ -17,5 +17,5 @@ includeSubsets:
     start: 2304
 recipeProvider: noto
 sources:
-- NotoSans.glyphspackage
-- NotoSans-Italic.glyphspackage
+- sources/NotoSans.glyphspackage
+- sources/NotoSans-Italic.glyphspackage

--- a/ofl/notosansgujaratiui/config.yaml
+++ b/ofl/notosansgujaratiui/config.yaml
@@ -14,4 +14,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSansGujarati.glyphs
+- sources/NotoSansGujarati.glyphs

--- a/ofl/notosansgurmukhiui/config.yaml
+++ b/ofl/notosansgurmukhiui/config.yaml
@@ -17,4 +17,4 @@ includeSubsets:
     start: 700
 recipeProvider: noto
 sources:
-- NotoSansGurmukhi.glyphs
+- sources/NotoSansGurmukhi.glyphs

--- a/ofl/notosanskannadaui/config.yaml
+++ b/ofl/notosanskannadaui/config.yaml
@@ -14,4 +14,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSansKannada.glyphs
+- sources/NotoSansKannada.glyphs

--- a/ofl/notosanskhmerui/config.yaml
+++ b/ofl/notosanskhmerui/config.yaml
@@ -13,4 +13,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSansKhmerUI.glyphs
+- sources/NotoSansKhmerUI.glyphs

--- a/ofl/notosanslaoui/config.yaml
+++ b/ofl/notosanslaoui/config.yaml
@@ -13,4 +13,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSansLaoUI-MM.glyphs
+- sources/NotoSansLaoUI-MM.glyphs

--- a/ofl/notosansmalayalamui/config.yaml
+++ b/ofl/notosansmalayalamui/config.yaml
@@ -14,4 +14,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSansMalayalam.glyphs
+- sources/NotoSansMalayalam.glyphs

--- a/ofl/notosansmyanmarui/config.yaml
+++ b/ofl/notosansmyanmarui/config.yaml
@@ -13,4 +13,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSansMyanmarUI.glyphs
+- sources/NotoSansMyanmarUI.glyphs

--- a/ofl/notosansnko_todelist/config.yaml
+++ b/ofl/notosansnko_todelist/config.yaml
@@ -13,4 +13,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSansNKoUnjoined.glyphs
+- sources/NotoSansNKoUnjoined.glyphs

--- a/ofl/notosansoriyaui/config.yaml
+++ b/ofl/notosansoriyaui/config.yaml
@@ -21,4 +21,4 @@ includeSubsets:
     start: 858
 recipeProvider: noto
 sources:
-- NotoSansOriya.glyphs
+- sources/NotoSansOriya.glyphs

--- a/ofl/notosanssinhalaui/config.yaml
+++ b/ofl/notosanssinhalaui/config.yaml
@@ -13,4 +13,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSansSinhala.glyphspackage
+- sources/NotoSansSinhala.glyphspackage

--- a/ofl/notosanstamilui/config.yaml
+++ b/ofl/notosanstamilui/config.yaml
@@ -14,4 +14,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSansTamil.glyphs
+- sources/NotoSansTamil.glyphs

--- a/ofl/notosansteluguui/config.yaml
+++ b/ofl/notosansteluguui/config.yaml
@@ -14,4 +14,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSansTelugu.glyphs
+- sources/NotoSansTelugu.glyphs

--- a/ofl/notosansthaiui/config.yaml
+++ b/ofl/notosansthaiui/config.yaml
@@ -10,4 +10,4 @@ familyName: Noto Sans Thai UI
 googleFonts: true
 recipeProvider: noto
 sources:
-- NotoSansThaiUI.designspace
+- sources/NotoSansThaiUI.designspace

--- a/ofl/notoserifdisplay/config.yaml
+++ b/ofl/notoserifdisplay/config.yaml
@@ -12,5 +12,5 @@ familyName: Noto Serif
 googleFonts: true
 recipeProvider: noto
 sources:
-- NotoSerif.glyphspackage
-- NotoSerif-Italic.glyphspackage
+- sources/NotoSerif.glyphspackage
+- sources/NotoSerif-Italic.glyphspackage

--- a/ofl/notoserifmyanmar/config.yaml
+++ b/ofl/notoserifmyanmar/config.yaml
@@ -15,4 +15,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSerifMyanmar.glyphs
+- sources/NotoSerifMyanmar.glyphs

--- a/ofl/notoserifnphmong/config.yaml
+++ b/ofl/notoserifnphmong/config.yaml
@@ -15,4 +15,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSerifNPHmong.designspace
+- sources/NotoSerifNPHmong.designspace

--- a/ofl/notoserifnyiakengpuachuehmong/config.yaml
+++ b/ofl/notoserifnyiakengpuachuehmong/config.yaml
@@ -15,4 +15,4 @@ includeSubsets:
   name: GF_Latin_Core
 recipeProvider: noto
 sources:
-- NotoSerifNPHmong.designspace
+- sources/NotoSerifNPHmong.designspace

--- a/ofl/snippet/config.yaml
+++ b/ofl/snippet/config.yaml
@@ -1,2 +1,2 @@
 sources:
-  - Snippet.ufo
+  - ofl/snippet/src/Snippet.ufo


### PR DESCRIPTION
> **Note**: This post was generated by an AI agent (Claude) working under the guidance of @felipesanches, but submitted **without human review**. @felipesanches himself would still need to participate in the PR thread if he wants to contribute to the review.

## Summary

Fixes source file paths in 25 override `config.yaml` files so that `gftools-builder` can find the source files when building from the upstream repos.

## What changed

**22 Noto families**: Prepend `sources/` to source file paths. These override configs were copied from `notofonts/` per-script repos where the config lives inside `sources/`, but the google/fonts build system copies override configs to the repo root — so source paths need the `sources/` prefix to resolve correctly.

**3 googlefontdirectory-hg families** (leckerlione, snippet, lilyscriptone): Prepend the monorepo-relative path `ofl/{family}/src/` to source file paths, since the repo is a monorepo where each family's sources live in a subdirectory.

## Why this is needed

Without this fix, running `gftools-builder` with these override configs produces `FileNotFoundError` because the source paths don't match the actual file locations in the upstream repos. Verified by running builds — all 25 families failed with "No such file or directory" errors before this fix.

## Test plan

- [ ] Verify each config.yaml parses correctly
- [ ] Spot-check that the paths resolve to real files in the respective upstream repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)