### PR TITLE
Create python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,70 @@
+# This workflow will upload a Python Package to PyPI when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build release distributions
+        run: |
+          # NOTE: put your own distribution build steps here.
+          python -m pip install build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: pypi
+      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+      # url: https://pypi.org/p/YOURPROJECT
+      #
+      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
+      # ALTERNATIVE: exactly, uncomment the following line instead:
+      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
# Sintaxis básica de redacción y formato

Cree un formato sofisticado para el prose y el código en GitHub con una sintaxis sencilla.

## Headings

Para crear un encabezado, agregue uno a seis <kbd>#</kbd> símbolos antes del texto del encabezado. El número de <kbd>#</kbd> uso determinará el nivel de jerarquía y el tamaño del tipo de letra del encabezado.

```markdown
# A first-level heading
## A second-level heading
### A third-level heading
```

![Captura de pantalla de los encabezados GitHub Markdown representados que muestran los encabezados h1, h2 y h3 de ejemplo, que descienden en tamaño de tipo y peso visual para mostrar el nivel de jerarquía.](/assets/images/help/writing/headings-rendered.png)

Al usar dos o más encabezados, GitHub genera automáticamente una tabla de contenido a la que puede acceder haciendo clic en el icono de menú "Esquema" <svg version="1.1" width="16" height="16" viewBox="0 0 16 16" class="octicon octicon-list-unordered" aria-label="Table of Contents" role="img"><path d="M5.75 2.5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5ZM2 14a1 1 0 1 1 0-2 1 1 0 0 1 0 2Zm1-6a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM2 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path></svg> dentro del encabezado de archivo. Cada título de título aparece en la tabla de contenido y puede hacer clic en un título para ir a la sección seleccionada.

![Captura de pantalla de un archivo LÉAME con el menú desplegable de la tabla de contenidos mostrada. El icono de tabla de contenido se describe en naranja oscuro.](/assets/images/help/repository/headings-toc.png)

## Aplicar estilo al texto

Puede indicar énfasis con negrita, cursiva, tachado, subíndice o texto de superíndice en los campos y `.md` archivos de comentario.

| Style | Syntax | Atajo de teclado | Example | Salida |
| ----- | ------ | ---------------- | ------- | ------ |
| Bold  |        |                  |         |        |

```
          `** **` o `__ __`| 
          <kbd>Command</kbd>+<kbd>B</kbd> (Mac) o <kbd>Ctrl</kbd>+<kbd>B</kbd> (Windows/Linux) | `**This is bold text**` | 
          **Este es texto en negrita** |
```

\| Itálico |
`* *` o `_ _`    | <kbd>Command</kbd>+<kbd>I</kbd> (Mac) o <kbd>Ctrl</kbd>+<kbd>I</kbd> (Windows/Linux) | `_This text is italicized_` |
*Este texto está en cursiva* |
\| Tachado |
`~~ ~~` o `~ ~` | Ninguno | `~~This was mistaken text~~` |
~~Se equivocó el texto~~ |
\| Negrita y cursiva anidada |
`** **` y `_ _` | Ninguno | `**This text is _extremely_ important**` |
**Este texto es *extremadamente* importante** |
\| Todo en negrita y cursiva | `*** ***` | Ninguno | `***All this text is important***` |
***Todo este texto es importante*** | <!-- markdownlint-disable-line emphasis-style -->
\| Subíndice | `<sub> </sub>` | Ninguno | `This is a <sub>subscript</sub> text` | Este es un texto <sub>de subíndice</sub> |
\| Superíndice | `<sup> </sup>` | Ninguno | `This is a <sup>superscript</sup> text` | Se trata de un texto <sup>superíndice</sup> |
\| Subrayado | `<ins> </ins>` | Ninguno | `This is an <ins>underlined</ins> text` | Se trata de un texto <ins>subrayado</ins> |

## Texto citado

Puede entrecomillar texto con .<kbd>></kbd>

```markdown
Text that is not a quote

> Text that is a quote
```

El texto citado se indenta con una línea vertical a la izquierda y se muestra en color gris.

![Captura de pantalla de GitHub Markdown representada que muestra la diferencia entre texto normal y entre comillas.](/assets/images/help/writing/quoted-text-rendered.png)

> \[!NOTE]
> Al ver una conversación, puede citar automáticamente texto en un comentario resaltando el texto y escribiendo <kbd>R</kbd>. Para citar un comentario completo, haga clic en <svg version="1.1" width="16" height="16" viewBox="0 0 16 16" class="octicon octicon-kebab-horizontal" aria-label="El icono de kebab horizontal" role="img"><path d="M8 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm13 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path></svg>y, a continuación, **respuesta de comillas**. Para obtener más información sobre los métodos abreviados de teclado, vea [Atajos de teclado](/es/get-started/accessibility/keyboard-shortcuts).

## Citar código

Puede destacar código o comandos dentro de una oración con comillas invertidas simples. No se dará formato al texto dentro de las comillas invertidas. También puede presionar el <kbd>Command</kbd>+<kbd>E</kbd> (Mac) o <kbd>Ctrl</kbd>+<kbd>E</kbd> (Windows/Linux) para insertar los retrocesos de un bloque de código dentro de una línea de Markdown.

```markdown
Use `git status` to list all new or modified files that haven't yet been committed.
```

![Captura de pantalla de GitHub Markdown representada en la que se muestra que los caracteres rodeados por acentos se muestran en un tipo de ancho fijo, resaltado en gris claro.](/assets/images/help/writing/inline-code-rendered.png)

Para dar formato al código o al texto en su propio bloque diferenciado, use tres comillas invertidas.

````markdown
Some basic Git commands are:
```
git status
git add
git commit
```
````

![Captura de pantalla de GitHub Markdown representada que muestra un bloque de código simple sin resaltado de sintaxis.](/assets/images/help/writing/code-block-rendered.png)

Para más información, consulta [Crear y resaltar bloques de código](/es/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks).

Si editas fragmentos de código y tablas con frecuencia, puedes beneficiarte de habilitar una fuente de ancho fijo en todos los campos de comentarios de GitHub. Para más información, consulta [Acerca de la escritura y el formato en GitHub](/es/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/about-writing-and-formatting-on-github#enabling-fixed-width-fonts-in-the-editor).

## Modelos de color admitidos

En los temas, solicitudes de incorporación de cambios y discusiones, pueden destacar colores dentro de una oración utilizando comillas invertidas. Un modelo de color admitido entre comillas invertidas mostrará una visualización del color.

```markdown
The background color is `#ffffff` for light mode and `#000000` for dark mode.
```

![Captura de pantalla de la GitHub Markdown representada en la que se muestran cómo los valores HEX dentro de las marcas inversas crean pequeños círculos de color, aquí blanco y negro.](/assets/images/help/writing/supported-color-models-rendered.png)

Estos son los modelos de color admitidos actualmente.

| Color              | Syntax                      | Example                             | Salida                                                                                                                                                                                                  |
| ------------------ | --------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| HEX or Hexadecimal | <code>\`#RRGGBB\`</code>    | <code>\`#0969DA\`</code>            | ![Captura de pantalla de GitHub Markdown representada que muestra cómo aparece el valor HEX #0969DA con un círculo azul.](/assets/images/help/writing/supported-color-models-hex-rendered.png)          |
| RGB                | <code>\`rgb(R,G,B)\`</code> | <code>\`rgb(9, 105, 218)\`</code>   | ![Captura de pantalla de GitHub Markdown representada que muestra cómo aparece el valor RGB 9, 105, 218 con un círculo azul.](/assets/images/help/writing/supported-color-models-rgb-rendered.png)      |
| HSL                | <code>\`hsl(H,S,L)\`</code> | <code>\`hsl(212, 92%, 45%)\`</code> | ![Captura de pantalla de GitHub Markdown representada que muestra cómo aparece el valor de HSL 212, 92%, 45% con un círculo azul.](/assets/images/help/writing/supported-color-models-hsl-rendered.png) |

> \[!NOTE]
>
> * Un modelo de color admitido no puede tener espacios iniciales o finales dentro de las comillas invertidas.
> * La visualización del color solo se admite en incidencias, pull requests y discusiones.

## Enlaces

Puede crear un vínculo insertado ajustando el texto del vínculo entre corchetes `[ ]`y ajustando la dirección URL entre paréntesis `( )`. También puede usar el método abreviado de teclado <kbd>Comando</kbd>+<kbd>K</kbd> para crear un vínculo. Cuando haya seleccionado texto, puede pegar una dirección URL del Portapapeles para crear automáticamente un vínculo a partir de la selección.

También puede crear un hipervínculo de Markdown resaltando el texto y usando el método abreviado de teclado <kbd>Command</kbd>+<kbd>V</kbd>. Si desea reemplazar el texto por el vínculo, use el método abreviado de teclado <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>V</kbd>.

`This site was built using [GitHub Pages](https://pages.github.com/).`

![Captura de pantalla de GitHub Markdown representada que muestra cómo el texto entre corchetes, "GitHub Pages", aparece como un hipervínculo azul.](/assets/images/help/writing/link-rendered.png)

> \[!NOTE]
> GitHub crea automáticamente vínculos cuando las direcciones URL válidas se escriben en un comentario. Para más información, consulta [Referencias y direcciones URL autovinculadas](/es/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls).

## Vínculos de sección

Puede vincular directamente a cualquier sección que tenga un encabezado. Para ver el delimitador generado automáticamente en un archivo representado, mantenga el puntero sobre el encabezado de sección para exponer el icono de <svg version="1.1" width="16" height="16" viewBox="0 0 16 16" class="octicon octicon-link" aria-label="the link" role="img"><path d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"></path></svg> y haga clic en el icono para mostrar el delimitador en el explorador.

![Captura de pantalla de un archivo README de un repositorio. A la izquierda de un encabezado de sección, se destaca un icono de vínculo en naranja oscuro.](/assets/images/help/repository/readme-links.png)

Si necesita determinar el delimitador de un encabezado en un archivo que está editando, puede usar las siguientes reglas básicas:

* Las letras se convierten en minúsculas.
* Los espacios se reemplazan por guiones (`-`). Se quitan cualquier otro espacio en blanco o caracteres de puntuación.
* Se quitan los espacios en blanco iniciales y finales.
* Se quita el formato de marcado, dejando solo el contenido (por ejemplo, `_italics_` se convierte en `italics`).
* Si el delimitador generado automáticamente para un encabezado es idéntico a un delimitador anterior en el mismo documento, se genera un identificador único anexando un guión y un entero de incremento automático.

Para obtener información más detallada sobre los requisitos de fragmentos de URI, consulte [RFC 3986: Identificador uniforme de recursos (URI): Sintaxis genérica, sección 3.5](https://www.rfc-editor.org/rfc/rfc3986#section-3.5).

El bloque de código siguiente muestra las reglas básicas que se usan para generar anclajes a partir de encabezados en contenido representado.

```markdown
# Example headings

## Sample Section

## This'll be a _Helpful_ Section About the Greek Letter Θ!
A heading containing characters not allowed in fragments, UTF-8 characters, two consecutive spaces between the first and second words, and formatting.

## This heading is not unique in the file

TEXT 1

## This heading is not unique in the file

TEXT 2

# Links to the example headings above

Link to the sample section: [Link Text](#sample-section).

Link to the helpful section: [Link Text](#thisll-be-a-helpful-section-about-the-greek-letter-Θ).

Link to the first non-unique section: [Link Text](#this-heading-is-not-unique-in-the-file).

Link to the second non-unique section: [Link Text](#this-heading-is-not-unique-in-the-file-1).
```

> \[!NOTE]
> Si edita un encabezado o cambia el orden de los encabezados con anclajes "idénticos", también deberá actualizar los vínculos a esos encabezados, ya que los delimitadores cambiarán.

## Vínculos relativos

Puedes definir enlaces relativos y rutas de imagen en los archivos representados para ayudar a que los lectores naveguen hasta otros archivos de tu repositorio.

Un enlace relativo es un enlace que es relativo al archivo actual. Por ejemplo, si tiene un archivo Léame en la raíz del repositorio y tiene otro archivo en *docs/CONTRIBUTING.md*, el vínculo relativo a *CONTRIBUTING.md* en el archivo Léame podría tener este aspecto:

```text
[Contribution guidelines for this project](docs/CONTRIBUTING.md)
```

GitHub transformará de manera automática el enlace relativo o la ruta de imagen en cualquier rama en la que te encuentres actualmente, de modo que el enlace o ruta siempre funcione. La ruta de acceso del vínculo será relativa al archivo actual. Los vínculos que comienzan por `/` serán relativos a la raíz del repositorio. Puede usar todos los operandos de vínculo relativos, como `./` y `../`.

El texto del vínculo debe estar en una sola línea. El ejemplo siguiente no funcionará.

```markdown
[Contribution
guidelines for this project](docs/CONTRIBUTING.md)
```

Los enlaces relativos son más sencillos para los usuarios que clonan tu repositorio. Puede que los enlaces absolutos no funcionen en los clones de tu repositorio. Recomendamos usar enlaces relativos para consultar los archivos dentro de tu repositorio.

## Anclajes personalizados

Puede usar etiquetas de anclaje HTML estándar (`<a name="unique-anchor-name"></a>`) para crear puntos de anclaje de navegación para cualquier ubicación del documento. Para evitar referencias ambiguas, use un esquema de nomenclatura único para etiquetas de anclaje, como agregar un prefijo al valor del `name` atributo.

> \[!NOTE]
> Los delimitadores personalizados no se incluirán en el esquema o tabla de contenido del documento.

Puede vincular a un delimitador personalizado mediante el valor del `name` atributo que proporcionó el delimitador. La sintaxis es exactamente la misma que cuando enlaza a un ancla que se genera automáticamente para un encabezado.

Por ejemplo:

```markdown
# Section Heading

Some body text of this section.

<a name="my-custom-anchor-point"></a>
Some text I want to provide a direct link to, but which doesn't have its own heading.

(… more content…)

[A link to that custom anchor](#my-custom-anchor-point)
```

> \[!TIP]
> Las anclas personalizadas no son consideradas por el comportamiento de nomenclatura y numeración automática de los vínculos de encabezado.

## Saltos de línea

Si está escribiendo problemas, solicitudes de incorporación de cambios o discusiones en un repositorio, GitHub representará automáticamente un salto de línea:

```markdown
This example
Will span two lines
```

Sin embargo, si está escribiendo en un archivo .md, el ejemplo anterior se mostraría en una única línea sin un fin de línea. Para crear un salto de línea en un archivo .md, deberá incluir uno de los siguientes elementos:

* Incluya dos espacios al final de la primera línea.
  <pre>
  This example&nbsp;&nbsp;
  Will span two lines
  </pre>

* Incluya una barra diagonal inversa al final de la primera línea.

  ```markdown
  This example\
  Will span two lines
  ```

* Incluya una etiqueta de salto de una sola línea HTML al final de la primera línea.

  ```markdown
  This example<br/>
  Will span two lines
  ```

Si deja una línea en blanco entre dos líneas, tanto en los archivos .md como en la sintaxis Markdown en incidencias, solicitudes de extracción y discusiones, las líneas se mostrarán separadas por la línea en blanco.

```markdown
This example

Will have a blank line separating both lines
```

## Imágenes

Puede mostrar una imagen agregando <kbd>!</kbd> y ajuste del texto alternativo en `[ ]`. El texto alternativo es un texto corto equivalente a la información de la imagen. A continuación, ajuste el vínculo de la imagen entre paréntesis `()`.

`![Screenshot of a comment on a GitHub issue showing an image, added in the Markdown, of an Octocat smiling and raising a tentacle.](https://myoctocat.com/assets/images/base-octocat.svg)`

![Captura de pantalla de un comentario sobre un problema de GitHub que muestra una imagen, agregada en Markdown, de un Octocat sonriendo y levantando un tentáculo.](/assets/images/help/writing/image-rendered.png)

GitHub admite la inserción de imágenes en sus problemas, solicitudes de incorporación de cambios, debates, comentarios y `.md` archivos. Puede mostrar una imagen desde el repositorio, agregar un vínculo a una imagen en línea o cargar una imagen. Para obtener más información, consulte [Carga de recursos](#uploading-assets).

> \[!NOTE]
> Cuando desee mostrar una imagen que se encuentra en el repositorio, use vínculos relativos en lugar de vínculos absolutos.

Estos son algunos ejemplos para usar vínculos relativos para mostrar una imagen.

| Context                                                                                 | Vínculo relativo                                                       |
| --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| En un `.md` archivo de la misma rama                                                    | `/assets/images/electrocat.png`                                        |
| En un `.md` archivo de otra rama                                                        | `/../main/assets/images/electrocat.png`                                |
| En las incidencias, solicitudes de extracción y comentarios del repositorio             | `../blob/main/assets/images/electrocat.png?raw=true`                   |
| En un `.md` archivo de otro repositorio                                                 | `/../../../../github/docs/blob/main/assets/images/electrocat.png`      |
| En problemas, solicitudes de incorporación de cambios y comentarios de otro repositorio | `../../../github/docs/blob/main/assets/images/electrocat.png?raw=true` |

> \[!NOTE]
> Los dos últimos vínculos relativos de la tabla anterior funcionarán para las imágenes de un repositorio privado solo si el visor tiene al menos acceso de lectura al repositorio privado que contiene estas imágenes.

Para obtener más información, vea [Vínculos relativos](#relative-links).

### Elemento Imagen

Se admite el `<picture>` elemento HTML.

## Lists

Puede crear una lista sin ordenar si precede una o varias líneas de texto con <kbd>-</kbd>, <kbd>\*</kbd>o <kbd>+</kbd>.

```markdown
- George Washington
* John Adams
+ Thomas Jefferson
```

![Captura de pantalla de GitHub Markdown representada en la que se muestra una lista con viñetas de los nombres de los tres primeros presidentes estadounidenses.](/assets/images/help/writing/unordered-list-rendered.png)

Para ordenar la lista, precede a cada línea con un número.

```markdown
1. James Madison
2. James Monroe
3. John Quincy Adams
```

![Captura de pantalla de GitHub Markdown representada en la que se muestra una lista numerada de los nombres de los presidentes cuarto, quinto y sexto estadounidense.](/assets/images/help/writing/ordered-list-rendered.png)

### Listas anidadas

Puede crear una lista anidada al sangrar uno o varios elementos de lista para ubicarlos debajo de otro elemento.

Para crear una lista anidada mediante