### PR TITLE
modak: add source metadata from EkType/Modak

### DIFF
--- a/ofl/modak/METADATA.pb
+++ b/ofl/modak/METADATA.pb
@@ -17,3 +17,7 @@ subsets: "devanagari"
 subsets: "latin"
 subsets: "latin-ext"
 primary_script: "Deva"
+source {
+  repository_url: "https://github.com/EkType/Modak"
+  commit: "143b2db4fd2279b71e68f22bba4b43a8a3a9de69"
+}

--- a/ofl/modak/upstream_info.md
+++ b/ofl/modak/upstream_info.md
@@ -1,7 +1,37 @@
-Font was designed by Ek Type. No source repository URL was recorded in METADATA.pb. The font covers Devanagari and Latin scripts and was added to Google Fonts in 2015.
+# Modak — Upstream Source Investigation
 
-**Repo:** unknown
-**Commit:** unknown
-**Config:** none
-**Status:** No upstream source recorded
-**Confidence:** Low
+**Model**: Claude Opus 4.6
+
+## Source Repository
+
+| Field | Value |
+|-------|-------|
+| Repository | [https://github.com/EkType/Modak](https://github.com/EkType/Modak) |
+| Commit | `143b2db4fd2279b71e68f22bba4b43a8a3a9de69` |
+| Version | 1.036 |
+| Date Added | 2015-02-18 |
+
+## Investigation Summary
+
+Modak is a heavy, rounded Devanagari + Latin display typeface designed by Ek Type (Girish Dalvi and Noopur Datye). The upstream repository at `EkType/Modak` contains VFB source files and AFDKO build configuration (feature files, GlyphOrderAndAliasDB, GPOS/GSUB/GDEF tables).
+
+The font was added to google/fonts in the initial bulk import (2015-03-07). The shipped version is 1.036, built with AFDKO (`makeotf.lib2.5.61930`) and autohinted with `ttfautohint v1.2.42`. Commit `143b2db4` (2015-02-25, "धारिका अद्यतनित केली" — Marathi for "font updated") is the last content update before the google/fonts import date.
+
+## Source Files
+
+- `SourceFiles/VFB/Modak.vfb` — FontLab source (proprietary format)
+- `SourceFiles/features` — OpenType feature code (AFDKO format)
+- `SourceFiles/GPOS`, `SourceFiles/GSUB`, `SourceFiles/GDEF` — OpenType layout tables
+- `SourceFiles/GlyphOrderAndAliasDB` — AFDKO glyph ordering
+- `SourceFiles/classes` — OpenType class definitions
+- `TTX/Modak-Regular.ttx` — TTX dump of the compiled font
+
+## Build Pipeline
+
+The font was built using **Adobe AFDKO** (Adobe Font Development Kit for OpenType), not gftools-builder or fontmake. The VFB source was processed through `makeotf` with the feature/table files in `SourceFiles/`. No `config.yaml` is applicable for this build pipeline.
+
+## Commit Verification
+
+Commit `143b2db4` is the last commit with content changes before the google/fonts bulk import on 2015-03-07. The repo had further updates in May 2016 (TTF build fixes, minor updates) but the font in google/fonts was never updated from the initial import.
+
+**Confidence**: MEDIUM (date correlation — last content commit before import, but no blob-level verification performed)


### PR DESCRIPTION
> **Note**: This post was generated by an AI agent (Claude) working under the guidance of @felipesanches, but submitted **without human review**. @felipesanches himself would still need to participate in the PR thread if he wants to contribute to the review.

## Summary

Adds `source { repository_url, commit }` block to Modak, pointing to `EkType/Modak`.

- **Repository**: https://github.com/EkType/Modak
- **Commit**: `143b2db4` (2015-02-25, last content update before google/fonts import)
- **Source format**: VFB + AFDKO build files (not gftools-builder buildable)
- **Verification**: Date correlation (MEDIUM confidence)

The repository was identified by @felipesanches. The commit was determined by finding the last content update before the google/fonts bulk import on 2015-03-07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)