### PR TITLE
Add override config.yaml for mixed sources

### DIFF
--- a/ofl/gentiumbookplus/config.yaml
+++ b/ofl/gentiumbookplus/config.yaml
@@ -1,0 +1,4 @@
+sources:
+  - source/GentiumPlusRoman.designspace
+  - source/GentiumPlusItalic.designspace
+familyName: "Gentium Book Plus"

--- a/ofl/gentiumbookplus/upstream_info.md
+++ b/ofl/gentiumbookplus/upstream_info.md
@@ -119,3 +119,9 @@ source {
 
 ### Status: `no_config_possible`
 ### Confidence: HIGH
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.designspace) and legacy `.sfd`/`.vfb` archives at the pinned commit `7ac5e5c` (upstream legacy: .vfb archives in source/archive/). Added an override `config.yaml` in `ofl/gentiumbookplus/` that references the compatible sources only (`source/GentiumPlusRoman.designspace`, `source/GentiumPlusItalic.designspace`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/gentiumplus/config.yaml
+++ b/ofl/gentiumplus/config.yaml
@@ -1,0 +1,4 @@
+sources:
+  - source/GentiumPlusRoman.designspace
+  - source/GentiumPlusItalic.designspace
+familyName: "Gentium Plus"

--- a/ofl/gentiumplus/upstream_info.md
+++ b/ofl/gentiumplus/upstream_info.md
@@ -117,3 +117,9 @@ source {
 
 ### Status: `no_config_possible`
 ### Confidence: HIGH
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.designspace) and legacy `.sfd`/`.vfb` archives at the pinned commit `7ac5e5c` (upstream legacy: .vfb archives in source/archive/). Added an override `config.yaml` in `ofl/gentiumplus/` that references the compatible sources only (`source/GentiumPlusRoman.designspace`, `source/GentiumPlusItalic.designspace`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/halant/config.yaml
+++ b/ofl/halant/config.yaml
@@ -1,0 +1,7 @@
+sources:
+  - styles/Light/font.ufo
+  - styles/Regular/font.ufo
+  - styles/Medium/font.ufo
+  - styles/SemiBold/font.ufo
+  - styles/Bold/font.ufo
+familyName: Halant

--- a/ofl/halant/upstream_info.md
+++ b/ofl/halant/upstream_info.md
@@ -81,3 +81,9 @@ source {
 ### Status: missing_config
 
 The repository has UFO sources but uses a custom build system without config.yaml or designspace. Creating an override config would require authoring a designspace file to define the interpolation space.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `5991cb7` (upstream legacy: .vfb masters in masters/). Added an override `config.yaml` in `ofl/halant/` that references the compatible sources only (`styles/Light/font.ufo`, `styles/Regular/font.ufo`, `styles/Medium/font.ufo`, `styles/SemiBold/font.ufo`, `styles/Bold/font.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/hind/config.yaml
+++ b/ofl/hind/config.yaml
@@ -1,0 +1,7 @@
+sources:
+  - styles/Light/font.ufo
+  - styles/Regular/font.ufo
+  - styles/Medium/font.ufo
+  - styles/SemiBold/font.ufo
+  - styles/Bold/font.ufo
+familyName: Hind

--- a/ofl/hind/upstream_info.md
+++ b/ofl/hind/upstream_info.md
@@ -100,3 +100,9 @@ There is no `config.yaml` override file in `ofl/hind/` in google/fonts.
 **Status: missing_config**
 
 The source block in METADATA.pb has the correct repository URL but is missing the `commit` field. The commit hash `6caef5262dc5bee3e033207082a073a6a1d172d6` (the latest and only meaningful reference point) should be added, with a note about the version discrepancy. An override config.yaml for gftools-builder could be created using the UFO master files, but the complex Devanagari-specific build pipeline (mI matching, custom feature generation, AFDKO instance generation) means the output may differ from the current v2.001 binaries. The build system uses `masters/Hind_0.ufo` and `masters/Hind_1.ufo` as source masters. Note that the repo has not been updated since 2014, while the fonts in google/fonts are v2.001 from 2017.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `6caef52` (upstream legacy: .vfb masters in masters/). Added an override `config.yaml` in `ofl/hind/` that references the compatible sources only (`styles/Light/font.ufo`, `styles/Regular/font.ufo`, `styles/Medium/font.ufo`, `styles/SemiBold/font.ufo`, `styles/Bold/font.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/karma/config.yaml
+++ b/ofl/karma/config.yaml
@@ -1,0 +1,7 @@
+sources:
+  - styles/Light/font.ufo
+  - styles/Regular/font.ufo
+  - styles/Medium/font.ufo
+  - styles/SemiBold/font.ufo
+  - styles/Bold/font.ufo
+familyName: Karma

--- a/ofl/karma/upstream_info.md
+++ b/ofl/karma/upstream_info.md
@@ -42,3 +42,9 @@ The source block needs a `commit` field added. The commit to use would need to b
 ## Commit Added (HIGH confidence)
 
 Commit `12228946ce59ce2008e0a95a6b222632e6481121` was determined by **tag_match**. Matched a version tag in the upstream repo whose date is on or before the binary modification date in google/fonts (2017-05-15). This is the most reliable method.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `1222894` (upstream legacy: .vfb masters in masters/). Added an override `config.yaml` in `ofl/karma/` that references the compatible sources only (`styles/Light/font.ufo`, `styles/Regular/font.ufo`, `styles/Medium/font.ufo`, `styles/SemiBold/font.ufo`, `styles/Bold/font.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/khand/config.yaml
+++ b/ofl/khand/config.yaml
@@ -1,0 +1,6 @@
+sources:
+  - styles/Light/font.ufo
+  - styles/Regular/font.ufo
+  - styles/SemiBold/font.ufo
+  - styles/Bold/font.ufo
+familyName: Khand

--- a/ofl/khand/upstream_info.md
+++ b/ofl/khand/upstream_info.md
@@ -41,3 +41,9 @@ The source block needs a `commit` field. The commit to use is likely `1f1d677` (
 ## Commit Added (HIGH confidence)
 
 Commit `1f1d6778d3a940999b543313b2371fa76b16a978` was determined by **tag_match**. Matched a version tag in the upstream repo whose date is on or before the binary modification date in google/fonts (2022-11-09). This is the most reliable method.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `1f1d677` (upstream legacy: .vfb masters in masters/; upstream also has ExtraLight/ExtraBold/Black/SemiLight UFOs not shipped). Added an override `config.yaml` in `ofl/khand/` that references the compatible sources only (`styles/Light/font.ufo`, `styles/Regular/font.ufo`, `styles/SemiBold/font.ufo`, `styles/Bold/font.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/laila/config.yaml
+++ b/ofl/laila/config.yaml
@@ -1,0 +1,7 @@
+sources:
+  - styles/Light/font.ufo
+  - styles/Regular/font.ufo
+  - styles/Medium/font.ufo
+  - styles/SemiBold/font.ufo
+  - styles/Bold/font.ufo
+familyName: Laila

--- a/ofl/laila/upstream_info.md
+++ b/ofl/laila/upstream_info.md
@@ -44,3 +44,9 @@ The source block exists with the repository URL but is missing the commit hash. 
 ## Commit Added (HIGH confidence)
 
 Commit `a8b5b4ee6cf52508cc0d4f606d4ec0ae4994953a` was determined by **tag_match**. Matched a version tag in the upstream repo whose date is on or before the binary modification date in google/fonts (2017-05-15). This is the most reliable method.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `a8b5b4e` (upstream legacy: .vfb masters in masters/). Added an override `config.yaml` in `ofl/laila/` that references the compatible sources only (`styles/Light/font.ufo`, `styles/Regular/font.ufo`, `styles/Medium/font.ufo`, `styles/SemiBold/font.ufo`, `styles/Bold/font.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/leaguescript/config.yaml
+++ b/ofl/leaguescript/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - source/LeagueScriptNumberOne.ufo
+familyName: "League Script"

--- a/ofl/leaguescript/upstream_info.md
+++ b/ofl/leaguescript/upstream_info.md
@@ -46,3 +46,9 @@ The repository URL is present but the commit hash is missing. The upstream repo 
 ## Commit Added (MEDIUM confidence)
 
 Commit `225add0b37cf8268759ba4572e02630d9fb54ecf` was determined by **date_correlation**. Found the latest upstream commit before the binary modification date in google/fonts (2019-07-09). This assumes the upstream HEAD at onboarding time was the commit used.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `225add0` (upstream legacy: .vfb in source/). Added an override `config.yaml` in `ofl/leaguescript/` that references the compatible sources only (`source/LeagueScriptNumberOne.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/mandali/config.yaml
+++ b/ofl/mandali/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - Mandali.ufo
+familyName: Mandali

--- a/ofl/mandali/upstream_info.md
+++ b/ofl/mandali/upstream_info.md
@@ -100,3 +100,9 @@ The commit hash **77ee092** is recommended because it is the only commit where t
 ## Commit Added (MEDIUM confidence)
 
 Commit `b5d09820cc850e98417250895a11bf0605ab2510` was determined by **date_correlation**. Found the latest upstream commit before the binary modification date in google/fonts (2015-03-07). This assumes the upstream HEAD at onboarding time was the commit used.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `b5d0982` (upstream legacy: .sfd in repo root). Added an override `config.yaml` in `ofl/mandali/` that references the compatible sources only (`Mandali.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/mirza/config.yaml
+++ b/ofl/mirza/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - "Sources/Mirza 2 Masters.glyphs"
+familyName: Mirza

--- a/ofl/mirza/upstream_info.md
+++ b/ofl/mirza/upstream_info.md
@@ -55,3 +55,9 @@ No `config.yaml` exists in the upstream repo or in the `ofl/mirza/` directory in
 - Co-authors include Lasse Fister (graphicore) and Eduardo Tunni, both active in the broader font community.
 - The `gh-pages` branch likely hosts the project website.
 - Confidence in repo identification: **High** — repo name, owner email (`tarobish@gmail.com`), and multi-weight Arabic font structure all match the METADATA.pb exactly.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.glyphs) and legacy `.sfd`/`.vfb` archives at the pinned commit `fa7b59c` (upstream legacy: .sfd technical-additions and Latin sidecar source). Added an override `config.yaml` in `ofl/mirza/` that references the compatible sources only (`Sources/Mirza 2 Masters.glyphs`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/mitr/config.yaml
+++ b/ofl/mitr/config.yaml
@@ -1,0 +1,8 @@
+sources:
+  - source/Mitr-200.glyphs
+  - source/Mitr-300.glyphs
+  - source/Mitr-400.glyphs
+  - source/Mitr-500.glyphs
+  - source/Mitr-600.glyphs
+  - source/Mitr-700.glyphs
+familyName: Mitr

--- a/ofl/mitr/upstream_info.md
+++ b/ofl/mitr/upstream_info.md
@@ -46,3 +46,9 @@ No `config.yaml` exists in the repository.
 - The latest commit `41950431d37f6410fd082760ca806eb490e4791f` on branch `master` is the appropriate reference for the METADATA.pb `source` block.
 - A `config.yaml` would need to be created to establish a reproducible gftools build pipeline, as none currently exists in the repo. Individual per-weight Glyphs sources would need to be mapped to their respective output font files.
 - **Recommended action**: Add a `source` block to METADATA.pb pointing to `https://github.com/cadsondemak/mitr`, commit `41950431d37f6410fd082760ca806eb490e4791f`, branch `master`. A `config.yaml` should be authored to enable future rebuilds.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.glyphs and .ufo (selected .glyphs)) and legacy `.sfd`/`.vfb` archives at the pinned commit `4195043` (upstream legacy: .vfb alongside each weight). Added an override `config.yaml` in `ofl/mitr/` that references the compatible sources only (`source/Mitr-200.glyphs`, `source/Mitr-300.glyphs`, `source/Mitr-400.glyphs`, `source/Mitr-500.glyphs`, `source/Mitr-600.glyphs`, `source/Mitr-700.glyphs`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/narnoor/config.yaml
+++ b/ofl/narnoor/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - source/Narnoor.designspace
+familyName: Narnoor

--- a/ofl/narnoor/upstream_info.md
+++ b/ofl/narnoor/upstream_info.md
@@ -56,3 +56,9 @@ Without a local clone of `font-narnoor`, the exact source format cannot be confi
 ## Commit Added (HIGH confidence)
 
 Commit `53fa5d8f5c3afecd9c2247ef7c8b26a02208f267` was determined by **tag_match**. Matched a version tag in the upstream repo whose date is on or before the binary modification date in google/fonts (2023-11-02). This is the most reliable method.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.designspace) and legacy `.sfd`/`.vfb` archives at the pinned commit `53fa5d8` (upstream legacy: .sfd in source/archive/). Added an override `config.yaml` in `ofl/narnoor/` that references the compatible sources only (`source/Narnoor.designspace`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/nats/config.yaml
+++ b/ofl/nats/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - NATS.ufo
+familyName: NATS

--- a/ofl/nats/upstream_info.md
+++ b/ofl/nats/upstream_info.md
@@ -36,3 +36,9 @@ A `config.yaml` file is listed in the repository tree, but its content could not
 - The font was added to Google Fonts on 2014-12-10 and has not been updated since the initial addition; the upstream repo similarly has had no activity since 2014.
 - The `nikstoj/neuton-font` GitHub repo seen in search results is unrelated to this family.
 - No upstream mirror exists in `/mnt/shared/upstream_repos/fontc_crater_cache/`.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `7e1486a` (upstream legacy: .sfd in repo root). Added an override `config.yaml` in `ofl/nats/` that references the compatible sources only (`NATS.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/noticiatext/config.yaml
+++ b/ofl/noticiatext/config.yaml
@@ -1,0 +1,6 @@
+sources:
+  - source/NoticiaText-Regular.glyphs
+  - source/NoticiaText-Italic.glyphs
+  - source/NoticiaText-Bold.glyphs
+  - source/NoticiaText-BoldItalic.glyphs
+familyName: "Noticia Text"

--- a/ofl/noticiatext/upstream_info.md
+++ b/ofl/noticiatext/upstream_info.md
@@ -47,3 +47,9 @@ No `config.yaml` exists in `/mnt/shared/google/fonts/ofl/noticiatext/`. None is 
 - The FONTLOG describes an ambitious 18-style family vision (text, condensed, display, sans variants), but only the 4 text styles have been released.
 - The Glyphs source format (`.glyphs`) is the most practical entry point for any future maintenance work using modern tooling (`fontmake` + `gftools`).
 - A `config.yaml` could be authored to enable a `fontmake`-based build pipeline from the `.glyphs` sources, but this would require QA comparison against the manually hinted existing binaries.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.glyphs) and legacy `.sfd`/`.vfb` archives at the pinned commit `bcc80c5` (upstream legacy: .vfb archives in extras/vfb/). Added an override `config.yaml` in `ofl/noticiatext/` that references the compatible sources only (`source/NoticiaText-Regular.glyphs`, `source/NoticiaText-Italic.glyphs`, `source/NoticiaText-Bold.glyphs`, `source/NoticiaText-BoldItalic.glyphs`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/ntr/config.yaml
+++ b/ofl/ntr/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - NTR.ufo
+familyName: NTR

--- a/ofl/ntr/upstream_info.md
+++ b/ofl/ntr/upstream_info.md
@@ -45,3 +45,9 @@ No `config.yaml` is present in the google/fonts directory for this family, and n
 - The repo has been dormant since November 2014. There is no evidence of more recent upstream activity.
 - Font version in the binary is 1.0.5 (ttfautohint v1.2.25).
 - No cached clone found in `/mnt/shared/upstream_repos/fontc_crater_cache/`.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `1268910` (upstream legacy: .sfd in repo root). Added an override `config.yaml` in `ofl/ntr/` that references the compatible sources only (`NTR.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/nuosusil/config.yaml
+++ b/ofl/nuosusil/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - source/NuosuSIL.designspace
+familyName: "Nuosu SIL"

--- a/ofl/nuosusil/upstream_info.md
+++ b/ofl/nuosusil/upstream_info.md
@@ -53,3 +53,9 @@ No `config.yaml` is present or referenced. The `METADATA.pb` does not have a `co
 ## Commit Added (HIGH confidence)
 
 Commit `1e9b50a3cb69f6ae01c8ca5da1af2d03a85c517f` was determined by **tag_match**. Matched a version tag in the upstream repo whose date is on or before the binary modification date in google/fonts (2023-06-22). This is the most reliable method.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.designspace) and legacy `.sfd`/`.vfb` archives at the pinned commit `1e9b50a` (upstream legacy: .vfb in source/archive/). Added an override `config.yaml` in `ofl/nuosusil/` that references the compatible sources only (`source/NuosuSIL.designspace`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/palanquin/config.yaml
+++ b/ofl/palanquin/config.yaml
@@ -1,0 +1,9 @@
+sources:
+  - Palanquin/SourceFiles/UFOs/Palanquin_Th.ufo
+  - Palanquin/SourceFiles/UFOs/Palanquin_ExLt.ufo
+  - "Palanquin/SourceFiles/UFOs/Palanquin Light.ufo"
+  - "Palanquin/SourceFiles/UFOs/Palanquin Regular.ufo"
+  - "Palanquin/SourceFiles/UFOs/Palanquin Medium.ufo"
+  - "Palanquin/SourceFiles/UFOs/Palanquin SemiBold.ufo"
+  - "Palanquin/SourceFiles/UFOs/Palanquin Bold.ufo"
+familyName: Palanquin

--- a/ofl/palanquin/upstream_info.md
+++ b/ofl/palanquin/upstream_info.md
@@ -30,3 +30,9 @@ The latest commit in the upstream repository was retrieved:
 ## METADATA.pb Changes
 
 A `source` block was added to METADATA.pb with the repository URL and latest commit hash.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `f912925` (upstream legacy: .vfb in Palanquin/SourceFiles/VFBs/). Added an override `config.yaml` in `ofl/palanquin/` that references the compatible sources only (`Palanquin/SourceFiles/UFOs/Palanquin_Th.ufo`, `Palanquin/SourceFiles/UFOs/Palanquin_ExLt.ufo`, `Palanquin/SourceFiles/UFOs/Palanquin Light.ufo`, `Palanquin/SourceFiles/UFOs/Palanquin Regular.ufo`, `Palanquin/SourceFiles/UFOs/Palanquin Medium.ufo`, `Palanquin/SourceFiles/UFOs/Palanquin SemiBold.ufo`, `Palanquin/SourceFiles/UFOs/Palanquin Bold.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/palanquindark/config.yaml
+++ b/ofl/palanquindark/config.yaml
@@ -1,0 +1,6 @@
+sources:
+  - "PalanquinDark/SourceFiles/UFOs/PalanquinDark Reg.ufo"
+  - "PalanquinDark/SourceFiles/UFOs/PalanquinDark Med.ufo"
+  - "PalanquinDark/SourceFiles/UFOs/PalanquinDark SBld.ufo"
+  - "PalanquinDark/SourceFiles/UFOs/PalanquinDark Bld.ufo"
+familyName: "Palanquin Dark"

--- a/ofl/palanquindark/upstream_info.md
+++ b/ofl/palanquindark/upstream_info.md
@@ -28,3 +28,9 @@ The latest commit in the upstream repository was retrieved:
 ## METADATA.pb Changes
 
 A `source` block was added to METADATA.pb with the repository URL and latest commit hash.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `f912925` (upstream legacy: .vfb in PalanquinDark/SourceFiles/VFBs/). Added an override `config.yaml` in `ofl/palanquindark/` that references the compatible sources only (`PalanquinDark/SourceFiles/UFOs/PalanquinDark Reg.ufo`, `PalanquinDark/SourceFiles/UFOs/PalanquinDark Med.ufo`, `PalanquinDark/SourceFiles/UFOs/PalanquinDark SBld.ufo`, `PalanquinDark/SourceFiles/UFOs/PalanquinDark Bld.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/pattaya/config.yaml
+++ b/ofl/pattaya/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - source/Pattaya.glyphs
+familyName: Pattaya

--- a/ofl/pattaya/upstream_info.md
+++ b/ofl/pattaya/upstream_info.md
@@ -30,3 +30,9 @@ The latest commit in the upstream repository was retrieved:
 ## METADATA.pb Changes
 
 A `source` block was added to METADATA.pb with the repository URL and latest commit hash.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.glyphs and .ufo (selected .glyphs)) and legacy `.sfd`/`.vfb` archives at the pinned commit `fec6c7a` (upstream legacy: .vfb alongside .glyphs). Added an override `config.yaml` in `ofl/pattaya/` that references the compatible sources only (`source/Pattaya.glyphs`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/pridi/config.yaml
+++ b/ofl/pridi/config.yaml
@@ -1,0 +1,8 @@
+sources:
+  - source/Pridi-200.glyphs
+  - source/Pridi-300.glyphs
+  - source/Pridi-400.glyphs
+  - source/Pridi-500.glyphs
+  - source/Pridi-600.glyphs
+  - source/Pridi-700.glyphs
+familyName: Pridi

--- a/ofl/pridi/upstream_info.md
+++ b/ofl/pridi/upstream_info.md
@@ -26,3 +26,9 @@ The repository contains UFO source files along with TTF/OTF outputs.
 ## Verdict
 
 **Canonical upstream repo found.** `https://github.com/cadsondemak/pridi` is the designer-owned repository. METADATA.pb was updated with `repository_url` and `commit` fields.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.glyphs and .ufo (selected .glyphs)) and legacy `.sfd`/`.vfb` archives at the pinned commit `fe54fb6` (upstream legacy: .vfb alongside each weight). Added an override `config.yaml` in `ofl/pridi/` that references the compatible sources only (`source/Pridi-200.glyphs`, `source/Pridi-300.glyphs`, `source/Pridi-400.glyphs`, `source/Pridi-500.glyphs`, `source/Pridi-600.glyphs`, `source/Pridi-700.glyphs`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/rajdhani/config.yaml
+++ b/ofl/rajdhani/config.yaml
@@ -1,0 +1,7 @@
+sources:
+  - styles/Light/font.ufo
+  - styles/Regular/font.ufo
+  - styles/Medium/font.ufo
+  - styles/SemiBold/font.ufo
+  - styles/Bold/font.ufo
+familyName: Rajdhani

--- a/ofl/rajdhani/upstream_info.md
+++ b/ofl/rajdhani/upstream_info.md
@@ -25,3 +25,9 @@ A canonical upstream source repository was found and a source block was added to
 - Designer: Indian Type Foundry
 - The repository contains both UFO and VFB (FontLab) files for the masters
 - The `itfoundry` GitHub account is the official Indian Type Foundry organization account
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `86cae0e` (upstream legacy: .vfb masters in masters/). Added an override `config.yaml` in `ofl/rajdhani/` that references the compatible sources only (`styles/Light/font.ufo`, `styles/Regular/font.ufo`, `styles/Medium/font.ufo`, `styles/SemiBold/font.ufo`, `styles/Bold/font.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/ramabhadra/config.yaml
+++ b/ofl/ramabhadra/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - Ramabhadra.ufo
+familyName: Ramabhadra

--- a/ofl/ramabhadra/upstream_info.md
+++ b/ofl/ramabhadra/upstream_info.md
@@ -25,3 +25,9 @@ A source repository was found and a source block was added to METADATA.pb.
 - The GitHub repository is maintained by `appajid` (Appaji Ambarisha Darbha), who maintains many Telugu fonts under the Silicon Andhra umbrella — this is consistent with the organization copyright
 - The repository description states "Updating TTF SFD Copyright and version", indicating active maintenance
 - The repo contains a UFO source file, making it suitable as an upstream source
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `0957942` (upstream legacy: .sfd in repo root). Added an override `config.yaml` in `ofl/ramabhadra/` that references the compatible sources only (`Ramabhadra.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/ramaraja/config.yaml
+++ b/ofl/ramaraja/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - Ramaraja-Regular.ufo
+familyName: Ramaraja

--- a/ofl/ramaraja/upstream_info.md
+++ b/ofl/ramaraja/upstream_info.md
@@ -26,3 +26,9 @@ A canonical upstream source repository was found and a source block was added to
 - The repository description states "updating copyright and latin characters", indicating active maintenance
 - The copyright in METADATA.pb references Silicon Andhra (fonts.siliconandhra.org) and Sebastian Kosch (Crimson font), as Ramaraja was based on the Crimson design extended to support Telugu
 - The appajid account maintains many Telugu font repositories under the Silicon Andhra umbrella
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `fc98f3e` (upstream legacy: .sfd in repo root). Added an override `config.yaml` in `ofl/ramaraja/` that references the compatible sources only (`Ramaraja-Regular.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/rationale/config.yaml
+++ b/ofl/rationale/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - sources/Rationale.glyphs
+familyName: Rationale

--- a/ofl/rationale/upstream_info.md
+++ b/ofl/rationale/upstream_info.md
@@ -18,3 +18,9 @@ The canonical upstream repository at `cyrealtype/Rationale` was located by searc
 ## Notes
 
 The repository also contains VFB files (legacy FontLab format), but the primary source is `Rationale.glyphs`. The copyright statement in METADATA.pb references `www.cyreal.org`, consistent with the `cyrealtype` GitHub organization.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.glyphs) and legacy `.sfd`/`.vfb` archives at the pinned commit `b12941d` (upstream legacy: .vfb alongside .glyphs (Rationale.vfb, Rationale-OTF.vfb, Rationale-TTF.vfb)). Added an override `config.yaml` in `ofl/rationale/` that references the compatible sources only (`sources/Rationale.glyphs`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/rozhaone/config.yaml
+++ b/ofl/rozhaone/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - styles/Regular/font.ufo
+familyName: "Rozha One"

--- a/ofl/rozhaone/upstream_info.md
+++ b/ofl/rozhaone/upstream_info.md
@@ -18,3 +18,9 @@ The canonical upstream repository at `itfoundry/rozhaone` was located by searchi
 ## Notes
 
 The designer is the Indian Type Foundry (`info@indiantypefoundry.com`), consistent with the copyright statement in METADATA.pb. A secondary fork exists at `web1o1/rozhaone`, but the `itfoundry` repository is the canonical upstream. The repository has not been updated since 2014. The build system uses custom Python scripts (`build.py`, `reference.py`) rather than a standard `config.yaml`.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `8225a64` (upstream legacy: .vfb master in masters/). Added an override `config.yaml` in `ofl/rozhaone/` that references the compatible sources only (`styles/Regular/font.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/sacramento/config.yaml
+++ b/ofl/sacramento/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - sources/Sacramento.glyphs
+familyName: Sacramento

--- a/ofl/sacramento/upstream_info.md
+++ b/ofl/sacramento/upstream_info.md
@@ -32,3 +32,9 @@ The repository was located by searching GitHub for `sacramento font astigmatic`.
 ## Result
 
 A source block was added to METADATA.pb referencing the repository URL, the latest commit hash, and the `sources/Sacramento.glyphs` file.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.glyphs) and legacy `.sfd`/`.vfb` archives at the pinned commit `86d34cf` (upstream legacy: .vfb in old/version-1.000/). Added an override `config.yaml` in `ofl/sacramento/` that references the compatible sources only (`sources/Sacramento.glyphs`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/sarpanch/config.yaml
+++ b/ofl/sarpanch/config.yaml
@@ -1,0 +1,8 @@
+sources:
+  - styles/Regular/font.ufo
+  - styles/Medium/font.ufo
+  - styles/SemiBold/font.ufo
+  - styles/Bold/font.ufo
+  - styles/ExtraBold/font.ufo
+  - styles/Black/font.ufo
+familyName: Sarpanch

--- a/ofl/sarpanch/upstream_info.md
+++ b/ofl/sarpanch/upstream_info.md
@@ -35,3 +35,9 @@ The repository was found by searching GitHub for `Sarpanch devanagari font`, whi
 ## Result
 
 A source block was added to METADATA.pb referencing the repository URL, the latest commit hash, and the primary UFO master source.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `265ec8e` (upstream legacy: .vfb masters in masters/). Added an override `config.yaml` in `ofl/sarpanch/` that references the compatible sources only (`styles/Regular/font.ufo`, `styles/Medium/font.ufo`, `styles/SemiBold/font.ufo`, `styles/Bold/font.ufo`, `styles/ExtraBold/font.ufo`, `styles/Black/font.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/sharetech/config.yaml
+++ b/ofl/sharetech/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - sources/ShareTech.glyphs
+familyName: "Share Tech"

--- a/ofl/sharetech/upstream_info.md
+++ b/ofl/sharetech/upstream_info.md
@@ -25,3 +25,9 @@ The repository also included fonts directory, METADATA.pb, OFL.txt, and README.
 ## Confidence
 
 High. The repository was described explicitly as "by Ralph Oliver du Carrois" (the principal designer at Carrois Apostrophe) and contained Glyphs source files for Share Tech. Note: no separate upstream repository was found for Share Tech Mono; this repository appears to cover only Share Tech Regular.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.glyphs) and legacy `.sfd`/`.vfb` archives at the pinned commit `2c50109` (upstream legacy: .sfd/.vfb archives in old/version-1.002/src/). Added an override `config.yaml` in `ofl/sharetech/` that references the compatible sources only (`sources/ShareTech.glyphs`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/sirinstencil/config.yaml
+++ b/ofl/sirinstencil/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - "sources/Sirin Stencil.glyphs"
+familyName: "Sirin Stencil"

--- a/ofl/sirinstencil/upstream_info.md
+++ b/ofl/sirinstencil/upstream_info.md
@@ -37,3 +37,9 @@ Source block was added pointing to `cyrealtype/Sirin-Stencil` at commit `803ade3
 ## Confidence
 
 High — The repository is owned by the Cyreal type foundry, contains Glyphs source files, and matches the font metadata.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.glyphs) and legacy `.sfd`/`.vfb` archives at the pinned commit `803ade3` (upstream legacy: .vfb archives in sources/old/version1.002/). Added an override `config.yaml` in `ofl/sirinstencil/` that references the compatible sources only (`sources/Sirin Stencil.glyphs`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/slabo13px/config.yaml
+++ b/ofl/slabo13px/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - "UFOs/Slabo 13px b004.ufo"
+familyName: "Slabo 13px"

--- a/ofl/slabo13px/upstream_info.md
+++ b/ofl/slabo13px/upstream_info.md
@@ -38,3 +38,9 @@ Source block was added pointing to `TiroTypeworks/Slabo` at commit `21420697b49e
 ## Confidence
 
 High — The repository is owned by Tiro Typeworks (the font's creator), contains UFO source files for both the 13px and 27px variants, and matches the font metadata.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `2142069` (upstream legacy: .vfb masters in FontLab Sources/). Added an override `config.yaml` in `ofl/slabo13px/` that references the compatible sources only (`UFOs/Slabo 13px b004.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/slabo27px/config.yaml
+++ b/ofl/slabo27px/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - "UFOs/Slabo 27px b002.ufo"
+familyName: "Slabo 27px"

--- a/ofl/slabo27px/upstream_info.md
+++ b/ofl/slabo27px/upstream_info.md
@@ -35,3 +35,9 @@ Source block was added pointing to `TiroTypeworks/Slabo` at commit `21420697b49e
 ## Confidence
 
 High — The repository is owned by Tiro Typeworks (the font's creator), contains UFO source files for the 27px variant, and matches the font metadata.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `2142069` (upstream legacy: .vfb masters in FontLab Sources/). Added an override `config.yaml` in `ofl/slabo27px/` that references the compatible sources only (`UFOs/Slabo 27px b002.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/sniglet/config.yaml
+++ b/ofl/sniglet/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - source/Sniglet_Regular.ufo
+familyName: Sniglet

--- a/ofl/sniglet/upstream_info.md
+++ b/ofl/sniglet/upstream_info.md
@@ -40,3 +40,9 @@ Source block was added pointing to `theleagueof/sniglet` at commit `5c6b0860bdd0
 ## Confidence
 
 Medium — The repository is maintained by The League of Moveable Type (the canonical host for Haley Fiege's fonts) and contains UFO sources for the Regular weight, but the ExtraBold weight source is absent.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `5c6b086` (upstream legacy: .vfb in source/ (upstream ships Regular UFO only; ExtraBold has no source at this commit)). Added an override `config.yaml` in `ofl/sniglet/` that references the compatible sources only (`source/Sniglet_Regular.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/sreekrushnadevaraya/config.yaml
+++ b/ofl/sreekrushnadevaraya/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - SreeKrushnadevaraya.ufo
+familyName: "Sree Krushnadevaraya"

--- a/ofl/sreekrushnadevaraya/upstream_info.md
+++ b/ofl/sreekrushnadevaraya/upstream_info.md
@@ -39,3 +39,9 @@ after the Telugu king Krishnadevaraya. The project was led by Appaji Ambarisha
 Darbha. The Latin portion of the font was derived from Cantata One, designed
 by Joana Correia da Silva for Sorkin Type Co. The repository was maintained by
 `appajid` (Appaji Ambarisha Darbha) on GitHub.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `1d8aea8` (upstream legacy: .sfd in repo root). Added an override `config.yaml` in `ofl/sreekrushnadevaraya/` that references the compatible sources only (`SreeKrushnadevaraya.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/suranna/config.yaml
+++ b/ofl/suranna/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - Suranna.ufo
+familyName: Suranna

--- a/ofl/suranna/upstream_info.md
+++ b/ofl/suranna/upstream_info.md
@@ -31,3 +31,9 @@ The repository root contained:
 ## Action Taken
 
 A `source` block was added to `METADATA.pb` pointing to `https://github.com/appajid/suranna` at commit `ce1c1f150ba50e59fd9d95c114c40545c4e8fe04`.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `ce1c1f1` (upstream legacy: .sfd in repo root). Added an override `config.yaml` in `ofl/suranna/` that references the compatible sources only (`Suranna.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/suravaram/config.yaml
+++ b/ofl/suravaram/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - Suravaram.ufo
+familyName: Suravaram

--- a/ofl/suravaram/upstream_info.md
+++ b/ofl/suravaram/upstream_info.md
@@ -31,3 +31,9 @@ The repository root contained:
 ## Action Taken
 
 A `source` block was added to `METADATA.pb` pointing to `https://github.com/appajid/suravaram` at commit `c8d4e86f6a287199182d1ce6c97450307388dc23`.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `c8d4e86` (upstream legacy: .sfd in repo root). Added an override `config.yaml` in `ofl/suravaram/` that references the compatible sources only (`Suravaram.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/tenaliramakrishna/config.yaml
+++ b/ofl/tenaliramakrishna/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - TenaliRamakrishna-Regular.ufo
+familyName: "Tenali Ramakrishna"

--- a/ofl/tenaliramakrishna/upstream_info.md
+++ b/ofl/tenaliramakrishna/upstream_info.md
@@ -26,3 +26,9 @@ The repository root contained:
 ## Confidence
 
 High — the repository was directly referenced in the family's description page and owned by the credited designer.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `444587c` (upstream legacy: .sfd in repo root). Added an override `config.yaml` in `ofl/tenaliramakrishna/` that references the compatible sources only (`TenaliRamakrishna-Regular.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/timmana/config.yaml
+++ b/ofl/timmana/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - TimmanaRegular.ufo
+familyName: Timmana

--- a/ofl/timmana/upstream_info.md
+++ b/ofl/timmana/upstream_info.md
@@ -32,3 +32,9 @@ Source block was added to `METADATA.pb` pointing to the above repository and com
 ### Notes
 
 A secondary repository at `davelab6/timmana` was also found, but it contained only TTX (compiled XML) files and a bakery.yaml, with no editable source files. It was therefore skipped in favor of the canonical upstream.
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `6ed6823` (upstream legacy: .vfb in repo root). Added an override `config.yaml` in `ofl/timmana/` that references the compatible sources only (`TimmanaRegular.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/vampiroone/config.yaml
+++ b/ofl/vampiroone/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - Vampiro.ufo
+familyName: "Vampiro One"

--- a/ofl/vampiroone/upstream_info.md
+++ b/ofl/vampiroone/upstream_info.md
@@ -28,3 +28,9 @@ The copyright string `"Copyright (c) 2012, Sorkin Type Co (www.sorkintype.com eb
 **Commit**: ec42cf12230a8663c3ccb7a0c2da590ba98d2cd9
 **Status**: UFO source present
 **Confidence**: High
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.ufo) and legacy `.sfd`/`.vfb` archives at the pinned commit `ec42cf1` (upstream legacy: .vfb in repo root and .sfd/.vfb archives in src/). Added an override `config.yaml` in `ofl/vampiroone/` that references the compatible sources only (`Vampiro.ufo`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.

--- a/ofl/vt323/config.yaml
+++ b/ofl/vt323/config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - sources/VT323.glyphs
+familyName: VT323

--- a/ofl/vt323/upstream_info.md
+++ b/ofl/vt323/upstream_info.md
@@ -27,3 +27,9 @@ The copyright string `"Copyright 2011, The VT323 Project Authors (peter.hull@oik
 **Commit**: 9bd4b3f69887fd960d51d07602db60a28a789145
 **Status**: Glyphs source present
 **Confidence**: High
+
+## Update (2026-04-24) — Override config.yaml
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Upstream has both compatible sources (.glyphs) and legacy `.sfd`/`.vfb` archives at the pinned commit `9bd4b3f` (upstream legacy: .sfd/.vfb archives in old/). Added an override `config.yaml` in `ofl/vt323/` that references the compatible sources only (`sources/VT323.glyphs`). The legacy archives are retained upstream for historical reference but are not consumed by gftools-builder. `google-fonts-sources` auto-detects the override on the next regeneration of crater's `targets.json`.


### PR DESCRIPTION
These are families that have in their upstream sources repos both legacy sources formats (such as `.vfb` and `.sfd`) as well as modern ones (such as `.glyphs` and `.ufo`) that are gftools-builder compatible.