### PR TITLE
Sync `upstream_info.md` and source-block metadata of most recent upstream/main commits (since 2025-08-01)

### DIFF
--- a/ofl/adamina/upstream_info.md
+++ b/ofl/adamina/upstream_info.md
@@ -67,9 +67,18 @@ buildVariable: false
 
 This override config enables gftools-builder to compile the font from upstream sources.
 
+## Recent upstream/main activity (post-investigation)
+
+- **2026-04-08** — Simon Cozens, commit [`2eb54483f`](https://github.com/google/fonts/commit/2eb54483f) ("Use a full URL"): added the `https://` prefix to `repository_url` in METADATA.pb (`github.com/cyrealtype/Adamina` → `https://github.com/cyrealtype/Adamina`). This resolves Open Question #1 below.
+
+The source block at HEAD therefore reads:
+- `repository_url`: `https://github.com/cyrealtype/Adamina` (corrected 2026-04-08)
+- `commit`: `719bd2a68700963ef0870bc707c77bc2b915dc7a` (unchanged)
+- `config_yaml`: omitted (override `config.yaml` lives in `ofl/adamina/`)
+
 ## Open Questions
 
-1. The METADATA.pb `repository_url` field is missing the `https://` prefix -- should this be fixed?
+1. ~~The METADATA.pb `repository_url` field is missing the `https://` prefix -- should this be fixed?~~ **Resolved 2026-04-08** by Simon Cozens (commit `2eb54483f`).
 2. Where are the actual sources for v1.013 that was added in PR #744? Were they generated from a different state of the repo that was later force-pushed?
 3. Should an override `config.yaml` be created in `ofl/adamina/` for gftools-builder compatibility, using `sources/Adamina.glyphs` as the source?
 4. Should a `commit` field be added to the METADATA.pb source block?

--- a/ofl/alansans/upstream_info.md
+++ b/ofl/alansans/upstream_info.md
@@ -51,3 +51,7 @@ Alan Sans has a complete source block in METADATA.pb with all required fields: r
 ## Recent upstream/main activity (post-investigation)
 
 - **2025-11-07** — Emma Marichal, commit [`53fe69aed`](https://github.com/google/fonts/commit/53fe69aed) ("Alan Sans - Update minisite_url to remove trailing slash"): trimmed the trailing slash from `minisite_url` (`https://typeface.alan.com/` → `https://typeface.alan.com`). Edit is outside the `source { ... }` block; no source-block impact.
+
+### Earlier (2025-10-29)
+
+- **2025-10-29** — Emma Marichal, commit [`75433c35c`](https://github.com/google/fonts/commit/75433c35c) ("update metadata.pb with new minisite"): added `minisite_url: "https://typeface.alan.com/"`. The trailing slash was trimmed by the later `53fe69aed` commit (2025-11-07) noted above.

--- a/ofl/alansans/upstream_info.md
+++ b/ofl/alansans/upstream_info.md
@@ -47,3 +47,7 @@ There is no local override `config.yaml` in the google/fonts family directory.
 Alan Sans has a complete source block in METADATA.pb with all required fields: repository URL, commit hash, branch, and config_yaml path. The data was established during original onboarding by Emma Marichal (PR #9796, merged Sep 2025), with the config_yaml field added later during batch enrichment (Feb 2026). The repository URL is valid, the commit hash was recorded by gftools-packager, and the upstream repo contains a proper gftools-builder config.yaml. The upstream repo has received updates since onboarding (Jan 2026 commit), but the referenced commit correctly reflects the version used for the initial catalog addition.
 
 **Confidence**: HIGH
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-11-07** — Emma Marichal, commit [`53fe69aed`](https://github.com/google/fonts/commit/53fe69aed) ("Alan Sans - Update minisite_url to remove trailing slash"): trimmed the trailing slash from `minisite_url` (`https://typeface.alan.com/` → `https://typeface.alan.com`). Edit is outside the `source { ... }` block; no source-block impact.

--- a/ofl/allkin/upstream_info.md
+++ b/ofl/allkin/upstream_info.md
@@ -44,19 +44,24 @@ Found `sources/config.yaml` in upstream repository at the recorded commit hash.
 
 ## Recent upstream/main activity (post-investigation)
 
-Several commits between 2026-02-11 and 2026-02-20 made non-source-block edits to METADATA.pb. None of them touch the `source { ... }` block, so the `repository_url`, `commit`, `config_yaml`, and `branch` fields are unchanged from the original investigation.
+Several commits between 2026-02-09 and 2026-02-20 made non-source-block edits to METADATA.pb. None of them touch the `source { ... }` block, so the `repository_url`, `commit`, `config_yaml`, and `branch` fields are unchanged from the original investigation.
 
 ### 2026-02-20: minisite URL corrections
 
 - **2026-02-20** — Emma Marichal, commit [`0a62c3fdd`](https://github.com/google/fonts/commit/0a62c3fdd) ("Update minisite URL in METADATA.pb"): replaced `https://typetrends.monotype.com/fr/peace-conflict` with `https://www.monotype.com/type-trends/peace-conflict/` (host migration from `typetrends.monotype.com` to `www.monotype.com`).
 - **2026-02-20** — Emma Marichal, commit [`dbc81e3cf`](https://github.com/google/fonts/commit/dbc81e3cf) ("Fix minisite URL in METADATA.pb — Updated minisite URL to remove trailing slash"): trimmed the trailing slash, leaving `https://www.monotype.com/type-trends/peace-conflict`.
 
-### 2026-02-11: sample-text padding adjustments
+### 2026-02-11: category change + sample-text padding adjustments
 
-Three Emma Marichal commits on 2026-02-11 tweaked the whitespace-padded `styles` and `tester` sample-text fields (used by the Google Fonts catalog UI for sentence-length reference strings). None of these changes affect glyphs or the source block:
+Four Emma Marichal commits on 2026-02-11 worked on family classification and sample-text padding. None affect glyphs or the source block:
 
-- **2026-02-11** — commit [`dfaa39fce`](https://github.com/google/fonts/commit/dfaa39fce) ("Update styles and tester fields in METADATA.pb"): widened both `styles` and `tester` blank lengths.
+- **2026-02-11** — commit [`ddd69eee5`](https://github.com/google/fonts/commit/ddd69eee5) ("Change font category and classifications to DISPLAY"): re-categorised the family — `category: "SANS_SERIF"` → `category: "DISPLAY"`, and `classifications: "SYMBOLS"` → `classifications: "DISPLAY"`.
+- **2026-02-11** — commit [`dfaa39fce`](https://github.com/google/fonts/commit/dfaa39fce) ("Update styles and tester fields in METADATA.pb"): widened both `styles` and `tester` blank lengths (sample-text reference strings used by the Google Fonts catalog UI).
 - **2026-02-11** — commit [`3c9cd4f9e`](https://github.com/google/fonts/commit/3c9cd4f9e) ("Update styles and tester fields in METADATA.pb"): re-balanced the lengths between `styles` and `tester`.
 - **2026-02-11** — commit [`8f6e3f9df`](https://github.com/google/fonts/commit/8f6e3f9df) ("Update tester field in METADATA.pb"): shortened the `tester` blank length.
 
-These three commits all landed within minutes of each other (PR-iteration tweaks). The final state of the fields after the third commit is what HEAD reflects today.
+The three padding commits all landed within minutes of each other (PR-iteration tweaks). The final state of the fields after the last commit is what HEAD reflects today.
+
+### 2026-02-09: tester field formatting
+
+- **2026-02-09** — Emma Marichal, commit [`f6d35fe21`](https://github.com/google/fonts/commit/f6d35fe21) ("Fix tester field formatting in METADATA.pb"): corrected the formatting of the `tester` field (likely a quoting/whitespace fix in the protobuf text representation).

--- a/ofl/allkin/upstream_info.md
+++ b/ofl/allkin/upstream_info.md
@@ -44,9 +44,19 @@ Found `sources/config.yaml` in upstream repository at the recorded commit hash.
 
 ## Recent upstream/main activity (post-investigation)
 
-Two commits on 2026-02-20 updated the family's `minisite_url` (outside the `source { ... }` block; no source-provenance impact):
+Several commits between 2026-02-11 and 2026-02-20 made non-source-block edits to METADATA.pb. None of them touch the `source { ... }` block, so the `repository_url`, `commit`, `config_yaml`, and `branch` fields are unchanged from the original investigation.
+
+### 2026-02-20: minisite URL corrections
 
 - **2026-02-20** — Emma Marichal, commit [`0a62c3fdd`](https://github.com/google/fonts/commit/0a62c3fdd) ("Update minisite URL in METADATA.pb"): replaced `https://typetrends.monotype.com/fr/peace-conflict` with `https://www.monotype.com/type-trends/peace-conflict/` (host migration from `typetrends.monotype.com` to `www.monotype.com`).
 - **2026-02-20** — Emma Marichal, commit [`dbc81e3cf`](https://github.com/google/fonts/commit/dbc81e3cf) ("Fix minisite URL in METADATA.pb — Updated minisite URL to remove trailing slash"): trimmed the trailing slash, leaving `https://www.monotype.com/type-trends/peace-conflict`.
 
-Both edits are outside the `source { ... }` block and do not affect the recorded source provenance. The `repository_url`, `commit`, `config_yaml`, and `branch` fields are unchanged from the original investigation.
+### 2026-02-11: sample-text padding adjustments
+
+Three Emma Marichal commits on 2026-02-11 tweaked the whitespace-padded `styles` and `tester` sample-text fields (used by the Google Fonts catalog UI for sentence-length reference strings). None of these changes affect glyphs or the source block:
+
+- **2026-02-11** — commit [`dfaa39fce`](https://github.com/google/fonts/commit/dfaa39fce) ("Update styles and tester fields in METADATA.pb"): widened both `styles` and `tester` blank lengths.
+- **2026-02-11** — commit [`3c9cd4f9e`](https://github.com/google/fonts/commit/3c9cd4f9e) ("Update styles and tester fields in METADATA.pb"): re-balanced the lengths between `styles` and `tester`.
+- **2026-02-11** — commit [`8f6e3f9df`](https://github.com/google/fonts/commit/8f6e3f9df) ("Update tester field in METADATA.pb"): shortened the `tester` blank length.
+
+These three commits all landed within minutes of each other (PR-iteration tweaks). The final state of the fields after the third commit is what HEAD reflects today.

--- a/ofl/allkin/upstream_info.md
+++ b/ofl/allkin/upstream_info.md
@@ -65,3 +65,11 @@ The three padding commits all landed within minutes of each other (PR-iteration 
 ### 2026-02-09: tester field formatting
 
 - **2026-02-09** — Emma Marichal, commit [`f6d35fe21`](https://github.com/google/fonts/commit/f6d35fe21) ("Fix tester field formatting in METADATA.pb"): corrected the formatting of the `tester` field (likely a quoting/whitespace fix in the protobuf text representation).
+
+### 2026-01-29/30: original Allkin onboarding + immediate post-onboarding edits
+
+- **2026-01-29** — Emma Marichal, commit [`b031b3c2e`](https://github.com/google/fonts/commit/b031b3c2e) ("Allkin: Version 1.010 added"): the original onboarding via gftools-packager. Created `ofl/allkin/` with `Allkin-Regular.ttf`, METADATA.pb (with the source block recording the upstream commit), OFL.txt, and supporting files.
+- **2026-01-30** — Emma Marichal, commit [`466bb0818`](https://github.com/google/fonts/commit/466bb0818) ("add custom strings to metadata"): added 36 lines of custom sample-text strings to METADATA.pb (the `styles` and `tester` fields tweaked subsequently in February).
+- **2026-01-30** — Emma Marichal, commit [`22d1cd3f3`](https://github.com/google/fonts/commit/22d1cd3f3) ("update unicodes"): adjusted 26 lines of the Unicode-coverage advertised in METADATA.pb (`subsets` / `language` blocks). No font-binary changes.
+
+All three are within scope of the post-onboarding metadata bedding-in. The `source { ... }` block was created by the v1.010 commit and has not been modified by any of these or the later edits documented above.

--- a/ofl/allkin/upstream_info.md
+++ b/ofl/allkin/upstream_info.md
@@ -41,3 +41,12 @@ Found `sources/config.yaml` in upstream repository at the recorded commit hash.
 ## Confidence
 
 **High**: URL pre-existing in METADATA.pb; commit pre-existing in METADATA.pb
+
+## Recent upstream/main activity (post-investigation)
+
+Two commits on 2026-02-20 updated the family's `minisite_url` (outside the `source { ... }` block; no source-provenance impact):
+
+- **2026-02-20** — Emma Marichal, commit [`0a62c3fdd`](https://github.com/google/fonts/commit/0a62c3fdd) ("Update minisite URL in METADATA.pb"): replaced `https://typetrends.monotype.com/fr/peace-conflict` with `https://www.monotype.com/type-trends/peace-conflict/` (host migration from `typetrends.monotype.com` to `www.monotype.com`).
+- **2026-02-20** — Emma Marichal, commit [`dbc81e3cf`](https://github.com/google/fonts/commit/dbc81e3cf) ("Fix minisite URL in METADATA.pb — Updated minisite URL to remove trailing slash"): trimmed the trailing slash, leaving `https://www.monotype.com/type-trends/peace-conflict`.
+
+Both edits are outside the `source { ... }` block and do not affect the recorded source provenance. The `repository_url`, `commit`, `config_yaml`, and `branch` fields are unchanged from the original investigation.

--- a/ofl/amarna/upstream_info.md
+++ b/ofl/amarna/upstream_info.md
@@ -47,3 +47,7 @@ Found `sources/config.yaml` in upstream repository at the recorded commit hash.
 ## Confidence
 
 **High**: URL pre-existing in METADATA.pb; commit pre-existing in METADATA.pb
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-02-12** — Emma Marichal, commit [`27cd544b8`](https://github.com/google/fonts/commit/27cd544b8) ("Correct designer name spelling in METADATA.pb"): corrected the `designer` field from `"Ishtar van Looy"` to `"Ishtār van Looy"` (added macron diacritic over the first `a`, matching the designer's preferred spelling). The change is outside the `source { ... }` block and does not affect the recorded source provenance.

--- a/ofl/anton/upstream_info.md
+++ b/ofl/anton/upstream_info.md
@@ -13,7 +13,7 @@
 | Repository URL | https://github.com/googlefonts/AntonFont |
 | Commit | `beb92fcad87808357123bb66881b4032dc96efe7` |
 | Config YAML | `sources/config.yaml` |
-| Branch | `master` |
+| Branch | `main` (corrected 2026-04-08; was `master`) |
 
 ## Methodology
 
@@ -47,3 +47,7 @@ Found `sources/config.yaml` in upstream repository at the recorded commit hash.
 ## Confidence
 
 **High**: URL pre-existing in METADATA.pb; commit pre-existing in METADATA.pb
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-04-08** — Simon Cozens, commit [`441751497`](https://github.com/google/fonts/commit/441751497) ("Correct main<->master"): corrected the `branch` field in METADATA.pb from `master` to `main`. Verified against upstream `googlefonts/AntonFont` (HEAD = `refs/heads/main` in the repo archive at `/home/fsanches/compartilhado/upstream_repos/repo_archive/googlefonts/AntonFont.git`). The Source Data table above now reflects `Branch: main`.

--- a/ofl/arapey/upstream_info.md
+++ b/ofl/arapey/upstream_info.md
@@ -49,3 +49,7 @@ Override `config.yaml` exists in `ofl/arapey/config.yaml`.
 ## Confidence
 
 **High**: URL pre-existing in METADATA.pb; commit pre-existing in METADATA.pb
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-04-10** — Dave Crossland, commit [`cf9e83c23`](https://github.com/google/fonts/commit/cf9e83c23) ("ofl/arapey/METADATA.pb Add minisite URL"): added `minisite_url: "https://etunni.github.io/Arapey-Minisite"` to METADATA.pb. This is outside the `source { ... }` block and does not affect the recorded source provenance — purely a display-side metadata addition.

--- a/ofl/balsamiqsans/upstream_info.md
+++ b/ofl/balsamiqsans/upstream_info.md
@@ -10,7 +10,8 @@
 | Repository URL | https://github.com/balsamiq/balsamiqsans |
 | Commit Hash | b1dca64c3ceeaa3c274f69fae5a6f508b9a4dcc4 |
 | Config YAML | sources/config.yaml |
-| Status | needs_correction |
+| Branch | `master` (corrected 2026-04-08; was `main`) |
+| Status | complete |
 | Confidence | HIGH |
 
 ## Source Data (METADATA.pb)
@@ -109,4 +110,9 @@ Repository is cached at `upstream_repos/fontc_crater_cache/balsamiq/balsamiqsans
 
 The `repository_url` and `config_yaml` fields are correct. The `commit` field must be corrected from `009740f8b2c3915b1553182ec406aaddb1a12dc7` (a 2024-12-17 commit, added erroneously by the fontc_crater batch import) to `b1dca64c3ceeaa3c274f69fae5a6f508b9a4dcc4` (the v1.020 release tag, 2023-04-20), which matches the `archive_url` version and predates the google/fonts onboarding.
 
-Action needed: Fix `commit` in `ofl/balsamiqsans/METADATA.pb`.
+~~Action needed: Fix `commit` in `ofl/balsamiqsans/METADATA.pb`.~~ **Done 2026-02-27** by Felipe Sanches in commit `f31a1ea94` ("Balsamiq Sans: fix source block in METADATA.pb"). Status is now `complete`.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-02-27** — Felipe Sanches, commit [`f31a1ea94`](https://github.com/google/fonts/commit/f31a1ea94) ("Balsamiq Sans: fix source block in METADATA.pb"): replaced the incorrect commit hash `009740f8b2c3915b1553182ec406aaddb1a12dc7` (2024-12-17, post-onboarding) with the correct v1.020 release tag `b1dca64c3ceeaa3c274f69fae5a6f508b9a4dcc4` (2023-04-20). This resolved the "Action needed" item in the original conclusion.
+- **2026-04-08** — Simon Cozens, commit [`441751497`](https://github.com/google/fonts/commit/441751497) ("Correct main<->master"): corrected the `branch` field in METADATA.pb from `main` to `master`. Verified against upstream `balsamiq/balsamiqsans` (HEAD = `refs/heads/master` in the repo archive). The Source Data table above now reflects `Branch: master`.

--- a/ofl/benne/upstream_info.md
+++ b/ofl/benne/upstream_info.md
@@ -61,3 +61,7 @@ These later commits were made by Simon Cozens to set up gftools-builder infrastr
 - The font binary at commit `0e13f2e` (rebuilt by Simon Cozens) should be verified to match the font currently served in google/fonts
 - The original onboarding commit `4a7cc7e` (Version 1.001, Feb 2021) is the historically correct reference for what was originally pushed to google/fonts
 - Benne supports Kannada script (`primary_script: "Knda"`) - this is a specialized script that may need specific QA
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-04-08** — Simon Cozens, commit [`441751497`](https://github.com/google/fonts/commit/441751497) ("Correct main<->master"): corrected the `branch` field in METADATA.pb from `master` to `main`. The upstream `googlefonts/Benne` repo's default branch was renamed from `master` to `main` after the original investigation; verified `HEAD = refs/heads/main` in the repo archive at `/home/fsanches/compartilhado/upstream_repos/repo_archive/googlefonts/Benne.git`. Note: the recorded commit `0e13f2e4e66eb5ed0076224b113398b78109748d` is still HEAD of the new `main` branch — the rename did not change content, only the ref name.

--- a/ofl/betaniapatmos/upstream_info.md
+++ b/ofl/betaniapatmos/upstream_info.md
@@ -47,3 +47,12 @@ Verification via GitHub API confirms the commit exists and is dated 2026-01-15T1
 
 1. The METADATA.pb source block is missing the `config_yaml` field. Should `config_yaml: "sources/config.yaml"` be added to the METADATA.pb, or should an override config be placed in the google/fonts family directory?
 2. There is a fifth variant "BetaniaPatmosInGDL" in the upstream repo's fonts/ttf directory that does not appear to have been onboarded to Google Fonts.
+
+## Recent upstream/main activity (post-investigation)
+
+The Betania Patmos family was onboarded to google/fonts in January 2026 as part of a 5-variant set (Patmos, In, GDL, In GDL, GuideLine) sharing the same upstream `huertatipografica/betania-patmos` at commit `08c83ac9540b0b2bf86ddf6b632651142f31a93c`.
+
+- **2026-01-15** — Emma Marichal, commit [`9adc7b48d`](https://github.com/google/fonts/commit/9adc7b48d) ("Betania Patmos: Version 11.002; ttfautohint (v1.8.4.16-eb64) added"): initial onboarding via gftools-packager. Created METADATA.pb (with the source block recording the upstream commit), OFL.txt, and the binary.
+- **2026-01-15** — Emma Marichal, commit [`f6499b220`](https://github.com/google/fonts/commit/f6499b220) ("Update copyright URL in OFL.txt"): same-day OFL.txt fix to correct the copyright URL.
+
+Both edits are within the source block's intent — the source block was created in the first commit and reflects the recorded upstream commit. No corrections needed.

--- a/ofl/betaniapatmosgdl/upstream_info.md
+++ b/ofl/betaniapatmosgdl/upstream_info.md
@@ -46,3 +46,10 @@ This is the same commit hash used for all Betania Patmos variants. The commit is
 
 1. The METADATA.pb source block is missing the `config_yaml` field. Should it be added?
 2. The display_name "Betania Patmos Guideline" clarifies the GDL abbreviation but may cause confusion with the separate "Betania Patmos Guide Line" family.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-01-23** — Emma Marichal, commit [`c26502dc7`](https://github.com/google/fonts/commit/c26502dc7) ("Betania Patmos GDL: Version 11.002; ttfautohint (v1.8.4.16-eb64) added"): initial onboarding via gftools-packager. Created METADATA.pb with source block referencing `huertatipografica/betania-patmos@08c83ac9` (shared with the Betania Patmos sibling families).
+- **2026-01-23** — Emma Marichal, commit [`a852e6e57`](https://github.com/google/fonts/commit/a852e6e57) ("update OFL"): same-day OFL.txt update.
+
+Source block reflects the recorded upstream commit; no corrections needed.

--- a/ofl/betaniapatmosguideline/upstream_info.md
+++ b/ofl/betaniapatmosguideline/upstream_info.md
@@ -46,3 +46,10 @@ This is the same commit hash used for all Betania Patmos variants. The commit is
 
 1. The METADATA.pb source block is missing the `config_yaml` field. Should it be added?
 2. The category is listed as DISPLAY in METADATA.pb but classifications say SYMBOLS - this font appears to contain guide lines/ruled lines for handwriting practice rather than letterforms.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-01-23** — Emma Marichal, commit [`02c6401c0`](https://github.com/google/fonts/commit/02c6401c0) ("Betania Patmos GuideLine: Version 11.002; ttfautohint (v1.8.4.16-eb64) added"): initial onboarding via gftools-packager. Created METADATA.pb with source block referencing `huertatipografica/betania-patmos@08c83ac9` (shared with the Betania Patmos sibling families).
+- **2026-01-23** — Emma Marichal, commit [`3ea62eb9c`](https://github.com/google/fonts/commit/3ea62eb9c) ("article + ofl"): same-day addition of the article and OFL.txt updates.
+
+Source block reflects the recorded upstream commit; no corrections needed.

--- a/ofl/betaniapatmosin/upstream_info.md
+++ b/ofl/betaniapatmosin/upstream_info.md
@@ -46,3 +46,10 @@ This is the same commit hash used for all Betania Patmos variants. The commit is
 
 1. The METADATA.pb source block is missing the `config_yaml` field. Should it be added?
 2. There is also a "BetaniaPatmosInGDL" variant in the upstream repo that was not onboarded to Google Fonts. It may be a companion "guideline" version of "Betania Patmos In", similar to how "Betania Patmos GDL" is the guideline version of "Betania Patmos".
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-01-23** — Emma Marichal, commit [`caf0f148c`](https://github.com/google/fonts/commit/caf0f148c) ("Betania Patmos In: Version 11.002; ttfautohint (v1.8.4.16-eb64) added"): initial onboarding via gftools-packager. Created METADATA.pb with source block referencing `huertatipografica/betania-patmos@08c83ac9` (shared with the Betania Patmos sibling families).
+- **2026-01-23** — Emma Marichal, commit [`8fffe23cc`](https://github.com/google/fonts/commit/8fffe23cc) ("update OFL"): same-day OFL.txt update.
+
+Source block reflects the recorded upstream commit; no corrections needed.

--- a/ofl/betaniapatmosingdl/upstream_info.md
+++ b/ofl/betaniapatmosingdl/upstream_info.md
@@ -58,3 +58,10 @@ Note: The METADATA.pb uses `files{}` blocks to copy pre-built TTFs directly from
 
 - The upstream repo is not yet cloned to the local cache. Should it be cloned?
 - The `config_yaml` field in METADATA.pb is pending in a PR branch; once merged, this family will be fully documented.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-01-23** — Emma Marichal, commit [`e7a906896`](https://github.com/google/fonts/commit/e7a906896) ("Betania Patmos In GDL: Version 11.002; ttfautohint (v1.8.4.16-eb64) added"): initial onboarding via gftools-packager. Created METADATA.pb with source block referencing `huertatipografica/betania-patmos@08c83ac9` (shared with the Betania Patmos sibling families).
+- **2026-01-23** — Emma Marichal, commit [`f8611f864`](https://github.com/google/fonts/commit/f8611f864) ("OFL"): same-day OFL.txt update.
+
+Source block reflects the recorded upstream commit; no corrections needed.

--- a/ofl/bitcountgriddoubleink/upstream_info.md
+++ b/ofl/bitcountgriddoubleink/upstream_info.md
@@ -114,3 +114,7 @@ The font was onboarded using **pre-built binaries** from the upstream repository
 | **Confidence** | HIGH |
 
 All metadata is correct. The repository URL, commit hash, and file mappings are verified. The override config.yaml is properly set up for building from sources. No changes needed to METADATA.pb.
+
+### Earlier (2025-09-05)
+
+- **2025-09-05** — Emma Marichal, commit [`b38b486fc`](https://github.com/google/fonts/commit/b38b486fc) ("update article"): same-day post-onboarding article update following the v1.001 onboarding (already covered by the existing investigation). Outside the `source { ... }` block.

--- a/ofl/bitcountgridsingleink/upstream_info.md
+++ b/ofl/bitcountgridsingleink/upstream_info.md
@@ -116,3 +116,8 @@ The source metadata for Bitcount Grid Single Ink is complete and accurate:
 - This family is part of the larger Bitcount project by Petr van Blokland, which produces many variants (Bitcount, Bitcount Grid Single, Bitcount Grid Single Ink, Bitcount Grid Double, Bitcount Prop Single, etc.) from a shared template designspace.
 - The upstream repo has a `sources/config.yaml` but it only sets `familyName: Bitcount` and does not cover the other Bitcount variants. The override config in google/fonts addresses this gap for this specific variant.
 - The font was added to Google Fonts on 2025-01-10 (per `date_added` in METADATA.pb) and updated to Version 1.001 on 2025-09-05.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-09-05** — Emma Marichal, commit [`3f08adabc`](https://github.com/google/fonts/commit/3f08adabc) ("Bitcount Grid Single Ink: Version 1.001 added"): initial v1.001 onboarding via gftools-packager. Source block references `petrvanblokland/TYPETR-Bitcount@89e7994f73b7f5ced80e7cf493d40be9e66ff82f` (shared with the Bitcount sibling families).
+- **2025-09-05** — Emma Marichal, commit [`f869115df`](https://github.com/google/fonts/commit/f869115df) ("OFL link"): same-day OFL.txt URL fix. License-file change tracked here per policy.

--- a/ofl/bitcountpropdoubleink/upstream_info.md
+++ b/ofl/bitcountpropdoubleink/upstream_info.md
@@ -53,3 +53,8 @@ Per policy, since an override `config.yaml` exists in the google/fonts directory
 ## Conclusion
 
 The METADATA.pb source block is complete. The commit `89e7994f73b7f5ced80e7cf493d40be9e66ff82f` is confirmed as the onboarding commit. An override `config.yaml` is present in the google/fonts family directory. No action needed.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-09-05** — Emma Marichal, commit [`beed7dadc`](https://github.com/google/fonts/commit/beed7dadc) ("Bitcount Prop Double Ink: Version 1.001 added"): initial v1.001 onboarding via gftools-packager. Source block references `petrvanblokland/TYPETR-Bitcount@89e7994f73b7f5ced80e7cf493d40be9e66ff82f` (shared with the Bitcount sibling families).
+- **2025-09-05** — Emma Marichal, commit [`a223b37be`](https://github.com/google/fonts/commit/a223b37be) ("update OFL link"): same-day OFL.txt URL fix.

--- a/ofl/bitcountpropsingleink/upstream_info.md
+++ b/ofl/bitcountpropsingleink/upstream_info.md
@@ -51,3 +51,7 @@ The fix would be either:
 ## Conclusion
 
 The commit hash is correct. However, `config_yaml: "sources/config.yaml"` points to an inadequate upstream config that only sets `familyName: Bitcount`. This family needs correction: a proper override `config.yaml` should be added to the google/fonts directory, and the `config_yaml` field should be removed from METADATA.pb to match the pattern used by all other Bitcount Ink families.
+
+### Earlier (2025-09-11)
+
+- **2025-09-11** — Emma Marichal, additional follow-up commit (see git log for details): minor follow-up work in the family directory after the v1.001 onboarding.

--- a/ofl/bitcountpropsingleink/upstream_info.md
+++ b/ofl/bitcountpropsingleink/upstream_info.md
@@ -54,4 +54,4 @@ The commit hash is correct. However, `config_yaml: "sources/config.yaml"` points
 
 ### Earlier (2025-09-11)
 
-- **2025-09-11** — Emma Marichal, additional follow-up commit (see git log for details): minor follow-up work in the family directory after the v1.001 onboarding.
+- **2025-09-11** — Emma Marichal, commit [`981e34fbe`](https://github.com/google/fonts/commit/981e34fbe) ("complete article with colr font"): same-day work following the v1.001 onboarding — added 312 lines to `article/ARTICLE.en_us.html`, with a binary update (file size unchanged at 513192 bytes — internal name-table refresh).

--- a/ofl/bitcountsingleink/upstream_info.md
+++ b/ofl/bitcountsingleink/upstream_info.md
@@ -53,3 +53,7 @@ The fix would be to:
 ## Conclusion
 
 The commit hash is correct. However, `config_yaml: "sources/config.yaml"` points to an inadequate upstream config that only sets `familyName: Bitcount`. This family needs correction: a proper override `config.yaml` should be added to the google/fonts directory, and the `config_yaml` field should be removed from METADATA.pb, matching the pattern used by the other Bitcount Ink families.
+
+### Earlier (2025-09-11)
+
+- **2025-09-11** — Emma Marichal, additional follow-up commit (see git log for details): minor follow-up work in the family directory after the v1.001 onboarding.

--- a/ofl/bitcountsingleink/upstream_info.md
+++ b/ofl/bitcountsingleink/upstream_info.md
@@ -56,4 +56,4 @@ The commit hash is correct. However, `config_yaml: "sources/config.yaml"` points
 
 ### Earlier (2025-09-11)
 
-- **2025-09-11** — Emma Marichal, additional follow-up commit (see git log for details): minor follow-up work in the family directory after the v1.001 onboarding.
+- **2025-09-11** — Emma Marichal, commit [`711bcf6c1`](https://github.com/google/fonts/commit/711bcf6c1) ("bump version"): same-day binary update following the v1.001 onboarding (binary-only, file size unchanged at 430912 bytes — internal version-string bump).

--- a/ofl/bjcree/upstream_info.md
+++ b/ofl/bjcree/upstream_info.md
@@ -1,0 +1,81 @@
+# BJCree
+
+**Status**: `complete`
+**Date**: 2026-04-27
+**Designer**: SIL International (Bill Jancewicz, Peter Martin, Sharon Correll)
+**License**: OFL
+**METADATA.pb**: `ofl/bjcree/METADATA.pb`
+**Model**: Claude Opus 4.7 (1M context)
+
+## Data
+
+| Field | Value |
+|-------|-------|
+| Repository URL | https://github.com/silnrsi/font-bjcree |
+| Commit | `7476fb691e64eff8956faf2bd68911cb3e1c65b7` |
+| Config YAML | (none — see Build Pipeline) |
+| Branch | `main` |
+| Archive URL | https://github.com/silnrsi/font-bjcree/releases/download/v7.000/BJCree-7.000.zip |
+| Release tag | `v7.000` (2026-02-11) |
+
+## Methodology
+
+### Repository URL
+Pre-existing in METADATA.pb `source { repository_url }` field. Verified canonical: `silnrsi` is the SIL Non-Roman Script Initiative GitHub org, and BJCree is an SIL-published typeface. WebFetch of `https://github.com/silnrsi/font-bjcree` confirms the repository is active with default branch `main`, latest release `v7.000`. No newer fork or canonical alternative was found.
+
+### Commit Hash
+Pre-existing in METADATA.pb `source { commit }` field. Mirrored upstream into the repo archive at `/home/fsanches/compartilhado/upstream_repos/repo_archive/silnrsi/font-bjcree.git` and verified:
+- Commit `7476fb691e64eff8956faf2bd68911cb3e1c65b7` exists, currently HEAD of `main`.
+- Author: LornaSIL <lorna_evans@sil.org>, 2026-03-11.
+- Message: "Update makedocs to create temporary productsite directory."
+- Tag `v7.000` points to an earlier commit (`5f901e4`, "Commit rebuilt documentation"), but the `references/` ttf binaries match across both — `7476fb691` is a docs-tooling commit on top.
+
+### Binary verification
+MD5 of `ofl/bjcree/BJCree-Regular.ttf` matches `references/BJCree-Regular.ttf` blob at the recorded commit (both `8bc789625a659af13ad20b11f47a632c`). All four shipped TTFs report `head.fontRevision = 7.0` and name table `Version 7.000`, consistent with the v7.000 release.
+
+### Config YAML
+No `config.yaml` (gftools-builder format) exists in the upstream repo. The repo uses SIL's own build pipeline (`smith` / `wscript`, `makedocs`, `preflight`). Sources are present (`source/BJCree.designspace`, `source/masters/BJCree-{Regular,Bold}.ufo/`), so a gftools-builder override is feasible but not currently provided. No override `config.yaml` in `ofl/bjcree/` either.
+
+## Evidence
+
+### METADATA.pb source block (current)
+- `repository_url`: `https://github.com/silnrsi/font-bjcree`
+- `commit`: `7476fb691e64eff8956faf2bd68911cb3e1c65b7`
+- `archive_url`: `https://github.com/silnrsi/font-bjcree/releases/download/v7.000/BJCree-7.000.zip`
+- `branch`: `main`
+- `config_yaml`: (not set)
+
+### google/fonts history
+- Onboarding commit: `c9a51e82b` — "BJCree: Version 7.000 added" (Emma Marichal, 2026-03-26). Commit body explicitly cites `silnrsi/font-bjcree` at `7476fb691...`.
+- Subsequent commits (article, primary_script, category fix, name normalization) — see "Recent upstream activity" below.
+
+### Upstream repo archive
+- Mirrored at `silnrsi/font-bjcree.git` (added 2026-04-27 by this investigation).
+- Commit `7476fb691...` verified.
+- v7.000 release tag verified.
+
+## Initial state
+- METADATA.pb already had a complete source block (URL, commit, branch, archive_url, files list) added at onboarding.
+- No `upstream_info.md` existed.
+
+## Actions taken
+- Mirrored `silnrsi/font-bjcree` into the permanent repo archive.
+- Verified commit `7476fb691` exists and produces the binaries currently shipped (MD5 match via `references/BJCree-Regular.ttf`).
+- Confirmed font version 7.000 matches release tag.
+- Confirmed no upstream `config.yaml`; documented SIL's smith-based build pipeline.
+- Authored this `upstream_info.md`.
+
+## Final state
+- METADATA.pb source block is correct and verified — no changes required.
+- No override `config.yaml` added; upstream uses SIL's smith pipeline (not gftools-builder).
+- Repo is mirrored in the archive for long-term provenance.
+
+## Recent upstream activity (post-onboarding, in google/fonts)
+- `c9a51e82b` (Emma Marichal, 2026-03-26): BJCree: Version 7.000 added — initial onboarding from `silnrsi/font-bjcree@7476fb691`.
+- `ed93d1d12` (Emma Marichal): added `article/ARTICLE.en_us.html`.
+- `023c5eec4` (Emma Marichal): added `primary_script: "Cans"`.
+- `b977700ca` (Emma Marichal, 2026-03-27): "BJCree: Change font category from SANS_SERIF to SERIF" — corrected category. The Latin glyphs in v7.000 are based on URW++ C059 (New Century Schoolbook), so SERIF is the correct classification per the FONTLOG.
+- `e1ecf218b` (Emma Marichal, 2026-04-16): "Rename 'BJ Cree' to 'BJCree' in METADATA.pb" — display-name normalization to match the upstream font family name (`name` ID 1 = `BJCree`).
+
+## Confidence
+**High**: Repository URL canonical (silnrsi org); commit hash verified against upstream mirror; binaries confirmed identical (MD5) to upstream `references/`; font version (`7.000`) matches release tag.

--- a/ofl/bpmfhuninn/upstream_info.md
+++ b/ofl/bpmfhuninn/upstream_info.md
@@ -62,3 +62,12 @@ This is fundamentally different from gftools-builder and cannot be represented w
 2. **Should the repository_url point to aaronbell/bpmfvs or ButTaiwan/bpmfvs?** The PR says it will transition to ButTaiwan, but that hasn't happened yet.
 3. **Will this project ever have a config.yaml?** Given the custom Ruby-based build system, this seems unlikely without a complete rewrite of the build process.
 4. The `upstream_sources.json` in the repo reveals that the Huninn base font comes from `github.com/justfont/Huninn`, adding a dependency chain.
+
+## Recent upstream/main activity (post-investigation)
+
+Two commits on 2026-02-11 made cosmetic corrections to `OFL.txt` (license file). License-file changes are tracked here per the policy that license updates are substantive:
+
+- **2026-02-11** — Emma Marichal, commit [`36aa986e0`](https://github.com/google/fonts/commit/36aa986e0) ("Fix copyright and license URLs in OFL.txt"): three changes — removed a trailing period from the copyright line (`bpmfvs).` → `bpmfvs)`); replaced the legacy SIL OFL link `https://scripts.sil.org/OFL` with the modern `https://openfontlicense.org/`; whitespace tidy.
+- **2026-02-11** — Emma Marichal, commit [`118107fd5`](https://github.com/google/fonts/commit/118107fd5) ("Fix URL formatting in OFL.txt"): trimmed the trailing slash from the OFL homepage URL (`https://openfontlicense.org/` → `https://openfontlicense.org`).
+
+Both edits are confined to `OFL.txt` and do not affect the `source { ... }` block. The `repository_url`, `commit`, and (absent) `config_yaml` fields are unchanged. The same OFL fix pattern was applied across all three Bpmf families (Huninn, Iansui, Zihi Kai Std) — see the corresponding `upstream_info.md` files for the sibling families.

--- a/ofl/bpmfiansui/upstream_info.md
+++ b/ofl/bpmfiansui/upstream_info.md
@@ -56,3 +56,12 @@ Same situation as all Bpmf families - the project uses a custom Ruby-based build
 1. **Which exact commit in aaronbell/bpmfvs was used to build the current font binary?** Aaron Bell should be asked.
 2. **Should the repository_url be updated to aaronbell/bpmfvs?** Or should we wait for the planned transition back to ButTaiwan/bpmfvs?
 3. The base font (Iansui) comes from `github.com/ButTaiwan/iansui`, adding a dependency chain. Changes to the base font require rebuilding the Bpmf variant.
+
+## Recent upstream/main activity (post-investigation)
+
+The Bpmf Iansui family was onboarded in a multi-commit sequence by Aaron Bell (2026-01-30). The earlier investigation already documents some of these commits in the Onboarding timeline; for completeness, two additional shared-with-siblings commits are recorded here:
+
+- **2026-01-30** — Aaron Bell, commit [`423e25002`](https://github.com/google/fonts/commit/423e25002) ("Onboarding three families related to the Bopomofo phonetic system"): the umbrella onboarding commit that introduced all three Bpmf families (Huninn, Iansui, Zihi Kai Std) at once.
+- **2026-01-30** — Aaron Bell, commit [`cc204af75`](https://github.com/google/fonts/commit/cc204af75) ("One at a time is the way to go..."): incremental retry that re-onboarded Iansui and Zihi Kai Std after the umbrella commit's binary issues.
+
+Both are part of the original onboarding sequence. The recorded `commit` and `repository_url` fields in METADATA.pb were populated by the gftools-packager-style onboarding and remain the same as flagged in the original investigation (still pointing to ButTaiwan/bpmfvs while the actual binaries were built in aaronbell/bpmfvs).

--- a/ofl/bpmfzihikaistd/upstream_info.md
+++ b/ofl/bpmfzihikaistd/upstream_info.md
@@ -60,3 +60,13 @@ Same situation as all Bpmf families - custom Ruby-based build system (`make_font
 2. **Where does the ZihiKaiStd base font come from?** Unlike Huninn (from justfont) and Iansui (from ButTaiwan/iansui), the Zihi Kai Std source font is not documented in `upstream_sources.json`.
 3. **Will the transition from aaronbell/bpmfvs to ButTaiwan/bpmfvs happen?** Until it does, the recorded commit hash will remain inaccurate.
 4. This family had the most updates of the three Bpmf families, suggesting it required more iteration to get right.
+
+## Recent upstream/main activity (post-investigation)
+
+The Bpmf Zihi Kai Std family was onboarded in a multi-commit sequence by Aaron Bell (2026-01-30) with the most binary updates of the three Bpmf families. The earlier investigation already documents some commits in the Onboarding timeline; for completeness, three additional shared-with-siblings commits are recorded here:
+
+- **2026-01-30** — Aaron Bell, commit [`423e25002`](https://github.com/google/fonts/commit/423e25002) ("Onboarding three families related to the Bopomofo phonetic system"): the umbrella onboarding commit that introduced all three Bpmf families (Huninn, Iansui, Zihi Kai Std) at once.
+- **2026-01-30** — Aaron Bell, commit [`cc204af75`](https://github.com/google/fonts/commit/cc204af75) ("One at a time is the way to go..."): incremental retry that re-onboarded Iansui and Zihi Kai Std after the umbrella commit's binary issues.
+- **2026-01-30** — Aaron Bell, commit [`d6f37786b`](https://github.com/google/fonts/commit/d6f37786b) ("Updating strings"): same-day binary update touching both Bpmf Huninn and Bpmf Zihi Kai Std (binary-only commit per the diff).
+
+All three are part of the original onboarding sequence. The recorded `commit` and `repository_url` fields in METADATA.pb still point to ButTaiwan/bpmfvs while the actual binaries were built in aaronbell/bpmfvs (the commit-hash provenance issue flagged in the original investigation remains open).

--- a/ofl/capriola/upstream_info.md
+++ b/ofl/capriola/upstream_info.md
@@ -74,3 +74,8 @@ No override config.yaml exists in the google/fonts family directory.
 ## Open Questions
 
 None. This family is fully documented and verified.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-10-23** — Emma Marichal, commit [`ba3bc8eee`](https://github.com/google/fonts/commit/ba3bc8eee) ("Capriola: Version 1.007 added"): version bump to v1.007 with a static→variable migration. The file changed from `Capriola-Regular.ttf` (static) to `Capriola[wght].ttf` (variable). Copyright string updated from the legacy "Sorkin Type Co" form to "Copyright 2025 The Capriola Project Authors (https://github.com/SorkinType/Capriola-VF)". The repository URL inside the copyright now references `Capriola-VF`, indicating the upstream is a VF-rebuild fork.
+- **2025-10-23** — Emma Marichal, commit [`af795803f`](https://github.com/google/fonts/commit/af795803f) ("Add config_yaml path to METADATA.pb"): same-day follow-up adding `config_yaml: "Capriola-VF/sources/config.yaml"` to the source block. The path includes the `Capriola-VF/` prefix because the upstream repo is the SorkinType/Capriola-VF fork that ships the VF sources.

--- a/ofl/cause/upstream_info.md
+++ b/ofl/cause/upstream_info.md
@@ -60,3 +60,8 @@ The `config_yaml` field is set to `sources/config.yaml` in the METADATA.pb sourc
 ## Open Questions
 
 None. This is a fully complete entry.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-12-05** — Emma Marichal, commit [`0b585e1cc`](https://github.com/google/fonts/commit/0b585e1cc) ("Cause: Version 1.000 added"): initial onboarding via gftools-packager. Created `ofl/cause/` with the binary `Cause[wght].ttf`, OFL.txt, and METADATA.pb (source block populated).
+- **2025-12-05** — Marianna Paszkowska, commit [`e0861a160`](https://github.com/google/fonts/commit/e0861a160) ("fontspector fixes: update copyright string, delete description"): same-day fontspector-driven cleanup. Updated the binary's name-table copyright string and removed `DESCRIPTION.en_us.html`. The binary size remained the same (110700 bytes) but the bytes changed. Outside the source block scope per se, though it does mean the shipping binary is not byte-identical to the original v1.000 upstream commit referenced in the source block.

--- a/ofl/chirongoroundtc/upstream_info.md
+++ b/ofl/chirongoroundtc/upstream_info.md
@@ -90,3 +90,7 @@ No override config.yaml exists in the google/fonts family directory.
   - Batch update `4fd9e239` proposes `803fb2f` + `scripts/config.yaml` (correct)
   - PR #9596 commit `0c8d6246` proposes `e7501a7` (workflow-only commit, less accurate)
 - These pending changes need to be merged to complete the METADATA.pb source block.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-09-25** — tamcy, commit [`7ee51a1b7`](https://github.com/google/fonts/commit/7ee51a1b7) ("Add `primary_language` field to Chiron GoRound TC, Chiron Hei HK and Chiron Sung HK"): added `primary_language: "yue_Hant"` (Cantonese in Traditional Chinese script) to METADATA.pb. The same commit touches all three Chiron HK/TC sibling families. Outside the `source { ... }` block.

--- a/ofl/chironheihk/upstream_info.md
+++ b/ofl/chironheihk/upstream_info.md
@@ -100,3 +100,7 @@ The `config_yaml: "scripts/config.yaml"` field is already set in the METADATA.pb
 
 - The commit `5d80c2c` (2025-05-13, "Adding GF-specific fonts") predates several font binary updates in google/fonts (v2.530 on 2025-06-25, rebuilds on 2025-06-26, NID13 on 2025-07-10). The font binaries currently in google/fonts may have been built from a later commit on the source branch. However, since this commit was explicitly agreed upon by the fontc_crater team, it serves as the canonical reference point.
 - The local cache at `upstream_repos/fontc_crater_cache/chiron-fonts/chiron-hei-hk` only has the `release` branch fetched; the `source` branch is not cached locally. This does not affect verification since the commit was confirmed via the GitHub API.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-09-25** — tamcy, commit [`7ee51a1b7`](https://github.com/google/fonts/commit/7ee51a1b7) ("Add `primary_language` field to Chiron GoRound TC, Chiron Hei HK and Chiron Sung HK"): added `primary_language: "yue_Hant"` (Cantonese in Traditional Chinese script) to METADATA.pb. The same commit touches all three Chiron HK/TC sibling families. Outside the `source { ... }` block.

--- a/ofl/chironsunghk/upstream_info.md
+++ b/ofl/chironsunghk/upstream_info.md
@@ -47,3 +47,7 @@ The config file `scripts/config.yaml` exists at commit `65b752caf7698f9e773991fd
 ## Open Questions
 
 None. The data is complete and verified.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-09-25** — tamcy, commit [`7ee51a1b7`](https://github.com/google/fonts/commit/7ee51a1b7) ("Add `primary_language` field to Chiron GoRound TC, Chiron Hei HK and Chiron Sung HK"): added `primary_language: "yue_Hant"` (Cantonese in Traditional Chinese script) to METADATA.pb. The same commit touches all three Chiron HK/TC sibling families. Outside the `source { ... }` block.

--- a/ofl/climatecrisis/upstream_info.md
+++ b/ofl/climatecrisis/upstream_info.md
@@ -65,3 +65,11 @@ The config also includes STAT table definitions and fvar instance overrides for 
 ## Open Questions
 
 None. The tracking data should be updated to reflect the latest commit hash `8e3882135dddeb43f582ae88f337589dbba625f4` which is now recorded in the current METADATA.pb in google/fonts.
+
+## Recent upstream/main activity (post-investigation)
+
+The original investigation already covered Emma Marichal's `9eabeac10` (2026-02-20, "Climate Crisis: Version 1.007 added"). One additional commit on the same day is now recorded here for completeness:
+
+- **2026-02-20** — Emma Marichal, commit [`66247cd5c`](https://github.com/google/fonts/commit/66247cd5c) ("body text (OFL)"): updated `OFL.txt` (license file) to match the upstream copy at the recorded commit `8e3882135`. License-file change tracked here per the policy that license updates are substantive.
+
+The shipping `ClimateCrisis[YEAR].ttf` (3601356 bytes, md5 `ff22433aab2cd1eba54062cbc231be2b`) is byte-identical to upstream `fonts/variable/ClimateCrisis[YEAR].ttf` at the recorded commit `8e3882135`. `head.fontRevision = 1.0070`, `name` ID 5 = "Version 1.007". No source-block changes are needed; the `commit` field is already correct.

--- a/ofl/cossettetexte/upstream_info.md
+++ b/ofl/cossettetexte/upstream_info.md
@@ -55,3 +55,8 @@ This is a valid gftools-builder configuration pointing to UFO sources.
 ## Open Questions
 
 None.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-08-01** — Emma Marichal, commit [`2378959f0`](https://github.com/google/fonts/commit/2378959f0) ("Update METADATA.pb"): metadata cleanup pre-cossette-repo-rename.
+- **2025-09-16** — Dave Crossland, commit [`e1d8333ee`](https://github.com/google/fonts/commit/e1d8333ee) ("Update Cossette repo and articles"): migrated `repository_url` from `https://github.com/cossette/cossette-fonts` to `https://github.com/googlefonts/cossette-fonts` (the source repo moved to the googlefonts org). Same commit affected the sibling `cossettetitre` family.

--- a/ofl/cossettetitre/upstream_info.md
+++ b/ofl/cossettetitre/upstream_info.md
@@ -55,3 +55,9 @@ This is a valid gftools-builder configuration pointing to UFO sources.
 ## Open Questions
 
 None.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-08-06** — Marc Foley, commit [`a5cda7bc1`](https://github.com/google/fonts/commit/a5cda7bc1) ("Cossette Titre: Version 1.001; ttfautohint (v1.8.4.7-5d5b) added"): initial v1.001 onboarding via gftools-packager from `m4rc1e/cossette-fonts@7a3a7d62f4eac78d1ac722d25def17c67d9bb445` (Marc's fork).
+- **2025-08-06** — Emma Marichal, commit [`ead3c04c6`](https://github.com/google/fonts/commit/ead3c04c6) ("Update METADATA.pb"): same-day metadata fix.
+- **2025-09-16** — Dave Crossland, commit [`e1d8333ee`](https://github.com/google/fonts/commit/e1d8333ee) ("Update Cossette repo and articles"): migrated `repository_url` from `cossette/cossette-fonts` to `googlefonts/cossette-fonts`. Same commit affected the sibling `cossettetexte` family.

--- a/ofl/coustard/METADATA.pb
+++ b/ofl/coustard/METADATA.pb
@@ -10,7 +10,7 @@ fonts {
   filename: "Coustard-Regular.ttf"
   post_script_name: "Coustard-Regular"
   full_name: "Coustard Regular"
-  copyright: "Copyright 2011 The Coustard Project Authors (https://github.com/googlefonts/bangers)"
+  copyright: "Copyright 2011 The Coustard Project Authors (https://github.com/googlefonts/coustardFont)"
 }
 fonts {
   name: "Coustard"
@@ -19,7 +19,7 @@ fonts {
   filename: "Coustard-Black.ttf"
   post_script_name: "Coustard-Black"
   full_name: "Coustard Black"
-  copyright: "Copyright 2011 The Coustard Project Authors (https://github.com/googlefonts/bangers)"
+  copyright: "Copyright 2011 The Coustard Project Authors (https://github.com/googlefonts/coustardFont)"
 }
 subsets: "latin"
 subsets: "latin-ext"

--- a/ofl/coustard/METADATA.pb
+++ b/ofl/coustard/METADATA.pb
@@ -40,4 +40,5 @@ source {
     dest_file: "OFL.txt"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/coustard/upstream_info.md
+++ b/ofl/coustard/upstream_info.md
@@ -88,6 +88,6 @@ The shipping `Coustard-Regular.ttf` (75432 bytes, md5 `1b81850f782640f19b5cc3244
 
 The original `vernnobile/coustardFont` repo (Vernon Adams's GitHub account, `5f54d232f` "migrate from code.google" 2013-03-01) is preserved as historical context above. It remains accessible online but is superseded by the `googlefonts/coustardFont` fork as the source-of-truth for current Coustard onboarding. Per policy, full details of the original repo are kept in this report.
 
-### Follow-up note
+### Follow-up note (resolved)
 
-The new copyright string in METADATA.pb (added by Emma's commit a0db74464) reads `"Copyright 2011 The Coustard Project Authors (https://github.com/googlefonts/bangers)"` — the URL `googlefonts/bangers` appears to be a typo (Bangers is a different family). The likely correct URL is `https://github.com/googlefonts/coustardFont`. This is outside the source-block sync scope but worth flagging for a future fix.
+The new copyright string in METADATA.pb added by Emma's commit `a0db74464` originally read `"Copyright 2011 The Coustard Project Authors (https://github.com/googlefonts/bangers)"` — the URL `googlefonts/bangers` was a copy-paste typo (Bangers is a different family). **Resolved in this branch** by cherry-picked commit `5e56b4565` ("Coustard: fix copyright URL typo (bangers -> coustardFont)"), which corrected both `fonts { ... copyright }` entries to reference `https://github.com/googlefonts/coustardFont`. The fix originated as a separate single-purpose branch (`fix-coustard-copyright-url`) before being folded into this audit branch.

--- a/ofl/coustard/upstream_info.md
+++ b/ofl/coustard/upstream_info.md
@@ -1,11 +1,21 @@
 # Coustard
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
+**Date investigated**: 2026-02-26 (initial); 2026-04-27 (post-migration update)
+**Status**: complete (was missing_config)
 **Designer**: Vernon Adams
 **METADATA.pb path**: `ofl/coustard/METADATA.pb`
+**Model**: Claude Opus 4.6 (initial) / Claude Opus 4.7 (1M context) (update)
 
-## Source Data
+## Source Data (current — post 2026-03-20 repo migration)
+
+| Field | Value |
+|-------|-------|
+| Repository URL | https://github.com/googlefonts/coustardFont (migrated; was vernnobile/coustardFont) |
+| Commit | `84d4ef2fbb8e87ba843d49308b98eeb4a874be91` (was `5f54d232ff52d0d43bad509357f03c5ddbdf51fc`) |
+| Config YAML | `sources/config.yaml` (added 2026-04-27 by this commit; upstream now ships a gftools-builder config) |
+| Branch | `master` |
+
+## Source Data (original — pre-migration, kept for historical reference)
 
 | Field | Value |
 |-------|-------|
@@ -52,3 +62,32 @@ SFD files are not compatible with gftools-builder, so a config.yaml cannot be cr
 
 1. The upstream repo sources (SFD) are from the original version, while google/fonts serves v1.001 from the 2017 hotfix. Where are the sources for the v1.001 hotfix? They may have been generated without updating the upstream repo.
 2. No config.yaml can be created from SFD sources without source conversion. This family will remain in `missing_config` status unless the sources are modernized.
+
+## Recent upstream/main activity (post-investigation)
+
+The original (2026-02-26) investigation flagged `missing_config` because the only known upstream `vernnobile/coustardFont` had SFD-only sources. Both issues raised in Open Questions have now been resolved by an upstream repo migration:
+
+- **2026-03-20** — Emma Marichal, commit [`a0db74464`](https://github.com/google/fonts/commit/a0db74464) ("Coustard: Version 1.100; ttfautohint (v1.8.4.16-eb64) added"): updated to v1.100 and migrated the recorded upstream from `vernnobile/coustardFont` to a new canonical fork at `googlefonts/coustardFont`. Emma developed the modernization upstream (PR #1 from `emmamarichal/master` was merged to `googlefonts/coustardFont` as commit `84d4ef2fb`); the new repo includes:
+  - Modern `.glyphs` source: `sources/Coustard.glyphs`
+  - gftools-builder `sources/config.yaml`
+  - Pre-built TTF/OTF/WOFF2 in `fonts/ttf/`, `fonts/otf/`, `fonts/webfonts/`
+  - Original SFD sources preserved under `sources/archives/`
+
+The shipping `Coustard-Regular.ttf` (75432 bytes, md5 `1b81850f782640f19b5cc3244e629ade`) is byte-identical to upstream `fonts/ttf/Coustard-Regular.ttf` at commit `84d4ef2fb`. `head.fontRevision = 1.1000`, `name` ID 5 = "Version 1.100; ttfautohint (v1.8.4.16-eb64)".
+
+### Updated source-of-truth fields
+
+- **Repository URL**: `https://github.com/googlefonts/coustardFont` (was `https://github.com/vernnobile/coustardFont`).
+- **Commit**: `84d4ef2fbb8e87ba843d49308b98eeb4a874be91` (the merge of upstream PR #1, 2026-03-20).
+- **Config YAML**: `sources/config.yaml` (added 2026-04-27 by this commit; the upstream config exists at the recorded commit and is fully functional).
+- **Branch**: `master`.
+- **Status**: **complete** (was missing_config).
+- **Confidence**: HIGH (md5-verified shipping binary).
+
+### Original Repository (dormant)
+
+The original `vernnobile/coustardFont` repo (Vernon Adams's GitHub account, `5f54d232f` "migrate from code.google" 2013-03-01) is preserved as historical context above. It remains accessible online but is superseded by the `googlefonts/coustardFont` fork as the source-of-truth for current Coustard onboarding. Per policy, full details of the original repo are kept in this report.
+
+### Follow-up note
+
+The new copyright string in METADATA.pb (added by Emma's commit a0db74464) reads `"Copyright 2011 The Coustard Project Authors (https://github.com/googlefonts/bangers)"` — the URL `googlefonts/bangers` appears to be a typo (Bangers is a different family). The likely correct URL is `https://github.com/googlefonts/coustardFont`. This is outside the source-block sync scope but worth flagging for a future fix.

--- a/ofl/ebgaramond/upstream_info.md
+++ b/ofl/ebgaramond/upstream_info.md
@@ -10,7 +10,7 @@
 | Field | Value |
 |-------|-------|
 | Repository URL | https://github.com/octaviopardo/EBGaramond12 |
-| Commit | `e608414f52e532b68e2182f96b4ce9db35335593` |
+| Commit | `106a4a6d377987459ae5e68673a4570f13b957fb` (updated 2026-03-27; was `e608414f52e532b68e2182f96b4ce9db35335593`) |
 | Config YAML | `sources/config.yaml` |
 | Branch | `master` |
 
@@ -84,3 +84,15 @@ None. The source block in METADATA.pb is complete and accurate:
 - Commit hash `e608414f` is the HEAD of master and correctly represents the state of sources used for the current fonts in google/fonts
 - Config YAML path `sources/config.yaml` exists at the referenced commit and is a valid gftools-builder configuration
 - The upstream repository is clean and up-to-date
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-03-27 (upstream)** — Octavio Pardo, upstream commit [`106a4a6d3`](https://github.com/octaviopardo/EBGaramond12/commit/106a4a6d3) ("Merge pull request #55 from dvoritdvorit/master — Update EB Garamond to include RCS Citation Glyphs"). The merge advanced master from `e608414f5` to `106a4a6d3` and produced new v1.002 binaries. The `f71dda451 Update copyright information in OFL.txt` commit on the `dvoritdvorit/master` PR branch is what motivated the OFL.txt sync below.
+- **2026-03-27** — Emma Marichal, commit [`7f444d171`](https://github.com/google/fonts/commit/7f444d171) ("EB Garamond: Version 1.001 added"): onboarded the upstream update via gftools-packager, advancing `commit` in METADATA.pb from `e608414f5` to `106a4a6d3`. Note the commit subject says "Version 1.001" but the binaries produced by upstream `106a4a6d3` are actually **`Version 1.002`** (`fontRevision = 1.0020`, `name` ID 5 = "Version 1.002") — the subject is a minor labeling inaccuracy by gftools-packager. The shipped `EBGaramond[wght].ttf` (851176 bytes, md5 `ea3b0fb24b4ca00602255b65710847a9`) is byte-identical to upstream `fonts/variable/EBGaramond[wght].ttf` at commit `106a4a6d3`.
+- **2026-03-27** — Emma Marichal, commit [`c337133ee`](https://github.com/google/fonts/commit/c337133ee) ("Revise copyright and license details in OFL.txt"): synced `OFL.txt` to match the updated copyright string from upstream commit `f71dda451`. License-file change tracked here per Felipe's policy that license updates are substantive.
+
+The Source Data table at the top of this document has been updated to reflect the new commit. The Timeline section preserves the original v1.001/v1.002 history; the new merge is listed in this Recent activity section.
+
+## Confidence (post-update)
+
+**High**: Md5 verification of the shipping `EBGaramond[wght].ttf` against upstream `106a4a6d3:fonts/variable/EBGaramond[wght].ttf` was byte-identical. The recorded source-block fields are all correct and current.

--- a/ofl/estedad/METADATA.pb
+++ b/ofl/estedad/METADATA.pb
@@ -34,6 +34,7 @@ source {
     dest_file: "Estedad[wght].ttf"
   }
   branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 primary_script: "Arab"
 stroke: "SANS_SERIF"

--- a/ofl/estedad/upstream_info.md
+++ b/ofl/estedad/upstream_info.md
@@ -1,0 +1,80 @@
+# Estedad
+
+**Status**: `complete`
+**Date**: 2026-04-27
+**Designer**: Amin Abedi, Fontamin
+**License**: OFL
+**METADATA.pb**: `ofl/estedad/METADATA.pb`
+**Model**: Claude Opus 4.7 (1M context)
+
+## Data
+
+| Field | Value |
+|-------|-------|
+| Repository URL | https://github.com/aminabedi68/Estedad |
+| Commit | `69e879f78a4a1c7c4594baf7da13ba1c9f65ffd3` |
+| Config YAML | `sources/config.yaml` |
+| Branch | `master` |
+
+## Methodology
+
+### Repository URL
+Pre-existing in METADATA.pb `source { repository_url }` field. Verified canonical: the upstream is owned by Amin Abedi (`aminabedi68`), whose GitHub email is `aminabedi68@gmail.com`. The font's `name` ID 9 (Designer) reads "Amin Abedi", confirming the repo owner is the actual designer. The studio "Fontamin" is listed as sole entry in `AUTHORS.txt` (`Fontamin <hifontamin@gmail.com>`). No third-party fork is more canonical; releases continue to be cut from this repo (latest: `Estedad-v8.5`, 2026-03-20).
+
+### Commit Hash
+Pre-existing in METADATA.pb `source { commit }` field. The onboarding commit message (`55ca157f7` "Estedad: Version 8.5 added") explicitly cites this hash. Verified upstream: it is the merge commit of PR #38 ("Add Estedad", from `emmamarichal/master`), authored 2026-03-31T23:48:19Z by Amin Abedi.
+
+### Config YAML
+Found `sources/config.yaml` in upstream repository at the recorded commit hash. Configuration uses `Estedad.glyphs` as source, `wght` axisOrder, with full STAT table covering 9 named instances Thin (100) through Black (900).
+
+## Evidence
+
+### METADATA.pb source block
+- `repository_url`: `https://github.com/aminabedi68/Estedad`
+- `commit`: `69e879f78a4a1c7c4594baf7da13ba1c9f65ffd3`
+- `branch`: `master`
+- `config_yaml`: `sources/config.yaml` (added 2026-04-27 by this commit)
+
+### Font binary verification
+The shipping binary `ofl/estedad/Estedad[wght].ttf` (328340 bytes, md5 `284743ae983adab00bdcc5148669cf27`) is **byte-identical** to `fonts/variable/Estedad[wght].ttf` at upstream commit `69e879f78`. Font metadata confirms the version:
+- `head.fontRevision`: `8.5`
+- `name` ID 5: `Version 8.5`
+- `name` ID 3: `8.5;amin;Estedad-Regular`
+- `name` ID 9 (Designer): `Amin Abedi`
+- `name` ID 0 (Copyright): `Copyright 2026 The Estedad Project Authors (https://github.com/aminabedi68/Estedad)`
+
+### Upstream commit metadata
+- Author: Amin Abedi `<aminabedi68@gmail.com>`
+- Date: 2026-03-31T23:48:19Z
+- Subject: "Merge pull request #38 from emmamarichal/master" (description: "Add Estedad")
+- Parents: `97d10596b3a260c040336199c2e83a6305d37663`, `c0514924d2cbca83895bac41d86c179564418056`
+
+### Recent upstream/main activity (post-onboarding)
+- `55ca157f7` (Emma Marichal, 2026-04-01) — "Estedad: Version 8.5 added": initial onboarding of v8.5 binaries from upstream commit `69e879f78`.
+- `5dd7677db` (Emma Marichal, 2026-04-03) — "Reorder designer name in METADATA.pb": adjusted `designer:` field; current value `"Amin Abedi, Fontamin"` matches the upstream evidence (Amin Abedi as primary designer per font name table; Fontamin as studio per AUTHORS.txt).
+- `b869de54c` (Emma Marichal, 2026-04-24) — "Add Arabic subset to METADATA.pb": added `subsets: "arabic"` (current METADATA.pb confirmed to contain it).
+
+None of those three commits required source-block changes — `repository_url` and `commit` were already correctly recorded by the onboarding `gftools-packager` run.
+
+## Initial state
+- METADATA.pb contained a complete `source { ... }` block (repository_url, commit, branch, file mappings) but `config_yaml` was not set.
+- No `upstream_info.md` existed for this family.
+- No override `config.yaml` in `ofl/estedad/`.
+
+## Actions taken
+- Validated the existing `repository_url` is the canonical upstream (designer `aminabedi68` matches font name table; releases continue to ship from this repo).
+- Validated the existing `commit` hash by md5-comparing the upstream font binary at that commit against the binary shipping in google/fonts — byte-identical match (328340 bytes, md5 `284743ae...`).
+- Located `sources/config.yaml` in the upstream repo at the recorded commit; added `config_yaml: "sources/config.yaml"` to the source block so gftools-builder can use it directly.
+- Created this `upstream_info.md` documenting provenance.
+
+## Final state
+- Provenance fully documented.
+- Source block now includes `config_yaml: "sources/config.yaml"`. All other fields verified correct.
+- No override `config.yaml` is required — upstream provides a working one.
+
+## Open follow-up
+- Mirror `aminabedi68/Estedad` into `/home/fsanches/compartilhado/upstream_repos/repo_archive/aminabedi68/` when disk space permits (currently 21 GB free, just above the 15 GB threshold).
+
+## Confidence
+
+**High**: repository_url verified canonical via designer/owner cross-check; commit hash verified by md5-identical font binary at that commit; upstream `config.yaml` confirmed to exist at recorded commit.

--- a/ofl/geist/upstream_info.md
+++ b/ofl/geist/upstream_info.md
@@ -10,9 +10,9 @@ Geist is a sans-serif variable font by Vercel (designers: Andres Briganti, Mateo
 |-------------------|--------------------------------------------------------------------|
 | Family Name       | Geist                                                              |
 | Repository URL    | https://github.com/vercel/geist-font                              |
-| Commit Hash       | b193ef74010119759bfb7f71ddf81a3dee238535                           |
-| Commit Date       | 2024-10-23                                                        |
-| Commit Message    | Merge pull request #141 from vercel/139-fixes                     |
+| Commit Hash       | a6d260e6cbc07eafdfad438f33601fe3c38b1e6f (updated 2026-04-03; was b193ef74010119759bfb7f71ddf81a3dee238535) |
+| Commit Date       | 2026-04-02                                                         |
+| Commit Message    | Merge pull request #216 from emmamarichal/main — Update Geist and Geist Mono |
 | Config YAML       | sources/config-Geist.yaml (in upstream repo)                      |
 | Source Files      | sources/Geist.glyphspackage                                       |
 | Onboarding PR     | #8246 (google/gftools_packager_ofl_geist)                         |
@@ -109,3 +109,21 @@ source {
 
 ### Status: complete
 ### Confidence: HIGH
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-04-02 (upstream)** — skullface, upstream commit [`a6d260e6c`](https://github.com/vercel/geist-font/commit/a6d260e6c) ("Merge pull request #216 from emmamarichal/main — Update Geist and Geist Mono"). Advanced upstream `main` from `b193ef740...` to `a6d260e6c...` and produced new v1.800 (Geist) and v1.700 (Geist Mono) binaries. The PR was authored by emmamarichal upstream — same person who later onboarded the binaries to google/fonts.
+- **2026-04-03** — Emma Marichal, commit [`87a44ad3d`](https://github.com/google/fonts/commit/87a44ad3d) ("Geist: Version 1.800 added"): onboarded the upstream update via gftools-packager. Updates to METADATA.pb included:
+  - `commit` advanced from `b193ef740...` to `a6d260e6c...`
+  - Italic font entry added; subsets `cyrillic-ext` and `vietnamese` added
+  - Removed `archive_url` (was `1.4.01/Geist-1.4.01.zip`)
+  - File mapping path changed: `variable/Geist[wght].ttf` → `fonts/Geist/variable/Geist[wght].ttf` (upstream layout reorganized)
+  - `config_yaml` field updated path: still `sources/config-Geist.yaml` (unchanged in upstream)
+
+The shipping `Geist[wght].ttf` (169056 bytes, md5 `3f599483f71a2100bf53030faeddd23f`) is byte-identical to upstream `fonts/Geist/variable/Geist[wght].ttf` at commit `a6d260e6c`. `head.fontRevision = 1.8000`, `name` ID 5 = "Version 1.800".
+
+The Key Findings table at the top of this document has been updated to reflect the new commit.
+
+## Confidence (post-update)
+
+**High**: Md5 verification of the shipping `Geist[wght].ttf` against upstream `a6d260e6c:fonts/Geist/variable/Geist[wght].ttf` was byte-identical. The recorded source-block fields are correct and current.

--- a/ofl/geistmono/upstream_info.md
+++ b/ofl/geistmono/upstream_info.md
@@ -10,9 +10,9 @@ Geist Mono is a monospace variable font by Vercel, the companion to Geist sans-s
 |-------------------|--------------------------------------------------------------------|
 | Family Name       | Geist Mono                                                         |
 | Repository URL    | https://github.com/vercel/geist-font                              |
-| Commit Hash       | b193ef74010119759bfb7f71ddf81a3dee238535                           |
-| Commit Date       | 2024-10-23                                                        |
-| Commit Message    | Merge pull request #141 from vercel/139-fixes                     |
+| Commit Hash       | a6d260e6cbc07eafdfad438f33601fe3c38b1e6f (updated 2026-04-03; was b193ef74010119759bfb7f71ddf81a3dee238535) |
+| Commit Date       | 2026-04-02                                                         |
+| Commit Message    | Merge pull request #216 from emmamarichal/main — Update Geist and Geist Mono |
 | Config YAML       | sources/config-GeistMono.yaml (in upstream repo)                  |
 | Source Files      | sources/GeistMono.glyphspackage                                   |
 | Onboarding PR     | #8264 (google/gftools_packager_ofl_geistmono)                     |
@@ -117,4 +117,22 @@ source {
 ```
 
 ### Status: complete
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-04-02 (upstream)** — skullface, upstream commit [`a6d260e6c`](https://github.com/vercel/geist-font/commit/a6d260e6c) ("Merge pull request #216 from emmamarichal/main — Update Geist and Geist Mono"). Same merge that produced Geist v1.800 also produced Geist Mono v1.700.
+- **2026-04-03** — Emma Marichal, commit [`474230b86`](https://github.com/google/fonts/commit/474230b86) ("Geist Mono: Version 1.700 added"): onboarded the upstream update via gftools-packager. Updates to METADATA.pb included:
+  - `commit` advanced from `b193ef740...` to `a6d260e6c...`
+  - Italic font entry added; subsets `cyrillic-ext`, `symbols2`, `vietnamese` added
+  - Removed `archive_url` (was `1.4.01/GeistMono-1.4.01.zip`)
+  - File mapping path changed: `variable/GeistMono[wght].ttf` → `fonts/GeistMono/variable/GeistMono[wght].ttf` (upstream layout reorganized)
+  - `config_yaml` field path unchanged (`sources/config-GeistMono.yaml`)
+
+The shipping `GeistMono[wght].ttf` (171968 bytes, md5 `6ff2091c2ccaba22f57e26df870c8f76`) is byte-identical to upstream `fonts/GeistMono/variable/GeistMono[wght].ttf` at commit `a6d260e6c`. `head.fontRevision = 1.7000`, `name` ID 5 = "Version 1.700".
+
+The Key Findings table at the top of this document has been updated to reflect the new commit.
+
+## Confidence (post-update)
+
+**High**: Md5 verification of the shipping `GeistMono[wght].ttf` against upstream `a6d260e6c:fonts/GeistMono/variable/GeistMono[wght].ttf` was byte-identical. The recorded source-block fields are correct and current.
 ### Confidence: HIGH

--- a/ofl/googlesanscode/upstream_info.md
+++ b/ofl/googlesanscode/upstream_info.md
@@ -140,3 +140,8 @@ source {
 - **Branch**: `main`
 - **Status**: **complete** (resolved by PR #10291).
 - **Confidence**: HIGH.
+
+### Earlier (2025-08-27 → 2025-09-12)
+
+- **2025-08-27** — Marianna Paszkowska, commit [`5be3d1410`](https://github.com/google/fonts/commit/5be3d1410) ("Google Sans Code: Version 6.001 added"): the v6.001 update referenced in PR #9762. Advanced `commit` from `18523d8837d98e6be89316017d323bc610b21c66` (the v6.000 onboarding hash) to `edcd56e39fb7e98d6f1b697e187c144cef2fd994` (the v6.001 release tag) and updated `archive_url` to the v6.001 zip.
+- **2025-09-12** — nyshadhr9 (Google), commit [`3932c2c36`](https://github.com/google/fonts/commit/3932c2c36) ("Update googlesanscode/METADATA.pb (#9824)"): added the `sample_text` block and corrected `category` to MONOSPACE per PR #9824. Outside the `source { ... }` block.

--- a/ofl/googlesanscode/upstream_info.md
+++ b/ofl/googlesanscode/upstream_info.md
@@ -11,8 +11,8 @@ Google Sans Code is a monospace variable font (weight axis 300-800) designed by 
 | Family Name       | Google Sans Code                                                   |
 | Repository URL    | https://github.com/googlefonts/googlesans-code                     |
 | Commit Hash       | edcd56e39fb7e98d6f1b697e187c144cef2fd994                           |
-| Config YAML       | sources/config.yaml (exists upstream, not referenced in METADATA.pb)|
-| Status            | needs_correction                                                   |
+| Config YAML       | sources/config.yaml (now referenced in METADATA.pb — fixed 2026-02-27) |
+| Status            | complete (was needs_correction; resolved by PR #10291)             |
 | Confidence        | HIGH                                                               |
 
 ## Investigation Details
@@ -110,3 +110,33 @@ source {
 
 **Status**: needs_correction (missing config_yaml field)
 **Confidence**: HIGH
+
+## Recent upstream/main activity (post-investigation)
+
+The original investigation flagged that `config_yaml` was missing from the source block. That has been fixed:
+
+- **2026-02-27** — nyshadhr9 (Google), commit [`c8e45997f`](https://github.com/google/fonts/commit/c8e45997f) ("Update METADATA.pb (#10291)"): moved `config_yaml: "sources/config.yaml"` out of the (incorrect) inner `files { ... }` block, where it had been mis-nested by an earlier edit, and into the proper `source { ... }` scope. The field now correctly references the upstream `sources/config.yaml` for fontc_crater builds.
+
+After the fix, the source block reads:
+
+```
+source {
+  repository_url: "https://github.com/googlefonts/googlesans-code"
+  commit: "edcd56e39fb7e98d6f1b697e187c144cef2fd994"
+  archive_url: "https://github.com/googlefonts/googlesans-code/releases/download/v6.001/GoogleSansCode-v6.001.zip"
+  config_yaml: "sources/config.yaml"
+  files { ... }
+  files { ... }
+  files { ... }
+  branch: "main"
+}
+```
+
+### Updated source-of-truth assessment
+
+- **Repository URL**: https://github.com/googlefonts/googlesans-code
+- **Commit**: `edcd56e39fb7e98d6f1b697e187c144cef2fd994` (release tag `v6.001`)
+- **Config YAML**: `sources/config.yaml` (now referenced in METADATA.pb)
+- **Branch**: `main`
+- **Status**: **complete** (resolved by PR #10291).
+- **Confidence**: HIGH.

--- a/ofl/grenze/upstream_info.md
+++ b/ofl/grenze/upstream_info.md
@@ -10,12 +10,12 @@ Grenze is a serif font family designed by Omnibus-Type, added to Google Fonts on
 |-------------------|--------------------------------------------------------------------|
 | Family Name       | Grenze                                                             |
 | Repository URL    | https://github.com/Omnibus-Type/Grenze                             |
-| Commit Hash       | `a2a182c7b828c3d6a1784ef08b22be8521b2b9a7` (only surviving commit) |
+| Commit Hash       | `e1be2f305f7b9490dcfd12e799e2dbc2c0cda6eb` (updated 2026-03-27; was `a2a182c7b828c3d6a1784ef08b22be8521b2b9a7`) |
 | Original Onboarding Hash | `00affb70f8e0bb8ab7c9adfd5b5067a5a2ae2d8d` (lost due to repo rewrite) |
 | Config Path       | `sources/config.yaml`                                              |
-| Source Files      | `Sources/Grenze.glyphs`, `sources/Grenze-Italic.glyphs`           |
-| Status            | **needs_correction**                                               |
-| Confidence        | **MEDIUM**                                                         |
+| Source Files      | `sources/Grenze.glyphs`, `sources/Grenze-Italic.glyphs` (now both lowercase, fixed in upstream) |
+| Status            | **complete**                                                       |
+| Confidence        | **HIGH**                                                           |
 
 ## Investigation Details
 
@@ -103,3 +103,26 @@ source {
 ### Assessment
 
 The current source block is the best available given the repo rewrite. The commit `a2a182c` is the only commit that exists, so while it is not the original onboarding commit, it is the only reference point available. The `config_yaml` field correctly points to the config file in the repo, though that config file itself has issues (wrong STAT reference, case-sensitivity problem). Status is **needs_correction** because the config.yaml in the upstream repo has errors that would prevent a clean build, and the original onboarding commit is lost.
+
+## Recent upstream/main activity (post-investigation)
+
+Many of the issues flagged in the original investigation have since been resolved upstream:
+
+- **Upstream `Omnibus-Type/Grenze` was rebuilt and now has a complete history.** As of 2026-04-27 the master branch contains 33+ commits (no longer a single squashed commit). Recent activity includes `a7e9b2b` "rebuild fonts" (regenerated all TTFs), `e1be2f305` "remove useless files" (cleanup), `2af38b2` "CONTRIBUTORS.txt", and others.
+- **`sources/config.yaml` has been fixed.** At commit `e1be2f305` the config now references `Grenze.glyphs` and `Grenze-Italic.glyphs` (both at lowercase `sources/`), and the STAT table correctly targets `Grenze[wght].ttf` and `Grenze-Italic[wght].ttf` (no Texturina copy-paste). The case-sensitivity issue and the Texturina STAT bug from the original investigation are no longer present.
+- **2026-03-27** — Emma Marichal, commit [`b9edf4389`](https://github.com/google/fonts/commit/b9edf4389) ("Grenze: Version 1.003 added"): onboarded v1.003 binaries via gftools-packager, advancing METADATA.pb `commit` from `a2a182c7b...` to `e1be2f305f...` (explicitly cited in the commit message body). The shipped `Grenze[wght].ttf` (139860 bytes, md5 `02bf2e334dd8aeb9f83eacbb1a42741d`) is byte-identical to upstream `fonts/variable/Grenze[wght].ttf` at commit `e1be2f305`. `head.fontRevision = 1.0030`, `name` ID 5 = "Version 1.003".
+
+### Updated METADATA.pb Source Block (post Emma's onboarding)
+
+```
+source {
+  repository_url: "https://github.com/Omnibus-Type/Grenze"
+  commit: "e1be2f305f7b9490dcfd12e799e2dbc2c0cda6eb"
+  config_yaml: "sources/config.yaml"
+}
+```
+
+### Updated Status: complete
+### Updated Confidence: HIGH
+
+The original onboarding commit `00affb70` from 2018 is still lost, but the v1.003 binaries currently shipping in google/fonts are now produced from a verifiable, working upstream commit with a clean buildable config. The source block is fully usable for reproducible-build verification.

--- a/ofl/ibmplexsansarabic/upstream_info.md
+++ b/ofl/ibmplexsansarabic/upstream_info.md
@@ -65,3 +65,7 @@ The `googlefonts/plex` repo is a Google-maintained fork of IBM/plex. The font fi
 The METADATA.pb source block has correct repository URL and commit hash for the pre-compiled font delivery. However, no config.yaml can be created for this commit since source files do not exist at the referenced commit. A config pointing to sources would require referencing a commit prior to January 2024.
 
 **Status: missing_config**
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-02-26** — Emma Marichal, commit [`1f26508db`](https://github.com/google/fonts/commit/1f26508db) ("Add designers Wael Morcos and Khajag Apelian"): expanded the `designer` field from `"Mike Abbink, Bold Monday"` to `"Mike Abbink, Bold Monday, Khajag Apelian, Wael Morcos"`. The investigation summary above already credited Khajag Apelian and Wael Morcos as designers; this metadata edit brings the METADATA.pb in line with the design credits documented here. The change is outside the `source { ... }` block and does not affect the recorded source provenance.

--- a/ofl/inclusivesans/upstream_info.md
+++ b/ofl/inclusivesans/upstream_info.md
@@ -65,3 +65,7 @@ The font was designed by Olivia King. The family was added to Google Fonts on 20
 ## Conclusion
 
 The source block for Inclusive Sans is complete and verified. Repository URL, commit hash, and config_yaml all check out. No action needed.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-01-06** — Simon Cozens, commit [`1f34dc19d`](https://github.com/google/fonts/commit/1f34dc19d) ("Remove Zinh primary script"): removed the `primary_script: "Zinh"` line from METADATA.pb. `"Zinh"` is the ISO 15924 code for "Code for inherited script" — not a meaningful primary script for a Latin-script family — so this was a metadata cleanup. Edit is outside the `source { ... }` block; no source-block impact.

--- a/ofl/kedebideri/upstream_info.md
+++ b/ofl/kedebideri/upstream_info.md
@@ -63,3 +63,7 @@ Added an override `config.yaml` in `ofl/kedebideri/` referencing the upstream gf
 
 - **2026-01-07** — Emma Marichal, commit [`1776dc2bb`](https://github.com/google/fonts/commit/1776dc2bb) ("Add subset 'beria-erfe' to METADATA.pb"): added a new entry `subsets: "beria-erfe"` (Beria-Erfe is the script-name token used in Google Fonts for the family's primary script). Outside the `source { ... }` block.
 - **2026-01-15** — Garret Rieger, commit [`9711e9d18`](https://github.com/google/fonts/commit/9711e9d18) ("Use primary_language instead of script for Kedebideri so that sample text will be chosen correctly"): switched `primary_script` to `primary_language` so the catalog sample-text picker resolves correctly for this minority-script family. Outside the `source { ... }` block.
+
+### Earlier (2025-10-02)
+
+- **2025-10-02** — Emma Marichal, commit [`03f0d980e`](https://github.com/google/fonts/commit/03f0d980e) ("fix OFL"): fixed a typo in `OFL.txt` ("with an FAQ" → "with a FAQ", added a missing line about the SIL OFL license). License-file change tracked here per policy.

--- a/ofl/kedebideri/upstream_info.md
+++ b/ofl/kedebideri/upstream_info.md
@@ -58,3 +58,8 @@ The source block has repository URL and commit hash. However, the SIL smith buil
 **Model**: Claude Opus 4.7 (1M context)
 
 Added an override `config.yaml` in `ofl/kedebideri/` referencing the upstream gftools-builder-compatible source at the pinned commit `4973b2e` (`source/Kedebideri.designspace`). The upstream repo has no `config.yaml` of its own at this rev; `google-fonts-sources` auto-detects the override and records it in crater's `targets.json` as an external config on the next regeneration.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-01-07** — Emma Marichal, commit [`1776dc2bb`](https://github.com/google/fonts/commit/1776dc2bb) ("Add subset 'beria-erfe' to METADATA.pb"): added a new entry `subsets: "beria-erfe"` (Beria-Erfe is the script-name token used in Google Fonts for the family's primary script). Outside the `source { ... }` block.
+- **2026-01-15** — Garret Rieger, commit [`9711e9d18`](https://github.com/google/fonts/commit/9711e9d18) ("Use primary_language instead of script for Kedebideri so that sample text will be chosen correctly"): switched `primary_script` to `primary_language` so the catalog sample-text picker resolves correctly for this minority-script family. Outside the `source { ... }` block.

--- a/ofl/kedebideri/upstream_info.md
+++ b/ofl/kedebideri/upstream_info.md
@@ -67,3 +67,7 @@ Added an override `config.yaml` in `ofl/kedebideri/` referencing the upstream gf
 ### Earlier (2025-10-02)
 
 - **2025-10-02** — Emma Marichal, commit [`03f0d980e`](https://github.com/google/fonts/commit/03f0d980e) ("fix OFL"): fixed a typo in `OFL.txt` ("with an FAQ" → "with a FAQ", added a missing line about the SIL OFL license). License-file change tracked here per policy.
+
+### Earlier (2025-09-17)
+
+- **2025-09-17** — Emma Marichal, commit [`116a842bb`](https://github.com/google/fonts/commit/116a842bb) ("Kedebideri: Version 3.001 added"): initial onboarding via gftools-packager. Created `ofl/kedebideri/` with source block referencing `silnrsi/font-kedebideri@4973b2e0258ef40acc0da3c2c1d155630faecc2c`, archive_url to v3.001 release.

--- a/ofl/kurale/METADATA.pb
+++ b/ofl/kurale/METADATA.pb
@@ -19,16 +19,16 @@ subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 source {
-  repository_url: "https://www.github.com/etunni/kurale"
+  repository_url: "https://github.com/etunni/kurale"
   commit: "08bf7684d57c6faacff84e6c5ab31df6b7beae18"
   files {
-    source_file: "fonts/ttf/Kurale-Regular.ttf"
+    source_file: "fonts/Kurale-Regular.ttf"
     dest_file: "Kurale-Regular.ttf"
   }
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"
   }
-  branch: "main"
+  branch: "master"
 }
 primary_script: "Deva"

--- a/ofl/kurale/upstream_info.md
+++ b/ofl/kurale/upstream_info.md
@@ -102,3 +102,45 @@ The source block in METADATA.pb was complete with:
 - **Confidence**: HIGH
 
 No further action was required for this family.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-02-27** — Simon Cozens, commit [`c9a8edf41`](https://github.com/google/fonts/commit/c9a8edf41) ("Rebuild and update kurale"): rebuilt the binary locally with `ttfautohint` and rewrote the source block. The Kurale-Regular.ttf binary changed from 250224 bytes (`Version 2.000`) to 265304 bytes (`Version 2.000; ttfautohint (v1.8.4.7-5d5b)`); md5 changed from `7e63a40022b4b92268acd6a84d703a06` to `2636a6a61057bb6c505d14b3762be5e1`. Simon also added file mappings + `branch` and updated the recorded commit.
+
+  ### Bugs introduced by Simon's commit (corrected here)
+
+  Simon's source block had three errors that this PR corrects:
+  1. `repository_url` was set to `https://www.github.com/etunni/kurale` (with `www.` prefix). Corrected to `https://github.com/etunni/kurale` — the canonical URL form used elsewhere in google/fonts.
+  2. `source_file` was set to `fonts/ttf/Kurale-Regular.ttf`. The actual path at upstream commit `08bf7684d` is `fonts/Kurale-Regular.ttf` (no `ttf/` subdirectory). Corrected.
+  3. `branch` was set to `main`. The upstream `etunni/kurale` repo's default branch is `master`. Corrected.
+
+  After the fixes, the source block reads:
+
+  ```
+  source {
+    repository_url: "https://github.com/etunni/kurale"
+    commit: "08bf7684d57c6faacff84e6c5ab31df6b7beae18"
+    files {
+      source_file: "fonts/Kurale-Regular.ttf"
+      dest_file: "Kurale-Regular.ttf"
+    }
+    files {
+      source_file: "OFL.txt"
+      dest_file: "OFL.txt"
+    }
+    branch: "master"
+  }
+  ```
+
+  ### Provenance caveat
+
+  The shipping Kurale-Regular.ttf in google/fonts is **NOT byte-identical** to upstream `08bf7684d:fonts/Kurale-Regular.ttf`:
+
+  | Source | size | md5 | Version string |
+  |---|---|---|---|
+  | upstream `08bf7684d:fonts/Kurale-Regular.ttf` | 250224 | `7e63a40022b4b92268acd6a84d703a06` | `Version 2.000` |
+  | shipping `ofl/kurale/Kurale-Regular.ttf` | 265304 | `2636a6a61057bb6c505d14b3762be5e1` | `Version 2.000; ttfautohint (v1.8.4.7-5d5b)` |
+
+  Simon ran `ttfautohint` locally on the upstream binary and committed the autohinted result to google/fonts without pushing the rebuilt binary upstream. The recorded `commit` therefore identifies the *source state* (which is consistent with the override `config.yaml`'s `Kurale.glyphs` source) but does NOT reproduce the shipping binary directly — a `ttfautohint v1.8.4.7-5d5b` post-process is required.
+
+  This is acceptable for source-provenance tracking since the override `config.yaml` documents the buildable state. A future improvement would be to either (a) push the autohinted binary upstream, or (b) record the ttfautohint invocation alongside the source block.

--- a/ofl/lilex/upstream_info.md
+++ b/ofl/lilex/upstream_info.md
@@ -184,3 +184,7 @@ source {
 ## Confidence
 
 **HIGH** -- The repository URL and commit hash are confirmed by the onboarding commit message and verified by binary file hash comparison. The config_yaml path correction is confirmed by inspecting the upstream repo's file tree at the referenced commit.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-11-07** — Emma Marichal, commit [`8a028720b`](https://github.com/google/fonts/commit/8a028720b) ("Update designer information in METADATA.pb"): expanded the `designer` field from `"Bold Monday, Mikhael Khrustik"` to `"Mike Abbink, Paul van der Laan, Pieter van Rosmalen, Mikhael Khrustik"` (replaced the Bold Monday foundry name with the three named designers). Edit is outside the `source { ... }` block; no source-block impact.

--- a/ofl/mingzat/upstream_info.md
+++ b/ofl/mingzat/upstream_info.md
@@ -34,3 +34,22 @@ Already present and correct — points to `sources: [source/Mingzat.designspace]
 ## Confidence
 
 **High** — The v1.100 tag clearly corresponds to the release archive referenced in METADATA.pb. The commit hash is unambiguous.
+
+## Recent upstream/main activity (post-investigation)
+
+The original investigation predicted that v1.200 would be a future onboarding. That onboarding has now landed:
+
+- **2026-03-06** — Emma Marichal, commit [`5120f9830`](https://github.com/google/fonts/commit/5120f9830) ("Mingzat: Version 1.200 added"): advanced the recorded commit and binaries to v1.200. METADATA.pb at HEAD now reads:
+  - `commit`: `613ac08e03fe5cecd4a3cdb636775f4ce33225dd` (was the placeholder for v1.100; now the upstream HEAD as of v1.200 release)
+  - `archive_url`: `https://github.com/silnrsi/font-mingzat/releases/download/v1.200/Mingzat-1.200.zip` (was v1.100)
+  - File mappings now reference `Mingzat-1.200/...` paths (was `Mingzat-1.100/...`)
+
+The v1.200 tag itself points to `59ed20ce52c89b343fda8a0d338f24aaff6e952a` (an earlier commit on `master`); the recorded `613ac08e0` is HEAD-after-tag (Lorna Evans, "Prep for subsequent development."). The shipping `Mingzat-Regular.ttf` (159916 bytes, md5 `f8675f56bf966b5598e88481f0e4acb6`) is byte-identical to upstream `references/Mingzat-Regular.ttf` AND `references/v1.200/Mingzat-Regular.ttf` at commit `613ac08e0`. `head.fontRevision = 1.2000`, `name` ID 5 = "Version 1.200".
+
+### Updated source-of-truth fields (post-onboarding)
+
+- **Repository URL**: https://github.com/silnrsi/font-mingzat (unchanged)
+- **Branch**: `master` (unchanged)
+- **Commit**: `613ac08e03fe5cecd4a3cdb636775f4ce33225dd`
+- **Archive URL**: `https://github.com/silnrsi/font-mingzat/releases/download/v1.200/Mingzat-1.200.zip`
+- **Override config.yaml**: present in `ofl/mingzat/config.yaml` (unchanged from earlier)

--- a/ofl/mirandasans/upstream_info.md
+++ b/ofl/mirandasans/upstream_info.md
@@ -49,3 +49,7 @@ A `config.yaml` exists at `sources/config.yaml`. It specifies both Glyphs source
 **Model**: Claude Opus 4.7 (1M context)
 
 Added `config_yaml: "sources/config.yaml"` to the METADATA.pb `source { }` block. Direct inspection of the upstream repo at the pinned commit `7cafa37b` (via the bare mirror in `upstream_repos/repo_archive/maxthunberg/miranda-sans.git`) confirms that `sources/config.yaml` exists at that commit and is a valid gftools-builder config — it declares the `sources:` key. The family should move from the dashboard's "missing_config" bucket into "covered" once `google-fonts-sources` regenerates crater's `targets.json`.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-02-11** — Emma Marichal, commit [`6c3102a96`](https://github.com/google/fonts/commit/6c3102a96) ("Miranda Sans: Version 1.000 added"): initial onboarding of Miranda Sans to google/fonts via gftools-packager. The commit created `ofl/mirandasans/` with the variable binaries `MirandaSans[wght].ttf` and `MirandaSans-Italic[wght].ttf`, METADATA.pb (with the source block recording `maxthunberg/miranda-sans@7cafa37b9`), OFL.txt, and the article. This is the same commit referenced in the original investigation's "added to google/fonts on 2026-02-11" line.

--- a/ofl/momosignature/upstream_info.md
+++ b/ofl/momosignature/upstream_info.md
@@ -5,3 +5,7 @@ Font was designed by Type Associates. Source files were taken from the GitHub re
 **Config:** sources/config.yaml
 **Status:** Binary copy from upstream with config
 **Confidence:** High
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-09-25** — Emma Marichal, commit [`116e8f883`](https://github.com/google/fonts/commit/116e8f883) ("Momo Signature: Version 1.000; ttfautohint (v1.8.4.7-5d5b) added"): initial onboarding via gftools-packager. Created `ofl/momosignature/` with the binary, OFL.txt, and METADATA.pb (source block recording `typeassociates/MomoSignature@c3ba208abfc2d6e661da920121653f0557bae611`).

--- a/ofl/momotrustdisplay/upstream_info.md
+++ b/ofl/momotrustdisplay/upstream_info.md
@@ -5,3 +5,7 @@ Font was designed by Type Associates. Source files were taken from the GitHub re
 **Config:** sources/config.yaml
 **Status:** Binary copy from upstream with config
 **Confidence:** High
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-09-18** — Emma Marichal, commit [`8c833ce6c`](https://github.com/google/fonts/commit/8c833ce6c) ("Momo Trust Display: Version 1.000; ttfautohint (v1.8.4.7-5d5b) added"): initial onboarding via gftools-packager. Created `ofl/momotrustdisplay/` with source block referencing `typeassociates/MomoTrustDisplay@33a85fe93dfe2ee4ee1cc0fe853f08b6a12d1815`. Sibling family Momo Trust Sans was onboarded a week earlier from a separate `typeassociates/MomoTrustSans` repo.

--- a/ofl/momotrustsans/upstream_info.md
+++ b/ofl/momotrustsans/upstream_info.md
@@ -5,3 +5,7 @@ Font was designed by Type Associates. Source files were taken from the GitHub re
 **Config:** sources/config.yaml
 **Status:** Binary copy from upstream with config
 **Confidence:** High
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-10-30** — Emma Marichal, commit [`aac472d8f`](https://github.com/google/fonts/commit/aac472d8f) ("update designer list in metadata.pb"): collapsed the `designer` field from a four-name list (`"TYPE Associates, DuyN, Phuc Tran, Bao Truong"`) to the single foundry name `"Type Associates"`. Outside the `source { ... }` block.

--- a/ofl/momotrustsans/upstream_info.md
+++ b/ofl/momotrustsans/upstream_info.md
@@ -9,3 +9,9 @@ Font was designed by Type Associates. Source files were taken from the GitHub re
 ## Recent upstream/main activity (post-investigation)
 
 - **2025-10-30** — Emma Marichal, commit [`aac472d8f`](https://github.com/google/fonts/commit/aac472d8f) ("update designer list in metadata.pb"): collapsed the `designer` field from a four-name list (`"TYPE Associates, DuyN, Phuc Tran, Bao Truong"`) to the single foundry name `"Type Associates"`. Outside the `source { ... }` block.
+
+### Earlier (2025-09-12)
+
+- **2025-09-12** — Emma Marichal, commit [`10649386d`](https://github.com/google/fonts/commit/10649386d) ("Momo Trust Sans: Version 1.000 added"): initial onboarding via gftools-packager. Created `ofl/momotrustsans/` with source block referencing `typeassociates/MomoTrustSans@35a9521152ca14fd2a4300902519a3c00706dd5b`.
+- **2025-09-12** — Emma Marichal, commit [`d3de930fa`](https://github.com/google/fonts/commit/d3de930fa) ("update name table for copyright"): same-day binary update to fix the name-table copyright string.
+- **2025-09-12** — Emma Marichal, commit [`4f98c2f7e`](https://github.com/google/fonts/commit/4f98c2f7e) ("update copyright in metadata"): same-day METADATA.pb copyright field update.

--- a/ofl/notonaskharabic/upstream_info.md
+++ b/ofl/notonaskharabic/upstream_info.md
@@ -15,3 +15,11 @@ The existing source metadata was reviewed. The source block contained both a rep
 - **Script**: Arabic (Naskh style)
 - **Category**: SERIF
 - Part of the Google Noto project at github.com/notofonts/arabic. Provides Naskh-style Arabic script coverage with variable weight (wght 400–700). Supports a wide range of Arabic-script languages.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-01-16** — Simon Cozens, commit [`35ddfc50b`](https://github.com/google/fonts/commit/35ddfc50b) ("Noto Naskh Arabic: Version 2.021 added"): advanced the source block from v2.020 → v2.021. METADATA.pb changes:
+  - `commit`: `1b2b7e5c6ce3ab4d50681c854892325530084c35` → `59f5a3fd985bf24858915c3dddfc51a537640965`
+  - `archive_url`: `.../NotoNaskhArabic-v2.020/...zip` → `.../NotoNaskhArabic-v2.021/...zip`
+
+  Binary `NotoNaskhArabic[wght].ttf` updated.

--- a/ofl/notonaskharabic/upstream_info.md
+++ b/ofl/notonaskharabic/upstream_info.md
@@ -23,3 +23,8 @@ The existing source metadata was reviewed. The source block contained both a rep
   - `archive_url`: `.../NotoNaskhArabic-v2.020/...zip` → `.../NotoNaskhArabic-v2.021/...zip`
 
   Binary `NotoNaskhArabic[wght].ttf` updated.
+
+### Earlier (2025-10-15 → 2025-10-29)
+
+- **2025-10-15** — simoncozens, commit [`a5cb0f48a`](https://github.com/google/fonts/commit/a5cb0f48a) ("Noto Naskh Arabic: Version 2.020 added"): preceded the v2.021 update — initial v2.020 onboarding via gftools-packager. Source block fields were populated then.
+- **2025-10-29** — Emma Marichal, commit [`4b76b0ca7`](https://github.com/google/fonts/commit/4b76b0ca7) ("Remove 'ms_Arab' language entry"): removed `languages: "ms_Arab"` from METADATA.pb. Outside the `source { ... }` block.

--- a/ofl/notosansbengali/upstream_info.md
+++ b/ofl/notosansbengali/upstream_info.md
@@ -15,3 +15,11 @@ The existing source metadata was reviewed. The source block contained both a rep
 - **Script**: Bengali/Bangla (Beng)
 - **Category**: SANS_SERIF
 - Part of the Google Noto project at github.com/notofonts/bengali. Variable axes wdth (62.5–100) and wght (100–900). Covers Bengali/Bangla, Assamese, Manipuri, and many other languages using the Bengali script.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-01-09** — Simon Cozens, commit [`73b393782`](https://github.com/google/fonts/commit/73b393782) ("Noto Sans Bengali: Version 3.011 added"): advanced the source block from v3.000 → v3.011. METADATA.pb changes:
+  - `commit`: `7ab89a047313e4a2c7ca5d670b28ced031c86542` → `85d80394cbbbb798ca0a41c983902e6cf77be3a3`
+  - `archive_url`: `.../NotoSansBengali-v3.000/...zip` → `.../NotoSansBengali-v3.011/...zip`
+
+  Binary `NotoSansBengali[wdth,wght].ttf` updated.

--- a/ofl/notosanskannada/METADATA.pb
+++ b/ofl/notosanskannada/METADATA.pb
@@ -28,9 +28,9 @@ axes {
 }
 source {
   repository_url: "https://github.com/notofonts/kannada"
-  commit: "6387faa16123c9becca4f0f3ca095189de5c61da"
+  commit: "7eeac8993f890e3d8568ba909ae67f554113ea92"
   config_yaml: "sources/config-sans-kannada.yaml"
-  archive_url: "https://github.com/notofonts/kannada/releases/download/NotoSansKannada-v2.005/NotoSansKannada-v2.005.zip"
+  archive_url: "https://github.com/notofonts/kannada/releases/download/NotoSansKannada-v2.006/NotoSansKannada-v2.006.zip"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/notosanskannada/upstream_info.md
+++ b/ofl/notosanskannada/upstream_info.md
@@ -15,3 +15,38 @@ The existing source metadata was reviewed. A complete `source` block was present
 - Script: Kannada (Knda)
 - Category: SANS_SERIF
 - Covers Kannada and Tulu.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-02-25** — Aaron Bell, commit [`9d71243b7`](https://github.com/google/fonts/commit/9d71243b7) ("Updating Noto Sans Kannada"): bumped the shipping `NotoSansKannada[wdth,wght].ttf` from v2.005 to v2.006 (binary-only commit; size 654460 → 641372). Aaron's commit body explained: "It seems the 2.006 release was never pushed out." — meaning the v2.006 release archive existed upstream but the corresponding binary had not been merged to google/fonts.
+
+  Aaron's commit did NOT update the source block in METADATA.pb. This left the recorded `commit` and `archive_url` referencing v2.005 while the shipping binary was v2.006, an out-of-sync state.
+
+  ### Source-block corrections (this commit)
+
+  Updated `commit` and `archive_url` to point to the v2.006 release:
+  - `commit`: `6387faa16123c9becca4f0f3ca095189de5c61da` (Simon Cozens 2023-09-27 "Fix website template", which was pre-v2.006) → `7eeac8993f890e3d8568ba909ae67f554113ea92` (Simon Cozens 2024-09-19 "Bump sans version to 2.006", the commit that the `NotoSansKannada-v2.006` tag points to).
+  - `archive_url`: `.../NotoSansKannada-v2.005/NotoSansKannada-v2.005.zip` → `.../NotoSansKannada-v2.006/NotoSansKannada-v2.006.zip`.
+
+  After the fix, METADATA.pb reads:
+
+  ```
+  source {
+    repository_url: "https://github.com/notofonts/kannada"
+    commit: "7eeac8993f890e3d8568ba909ae67f554113ea92"
+    config_yaml: "sources/config-sans-kannada.yaml"
+    archive_url: "https://github.com/notofonts/kannada/releases/download/NotoSansKannada-v2.006/NotoSansKannada-v2.006.zip"
+    ...
+    branch: "main"
+  }
+  ```
+
+### Updated source-of-truth fields
+
+- **Repository URL**: https://github.com/notofonts/kannada (unchanged)
+- **Commit**: `7eeac8993f890e3d8568ba909ae67f554113ea92` (v2.006 tag)
+- **Archive URL**: v2.006 release zip
+- **Branch**: `main` (unchanged)
+- **Config YAML**: `sources/config-sans-kannada.yaml` (unchanged)
+- **Status**: present
+- **Confidence**: HIGH — the v2.006 tag commit is unambiguous and corresponds to the shipping `Version 2.006` binary (`head.fontRevision = 2.0060`).

--- a/ofl/notosansoriya/upstream_info.md
+++ b/ofl/notosansoriya/upstream_info.md
@@ -13,3 +13,11 @@
 ## Summary
 
 Noto Sans Oriya was sourced from the notofonts/oriya repository. The family was published as a variable font with `wdth` (62.5–100) and `wght` (100–900) axes, covering the Odia script (Orya) and supporting Odia, Sanskrit, Santali, Kharia, Kudmali, and Mundari languages. Files were built using the gftools-builder pipeline with `sources/config-sans-oriya.yaml`. The font was added to Google Fonts on 2020-11-19 and released at version 2.007.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-02-03** — Simon Cozens, commit [`606ff7894`](https://github.com/google/fonts/commit/606ff7894) ("Noto Sans Oriya: Version 2.007 added"): advanced the source block from v2.006 → v2.007. METADATA.pb changes:
+  - `commit`: `97abab82ec512f8a4a98c389352f194a03385ce2` → `8540c2079d99db2db98a0c82e9daae71d4740c44`
+  - `archive_url`: `.../NotoSansOriya-v2.006/...zip` → `.../NotoSansOriya-v2.007/...zip`
+
+  Binary `NotoSansOriya[wdth,wght].ttf` updated. The recorded `8540c2079...` is what the existing investigation captured; this appendix records the chronology of how it got there.

--- a/ofl/notosansrejang/upstream_info.md
+++ b/ofl/notosansrejang/upstream_info.md
@@ -13,3 +13,11 @@
 ## Summary
 
 Noto Sans Rejang was sourced from the notofonts/rejang repository. The family provided a single Regular weight covering the Rejang script (Rjng), used for the Rejang language of Sumatra, Indonesia, and Sanskrit. Files were built using the gftools-builder pipeline with `sources/config-sans-rejang.yaml`. The font was added to Google Fonts on 2020-11-19 and released at version 2.003.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-11-17** — Simon Cozens, commit [`10424dcbf`](https://github.com/google/fonts/commit/10424dcbf) ("Noto Sans Rejang: Version 2.003; ttfautohint (v1.8.4.16-eb64) added"): advanced the source block from v2.002 → v2.003. METADATA.pb changes:
+  - `commit`: `260e890f159e60ffbcc4994006a003b7a9a28f07` → `f8a0b6d6e937ca8893d86c4a3e3dabd3ffa3ccd9`
+  - `archive_url`: `.../NotoSansRejang-v2.002/...zip` → `.../NotoSansRejang-v2.003/...zip`
+
+  Binary `NotoSansRejang-Regular.ttf` updated; OFL.txt synced.

--- a/ofl/notosanssyriacwestern/upstream_info.md
+++ b/ofl/notosanssyriacwestern/upstream_info.md
@@ -13,3 +13,14 @@
 ## Summary
 
 Noto Sans Syriac Western was sourced from the notofonts/syriac repository (shared with Noto Sans Syriac and Noto Sans Syriac Eastern). The family was published as a variable font with a `wght` axis (100–900), covering the Western Syriac script variant (Syrc) and supporting Assyrian Neo-Aramaic, Classical Syriac, Syriac, Turoyo, and Arabic written in Syriac. No `config_yaml` field was present in the METADATA.pb source block. Files were distributed via the NotoSansSyriacWestern-v3.001 release archive. The font was added to Google Fonts on 2023-01-06 and released at version 3.001.
+
+## Recent upstream/main activity (post-investigation)
+
+A four-commit revision sequence by Simon Cozens on 2025-10-02/03 advanced this family to v3.001:
+
+- **2025-10-02** — Simon Cozens, commit [`4416b69d2`](https://github.com/google/fonts/commit/4416b69d2) ("Add 3.001"): added the v3.001 binary update.
+- **2025-10-02** — Simon Cozens, commit [`1b6a4d32d`](https://github.com/google/fonts/commit/1b6a4d32d) ("Update metadata"): advanced `commit` (`0be4b71c...` → `4b57be25d...`) and removed the v3.000 `archive_url`.
+- **2025-10-03** — Simon Cozens, commit [`5d425ebbb`](https://github.com/google/fonts/commit/5d425ebbb) ("Fix again"): another binary update.
+- **2025-10-03** — Simon Cozens, commit [`aa728a5ea`](https://github.com/google/fonts/commit/aa728a5ea) ("Update SHA"): advanced `commit` again (`4b57be25d...` → `a24ba4586...`), the final state of the source block at HEAD.
+
+The final recorded commit `a24ba4586441a6b76df20215464898852e702078` is what HEAD reflects today.

--- a/ofl/parastoo/upstream_info.md
+++ b/ofl/parastoo/upstream_info.md
@@ -42,3 +42,7 @@ The source block specified explicit file mappings: `OFL.txt`, `fonts/variable/Pa
 ## Confidence
 
 **High** — The repository is hosted under the `googlefonts` organization. The commit is explicitly referenced and the copyright notice matches the repository URL.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-09-15** — Dave Crossland, commit [`05951fc1f`](https://github.com/google/fonts/commit/05951fc1f) ("Update ofl/parastoo/METADATA.pb with arabic subset"): added an Arabic subset entry to METADATA.pb. Outside the `source { ... }` block.

--- a/ofl/playwritenz/upstream_info.md
+++ b/ofl/playwritenz/upstream_info.md
@@ -11,3 +11,10 @@ The METADATA.pb contained a source block pointing to the TypeTogether/Playwrite 
 
 ## Status
 - **Category**: WITH_SOURCE
+
+## Recent upstream/main activity (post-investigation)
+
+Two commits on 2026-01-21 advanced this family to v1.004:
+
+- **2026-01-21** — Emma Marichal, commit [`51c2bf9c5`](https://github.com/google/fonts/commit/51c2bf9c5) ("Playwrite NZ: Version 1.004 added"): version bump to 1.004 via gftools-packager. Updated `PlaywriteNZ[wght].ttf` (349396 → 368940 bytes), METADATA.pb, and article. Source block fields advanced to reflect the v1.004 upstream commit.
+- **2026-01-21** — Marc Foley, commit [`e6f137049`](https://github.com/google/fonts/commit/e6f137049) ("remove all subsets apart from menu"): removed 3 subsets from METADATA.pb (post-onboarding cleanup; presumably to address a fontspector or QA finding). Outside the `source { ... }` block.

--- a/ofl/playwritenzbasic/upstream_info.md
+++ b/ofl/playwritenzbasic/upstream_info.md
@@ -11,3 +11,12 @@ The METADATA.pb contained a source block pointing to the TypeTogether/Playwrite 
 
 ## Status
 - **Category**: WITH_SOURCE
+
+## Recent upstream/main activity (post-investigation)
+
+This family was newly onboarded to google/fonts on 2026-01-21:
+
+- **2026-01-21** — Emma Marichal, commit [`dd04af331`](https://github.com/google/fonts/commit/dd04af331) ("Playwrite NZ Basic: Version 1.004 added"): initial onboarding via gftools-packager. Created `ofl/playwritenzbasic/` with METADATA.pb, OFL.txt, the binary `PlaywriteNZBasic[wght].ttf`, and article.
+- **2026-01-21** — Marc Foley, commit [`9168cb8eb`](https://github.com/google/fonts/commit/9168cb8eb) ("playwritenzbasic*: rm all subsets apart from menu"): same-day post-onboarding cleanup, removing extra subsets from METADATA.pb. Same commit also touched the sibling `ofl/playwritenzbasicguides/` family.
+
+Source block was populated by gftools-packager in the v1.004 commit; no corrections needed.

--- a/ofl/playwritenzbasicguides/upstream_info.md
+++ b/ofl/playwritenzbasicguides/upstream_info.md
@@ -11,3 +11,12 @@ The METADATA.pb contained a source block pointing to the TypeTogether/Playwrite 
 
 ## Status
 - **Category**: WITH_SOURCE
+
+## Recent upstream/main activity (post-investigation)
+
+This family was newly onboarded to google/fonts on 2026-01-21:
+
+- **2026-01-21** — Emma Marichal, commit [`dee079aac`](https://github.com/google/fonts/commit/dee079aac) ("Playwrite NZ Basic Guides: Version 1.004 added"): initial onboarding via gftools-packager. Created `ofl/playwritenzbasicguides/` with METADATA.pb, the binary `PlaywriteNZBasicGuides-Regular.ttf`, and article.
+- **2026-01-21** — Marc Foley, commit [`9168cb8eb`](https://github.com/google/fonts/commit/9168cb8eb) ("playwritenzbasic*: rm all subsets apart from menu"): same-day post-onboarding cleanup, removing extra subsets from METADATA.pb. Same commit also touched the sibling `ofl/playwritenzbasic/` family.
+
+Source block was populated by gftools-packager in the v1.004 commit; no corrections needed.

--- a/ofl/playwritenzguides/upstream_info.md
+++ b/ofl/playwritenzguides/upstream_info.md
@@ -11,3 +11,10 @@ The METADATA.pb contained a source block pointing to the TypeTogether/Playwrite 
 
 ## Status
 - **Category**: WITH_SOURCE
+
+## Recent upstream/main activity (post-investigation)
+
+Two commits on 2026-01-21 advanced this family to v1.004:
+
+- **2026-01-21** — Emma Marichal, commit [`ba7373c4b`](https://github.com/google/fonts/commit/ba7373c4b) ("Playwrite NZ Guides: Version 1.004 added"): version bump to 1.004 via gftools-packager. Updated `PlaywriteNZGuides-Regular.ttf` (368516 → 387680 bytes), METADATA.pb, article. Source block fields advanced.
+- **2026-01-21** — Marc Foley, commit [`55aec06a9`](https://github.com/google/fonts/commit/55aec06a9) ("Remove all subsets apart from menu"): removed 3 subsets from METADATA.pb (post-onboarding cleanup). Outside the `source { ... }` block.

--- a/ofl/ramsina/upstream_info.md
+++ b/ofl/ramsina/upstream_info.md
@@ -19,3 +19,11 @@ Designed by SIL International. A serif typeface with Syriac as the primary scrip
 **Model**: Claude Opus 4.7 (1M context)
 
 Added an override `config.yaml` in `ofl/ramsina/` referencing the upstream gftools-builder-compatible source at the pinned commit `263c8d5` (`source/Ramsina.designspace`). The upstream repo has no `config.yaml` of its own at this rev; `google-fonts-sources` auto-detects the override and records it in crater's `targets.json` as an external config on the next regeneration.
+
+## Recent upstream/main activity (post-investigation)
+
+The original onboarding and subsequent metadata edits:
+
+- **2026-01-21** — Emma Marichal, commit [`653676022`](https://github.com/google/fonts/commit/653676022) ("Ramsina: Version 2.000 added"): initial onboarding via gftools-packager. Created `ofl/ramsina/` with the binary `Ramsina-Regular.ttf`, OFL.txt, and METADATA.pb (with the source block referencing the upstream commit).
+- **2026-01-21** — Emma Marichal, commit [`e03d57ffe`](https://github.com/google/fonts/commit/e03d57ffe) ("Update designer name to 'SIL International'"): same-day correction of the `designer` field. Outside the `source { ... }` block.
+- **2026-01-22** — Emma Marichal, commit [`5c440604d`](https://github.com/google/fonts/commit/5c440604d) ("Change font category from SANS_SERIF to SERIF"): re-categorised the family. Outside the `source { ... }` block.

--- a/ofl/roboto/upstream_info.md
+++ b/ofl/roboto/upstream_info.md
@@ -13,3 +13,11 @@ The existing source metadata was reviewed. The repository URL and commit hash we
 
 ## Notes
 Designed by Christian Robertson, ParaType, and Font Bureau. A variable sans-serif with width (75–100) and weight (100–900) axes, available in upright and italic styles. One of Google Fonts' most widely used typefaces. Covers a broad range of subsets including Cyrillic, Greek, Latin, Vietnamese, Math, and Symbols. An archive URL pointing to a versioned release zip is also present in the source block.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-01-27** — Aaron Bell, commit [`6183fc0d2`](https://github.com/google/fonts/commit/6183fc0d2) ("Roboto 3.015 update"): advanced the source block from v3.011 → v3.015. METADATA.pb changes:
+  - `commit`: `b3ab25297a96373a8053db2d6fbf94b3ce61a8ac` → `91d5d3e5b81efa04a77925cc609fdcdd7ee663d1`
+  - `archive_url`: `.../v3.011/Roboto_v3.011.zip` → `.../v3.015/Roboto_v3.015.zip`
+
+  Both binaries (`Roboto[wdth,wght].ttf` and `Roboto-Italic[wdth,wght].ttf`) were updated. The recorded `91d5d3e5b...` is what the existing investigation captured; this appendix simply records the chronology of how it got there.

--- a/ofl/robotomono/upstream_info.md
+++ b/ofl/robotomono/upstream_info.md
@@ -13,3 +13,11 @@ The existing source metadata was reviewed. The repository URL and commit hash we
 
 ## Notes
 Designed by Christian Robertson. A monospace variable font with a weight axis from 100 to 700, available in upright and italic styles. Licensed under Apache 2.0 (not OFL). Covers Cyrillic, Cyrillic Extended, Greek, Latin, Latin Extended, and Vietnamese subsets.
+
+## Recent upstream/main activity (post-investigation)
+
+The Apache 2.0 vs OFL note above was based on the upstream repo's `LICENSE` file. However, the google/fonts catalog distributes Roboto Mono under OFL, and the METADATA.pb `license` field was corrected to reflect that:
+
+- **2026-02-09** — Aaron Bell, commit [`21406e8f5`](https://github.com/google/fonts/commit/21406e8f5) ("Fixing license in Roboto Mono"): changed the `license` field in METADATA.pb from `"APACHE2"` to `"OFL"`. The family directory has always been `ofl/robotomono/` (the directory naming reflects the catalog's licensing of the family), but the METADATA.pb `license` field had drifted. Aaron's fix re-aligns the field with the catalog convention.
+
+Edit is outside the `source { ... }` block; the `repository_url`, `commit`, and `config_yaml` fields are unchanged.

--- a/ofl/sairastencil/METADATA.pb
+++ b/ofl/sairastencil/METADATA.pb
@@ -51,6 +51,7 @@ source {
     dest_file: "SairaStencil-Italic[wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"

--- a/ofl/sairastencil/upstream_info.md
+++ b/ofl/sairastencil/upstream_info.md
@@ -1,0 +1,83 @@
+# Saira Stencil
+
+**Status**: `complete`
+**Date**: 2026-04-27
+**Designer**: Hector Gatti, Omnibus-Type
+**License**: OFL
+**METADATA.pb**: `ofl/sairastencil/METADATA.pb`
+**Model**: Claude Opus 4.7 (1M context)
+
+## Data
+
+| Field | Value |
+|-------|-------|
+| Repository URL | https://github.com/Omnibus-Type/Saira_Stencil |
+| Commit | `426fb33c0deade38404978462b01c09829003a17` |
+| Config YAML | `sources/config.yaml` |
+| Branch | `main` |
+
+## Methodology
+
+### Repository URL
+Pre-existing in METADATA.pb `source { repository_url }` field. Confirmed canonical Omnibus-Type repo (default branch `main`, full history, no squash/rewrite).
+
+### Commit Hash
+Pre-existing in METADATA.pb `source { commit }` field; further confirmed by the body of onboarding commit `a4d1ba810` (Emma Marichal, 2026-03-20), which explicitly records: "Taken from the upstream repo https://github.com/Omnibus-Type/Saira_Stencil at commit https://github.com/Omnibus-Type/Saira_Stencil/commit/426fb33c0deade38404978462b01c09829003a17."
+
+- Commit date: 2026-03-19 22:25:03 -0300
+- Commit author: Omnibus-Type
+- Commit subject: "Update README.md"
+- Currently equal to `refs/heads/main` HEAD (no upstream activity since onboarding).
+
+### Config YAML
+Found at `sources/config.yaml` in the upstream repository at the recorded commit. Contains gftools-builder configuration (sources: `SairaStencil.glyphs`, `SairaStencil-Italic.glyphs`; axisOrder `wdth`, `wght`; full STAT table). Now referenced from METADATA.pb.
+
+## Evidence
+
+### METADATA.pb source block
+- `repository_url`: `https://github.com/Omnibus-Type/Saira_Stencil`
+- `commit`: `426fb33c0deade38404978462b01c09829003a17`
+- `branch`: `main`
+- `config_yaml`: `sources/config.yaml` (added 2026-04-27 by this commit)
+
+### google/fonts history
+- Last font modification: `a4d1ba810` (Emma Marichal, 2026-03-20) "Saira Stencil: Version 1.101 added"
+- Prior history: family was deleted in `877762234` (PR #2002) after the original `10053565d` v1.003 onboarding; the 2026-03 commit is a fresh re-onboarding via gftools-packager.
+
+### Binary verification
+fontTools confirms `nameID 5` = `Version 1.101` on both shipping VFs.
+- md5 of upstream `fonts/variable/SairaStencil[wdth,wght].ttf` at `426fb33c0` = `79fb92d4d68e799c28f6bc96a0c30160` = shipping `ofl/sairastencil/SairaStencil[wdth,wght].ttf`.
+- md5 of upstream `fonts/variable/SairaStencil-Italic[wdth,wght].ttf` at `426fb33c0` = `792184edde67f6e6059cf625819d107c` = shipping italic.
+
+Byte-identical match — the recorded commit produces exactly the binaries currently shipping.
+
+### Upstream repo archive
+- Mirrored at `/home/fsanches/compartilhado/upstream_repos/repo_archive/Omnibus-Type/Saira_Stencil.git` (cloned 2026-04-27 by this investigation).
+- 24 commits, full history retained, default branch `main`.
+- HEAD of `main` is the recorded commit.
+
+## Initial state
+- METADATA.pb already contained a complete `source { ... }` block with repository_url, commit, file mappings, and `branch: main`.
+- No `upstream_info.md` existed in the family directory.
+- METADATA.pb was missing `config_yaml`, despite a usable `sources/config.yaml` in the upstream repo.
+
+## Actions taken
+- Verified Omnibus-Type/Saira_Stencil is the canonical upstream and that the repo has full (non-squashed) history.
+- Verified recorded commit `426fb33c0` exists, equals `main` HEAD, and produces the exact binaries shipping in google/fonts (md5 match for both VFs).
+- Confirmed gftools-builder `sources/config.yaml` is present at the recorded commit.
+- Cloned upstream as bare mirror into the repo archive.
+- Authored this `upstream_info.md`.
+- Added `config_yaml: "sources/config.yaml"` to METADATA.pb source block.
+
+## Final state
+- `upstream_info.md` present with full provenance.
+- METADATA.pb source block has `config_yaml: "sources/config.yaml"` set.
+- No override `config.yaml` is required — upstream is gftools-builder ready.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-03-20** — Emma Marichal, commit [`a4d1ba810`](https://github.com/google/fonts/commit/a4d1ba810) ("Saira Stencil: Version 1.101 added"): re-onboarded the family after its earlier deletion (PR #2002) via gftools-packager, sourced from `Omnibus-Type/Saira_Stencil@426fb33c0`. This is the version currently shipping. No upstream activity after that commit (recorded commit is HEAD of upstream `main`).
+
+## Confidence
+
+**High**: URL pre-existing in METADATA.pb; commit pre-existing in METADATA.pb and explicitly cited in onboarding commit body; binary md5 match against upstream confirms the recorded commit produced the shipping fonts.

--- a/ofl/scheherazadenew/upstream_info.md
+++ b/ofl/scheherazadenew/upstream_info.md
@@ -13,3 +13,7 @@ The existing source metadata was reviewed. The repository URL and commit hash we
 
 ## Notes
 An Arabic serif typeface produced by SIL International (SIL Global), with primary script `Arab`. The source block references an archive URL pointing to release v4.400. The family includes four weights: Regular, Medium, SemiBold, and Bold. The repository is hosted under the silnrsi GitHub organization. The source block uses the `master` branch. No config.yaml is referenced in the source block.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-09-05** — Emma Marichal, commit [`c14713864`](https://github.com/google/fonts/commit/c14713864) ("Scheherazade New: Version 4.400 added"): version bump from v4.300 → v4.400. Advanced `commit` from `74197340596893c31122e71052fc440570b838ef` to `e630202ccd00ca8f147641658b4518f7b847a511` and updated archive_url accordingly. Sibling families Lateef and Harmattan were updated on the same day from related upstream repos.

--- a/ofl/sciencegothic/upstream_info.md
+++ b/ofl/sciencegothic/upstream_info.md
@@ -13,3 +13,8 @@ The existing source metadata was reviewed. The repository URL and commit hash we
 
 ## Notes
 A sans-serif variable font designed by Thomas Phinney, Vassil Kateliev, and Brandon Buerkle, added to Google Fonts in 2025. It features four axes: CTRS (0–85), slnt (-10–0), wdth (50–200), and wght (100–900). The repository is hosted under the googlefonts organization. The source block uses the `main` branch and references a `build-config.yaml` (note: non-standard config filename).
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-10-10** — Emma Marichal, commit [`37cc7fb32`](https://github.com/google/fonts/commit/37cc7fb32) ("Science Gothic: Version 1.035 added"): version update via gftools-packager. Source block updated to reference `googlefonts/science-gothic@9eae80c1fe8f937e4f7009629c8248a959735c77`.
+- **2025-10-15** — Emma Marichal, commit [`209ea1788`](https://github.com/google/fonts/commit/209ea1788) ("Update OFL.txt for clarity and formatting"): same-week OFL.txt cosmetic cleanup. License-file change tracked here per policy.

--- a/ofl/sekuya/upstream_info.md
+++ b/ofl/sekuya/upstream_info.md
@@ -13,3 +13,7 @@ The existing source metadata was reviewed. The repository URL and commit hash we
 
 ## Notes
 A display typeface attributed to the designer named SEKUYA, added to Google Fonts in 2025. The repository is hosted under the personal GitHub account kevinnseptian, with the repository name in uppercase (SEKUYA). The source block uses the `main` branch and references a config.yaml.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-11-14** — Emma Marichal, commit [`93d336abd`](https://github.com/google/fonts/commit/93d336abd) ("Sekuya: Version 1.001; ttfautohint (v1.8.4.7-5d5b) added"): initial onboarding via gftools-packager that created METADATA.pb, OFL.txt, and the binary. The recorded `commit` and `repository_url` in the source block were populated by gftools-packager from the upstream commit referenced in the packager run.

--- a/ofl/snpro/upstream_info.md
+++ b/ofl/snpro/upstream_info.md
@@ -16,3 +16,8 @@
 ## Summary
 
 SN Pro was designed by Tobias Whetton for Supernotes and open-sourced under the OFL. The family was published as a variable font pair (upright and italic) with a wght axis ranging from ExtraLight (200) to Black (900). It supported Cyrillic, Cyrillic Extended, Latin, Latin Extended, and Vietnamese subsets. The build configuration was located at `sources/config.yaml`.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-12-10** — Emma Marichal, commit [`1c8e63a74`](https://github.com/google/fonts/commit/1c8e63a74) ("SN Pro: Version 1.005 added"): initial onboarding via gftools-packager. Created `ofl/snpro/` with the binary, OFL.txt, and METADATA.pb (source block populated from the upstream commit).
+- **2025-12-12** — Emma Marichal, commit [`f8b94b847`](https://github.com/google/fonts/commit/f8b94b847) ("add supernotes to designers"): expanded the `designer` field to include "Supernotes". Outside the `source { ... }` block.

--- a/ofl/stacksansheadline/upstream_info.md
+++ b/ofl/stacksansheadline/upstream_info.md
@@ -28,3 +28,7 @@ The family covered the following subsets: latin, latin-ext.
 ## Notes
 
 Stack Sans Headline was designed by Koto and published to Google Fonts on 2025-10-03. It shared its upstream repository with Stack Sans Text and Stack Sans Notch, each built from a separate config YAML. The headline variant was built using `sources/config-headline.yaml`.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-10-03** — Emma Marichal, commit [`7b0b65a7e`](https://github.com/google/fonts/commit/7b0b65a7e) ("Stack Sans Headline: Version 1.000 added"): initial onboarding via gftools-packager. Created `ofl/stacksansheadline/` with the binary, OFL.txt, and METADATA.pb (source block recording `DylanYoungKoto/Stack-Sans@4b62a2ddf8c2ff3bb1c31bfe97c8fa3aab26a0cd`, shared with sibling Stack Sans Text and the later-onboarded Stack Sans Notch).

--- a/ofl/stacksansnotch/upstream_info.md
+++ b/ofl/stacksansnotch/upstream_info.md
@@ -28,3 +28,7 @@ The family covered the following subsets: latin, latin-ext.
 ## Notes
 
 Stack Sans Notch was designed by Koto and published to Google Fonts on 2025-10-16. It shared its upstream repository with Stack Sans Headline and Stack Sans Text, each built from a separate config YAML. The notch variant was built using `sources/config-notch.yaml` from a slightly later commit than its sibling families.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-10-16** — Emma Marichal, commit [`00ddfbc52`](https://github.com/google/fonts/commit/00ddfbc52) ("Stack Sans Notch: Version 1.000 added"): initial onboarding via gftools-packager. Created `ofl/stacksansnotch/` with the binary, OFL.txt, and METADATA.pb (source block recording `DylanYoungKoto/Stack-Sans@b9f1dbd88aa25563ed2ea60aa14ec4436e0c8015`). Sibling families Stack Sans Text and Stack Sans Headline were onboarded from the same upstream repo two weeks earlier (at an earlier commit `4b62a2ddf8c2ff3bb1c31bfe97c8fa3aab26a0cd`).

--- a/ofl/stacksanstext/upstream_info.md
+++ b/ofl/stacksanstext/upstream_info.md
@@ -28,3 +28,7 @@ The family covered the following subsets: latin, latin-ext.
 ## Notes
 
 Stack Sans Text was designed by Koto and published to Google Fonts on 2025-10-03. It shared its upstream repository (and the same commit) with Stack Sans Headline, each built from a separate config YAML. The text variant was built using `sources/config-text.yaml`.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-10-03** — Emma Marichal, commit [`66415ceab`](https://github.com/google/fonts/commit/66415ceab) ("Stack Sans Text: Version 1.000 added"): initial onboarding via gftools-packager. Created `ofl/stacksanstext/` with the binary, OFL.txt, and METADATA.pb (source block recording `DylanYoungKoto/Stack-Sans@4b62a2ddf8c2ff3bb1c31bfe97c8fa3aab26a0cd`, shared with sibling Stack Sans Headline and the later-onboarded Stack Sans Notch).

--- a/ofl/strichpunktsans/METADATA.pb
+++ b/ofl/strichpunktsans/METADATA.pb
@@ -37,5 +37,6 @@ source {
     dest_file: "StrichpunktSans[wdth,wght].ttf"
   }
   branch: "main"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SANS_SERIF"

--- a/ofl/strichpunktsans/upstream_info.md
+++ b/ofl/strichpunktsans/upstream_info.md
@@ -1,0 +1,82 @@
+# Strichpunkt Sans
+
+**Status**: `complete`
+**Date**: 2026-04-27
+**Designer**: René Bieder
+**License**: OFL
+**METADATA.pb**: `ofl/strichpunktsans/METADATA.pb`
+**Model**: Claude Opus 4.7 (1M context)
+
+## Data
+
+| Field | Value |
+|-------|-------|
+| Repository URL | https://github.com/strichpunkt-design/Strichpunkt_Sans |
+| Commit | `9a24fe35f229db9d86724550255429a86a9bb308` |
+| Config YAML | `sources/config.yaml` |
+| Branch | `main` |
+
+## Methodology
+
+### Repository URL
+Pre-existing in METADATA.pb `source { repository_url }` field. Verified to be the canonical upstream: the repo is owned by `strichpunkt-design`, the GitHub org of the German design and branding agency Strichpunkt (Stuttgart/Berlin/Hamburg/Basel), and the repo description is "Open source variable brand font family by Strichpunkt Design". The README credits René Bieder as the designer, matching METADATA.pb.
+
+### Commit Hash
+Pre-existing in METADATA.pb `source { commit }` field. Verified to exist upstream as the merge commit of `strichpunkt-design/Strichpunkt_Sans#7` "Add Strichpunkt Sans" (merged 2026-03-27, author emmamarichal) — the same person who onboarded the family in google/fonts.
+
+### Config YAML
+Found `sources/config.yaml` in the upstream repository at the recorded commit. It uses `recipeProvider: googlefonts` over `StrichpunktSans.glyphs` and produces `StrichpunktSans[wdth,wght].ttf` plus weight-only subspace variants (standard/Wide/Exp). No override needed in google/fonts.
+
+## Evidence
+
+### METADATA.pb source block
+- `repository_url`: `https://github.com/strichpunkt-design/Strichpunkt_Sans`
+- `commit`: `9a24fe35f229db9d86724550255429a86a9bb308`
+- `branch`: `main`
+- `config_yaml`: `sources/config.yaml` (added 2026-04-27 by this commit)
+- `files`: `OFL.txt` → `OFL.txt`, `fonts/variable/StrichpunktSans[wdth,wght].ttf` → `StrichpunktSans[wdth,wght].ttf`
+
+### Font binary verification
+`StrichpunktSans[wdth,wght].ttf` head/name tables:
+- `fontRevision`: 1.0
+- `head.created`: 2026-01-26 15:01:20
+- `head.modified`: 2026-03-26 16:51:09
+- `name[5]` Version: `Version 1.000`
+- `name[3]` Unique ID: `1.000;RENE;StrichpunktSans-Regular`
+- `name[8]` Manufacturer: `Studio Rene Bieder`
+- `name[11]` Vendor URL: `https://www.renebieder.com`
+
+The build modification date (2026-03-26) is one day prior to the upstream PR merge (2026-03-27), consistent with the binaries being committed to upstream by the merge, and four days before the google/fonts onboarding (2026-04-01). Designer string matches.
+
+### google/fonts history
+- Onboarding commit: `e4391053f` "Strichpunkt Sans: Version 1.000 added" (Emma Marichal, 2026-04-01) — added METADATA.pb, OFL.txt, the variable TTF, and stub article via `gftools-packager`.
+- Followups same day: `d17d28369` "Add article", `73d69bea3` "Add images", `4a067470d` "Update OFL.txt".
+- Onboarding PR: [google/fonts#10402](https://github.com/google/fonts/pull/10402) (branch `gftools_packager_ofl_strichpunktsans`, merged 2026-04-02). The packager commit message references the exact upstream commit `9a24fe35f...`.
+
+### Upstream repo archive
+Not yet mirrored in `/home/fsanches/compartilhado/upstream_repos/repo_archive/strichpunkt-design/`. Recommended to mirror when disk space permits (currently 21 GB free, near the 15 GB threshold).
+
+## Initial state
+- METADATA.pb already had a `source { ... }` block with `repository_url`, `commit`, `branch=main`, and `files` mappings (added by gftools-packager in `e4391053f`).
+- No `upstream_info.md` existed.
+- `config_yaml` field not set in METADATA.pb.
+
+## Actions taken
+- Verified the upstream repository is canonical and owned by Strichpunkt Design (designer René Bieder).
+- Confirmed commit `9a24fe35f` exists upstream as the merge commit of upstream PR #7 (merged 2026-03-27).
+- Confirmed `sources/config.yaml` exists at that commit with a googlefonts recipe over `StrichpunktSans.glyphs`.
+- Cross-checked font binary head/name tables: version 1.000, modified 2026-03-26, designer "Studio Rene Bieder" — consistent with the recorded commit.
+- Cross-checked onboarding PR #10402 description against the recorded commit hash — match.
+- Added `config_yaml: "sources/config.yaml"` to the METADATA.pb source block (the upstream config exists at the recorded commit and is fully functional; explicit field aids tooling).
+- Authored this `upstream_info.md`.
+
+## Final state
+- `upstream_info.md` present with full provenance.
+- METADATA.pb source block has `config_yaml: "sources/config.yaml"` set.
+- No override `config.yaml` needed.
+
+## Onboarding
+The family was onboarded to google/fonts in PR [#10402](https://github.com/google/fonts/pull/10402) by Emma Marichal on 2026-04-01 via `gftools-packager`, which produced the initial commit `e4391053f` referencing upstream commit `9a24fe35f229db9d86724550255429a86a9bb308`. The PR also included follow-up commits adding the article (`d17d28369`), uploading article images (`73d69bea3`), and an `OFL.txt` correction (`4a067470d`). The `4a067470d` "Update OFL.txt" commit on 2026-04-01 fixed a 1-line discrepancy in the OFL header (the copyright/repo URL).
+
+## Confidence
+**High**: Upstream URL verified canonical; commit verified to exist upstream and to predate the google/fonts merge; binary version, designer, and dates align with the recorded commit; onboarding PR description corroborates the commit hash.

--- a/ofl/suse/upstream_info.md
+++ b/ofl/suse/upstream_info.md
@@ -29,3 +29,10 @@ The family covered the following subsets: latin, latin-ext, vietnamese.
 ## Notes
 
 SUSE was designed by René Bieder and published to Google Fonts on 2024-08-14. The font was developed by SUSE, the open-source software company, and hosted under their GitHub organization. Fonts were sourced from release archive v2.001. The same upstream repository also contained the SUSE Mono companion family.
+
+## Recent upstream/main activity (post-investigation)
+
+A multi-commit revision sequence took the SUSE family from v1.000 → v2.001 between 2025-08-20 and 2025-09-10:
+
+- **2025-08-20** — Simon Cozens, commit [`074fdad09`](https://github.com/google/fonts/commit/074fdad09) ("SUSE: Version 2.000 added"): v1.000 → v2.000 via gftools-packager. Advanced `commit` from `f315ee46344ccc4f8d470cee3644b7bc99cadbaa` to `7159afb2555b06d3a5c2f90e4d324e59e69c277d` and removed the legacy v1.000 `archive_url`. Same upstream commit also produced the v2.000 SUSE Mono onboarding (sibling family).
+- **2025-09-10** — Emma Marichal, commits [`eb2c62d50`](https://github.com/google/fonts/commit/eb2c62d50), [`29d4f58b2`](https://github.com/google/fonts/commit/29d4f58b2), [`34560ce5c`](https://github.com/google/fonts/commit/34560ce5c) ("update", "bump version to 2.001", "small update in metadata.pb"): three same-day commits to bump the family to v2.001 (binary updates plus metadata adjustments).

--- a/ofl/susemono/upstream_info.md
+++ b/ofl/susemono/upstream_info.md
@@ -29,3 +29,8 @@ The family covered the following subsets: latin, latin-ext, vietnamese.
 ## Notes
 
 SUSE Mono was designed by René Bieder and published to Google Fonts on 2025-08-20. It was the monospace companion to the SUSE family, sharing the same upstream repository, commit, and release archive (v2.001). The repository was maintained by SUSE, the open-source software company.
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-08-20** — Simon Cozens, commit [`a201be467`](https://github.com/google/fonts/commit/a201be467) ("SUSE Mono: Version 2.000 added"): initial onboarding via gftools-packager. Created `ofl/susemono/` with source block referencing `SUSE/suse-font@7159afb2555b06d3a5c2f90e4d324e59e69c277d` (shared with SUSE sibling family). archive_url points to the v2.000 release zip.
+- **2025-09-10** — Emma Marichal, commits [`175b42844`](https://github.com/google/fonts/commit/175b42844), [`d4128f783`](https://github.com/google/fonts/commit/d4128f783) ("update + bump version", "update metadata.pb"): two same-day commits paralleling the SUSE family's v2.001 update (binary + metadata).

--- a/ofl/yuseimagic/upstream_info.md
+++ b/ofl/yuseimagic/upstream_info.md
@@ -24,3 +24,7 @@ Branch: master
 Status: commit hash added
 Confidence: high (verified via GitHub API)
 ```
+
+## Recent upstream/main activity (post-investigation)
+
+- **2026-01-09** — evanwadams (Google), commit [`254f22c5e`](https://github.com/google/fonts/commit/254f22c5e) ("Update METADATA.pb (#10121)"): corrected the ISO 15924 script code in `primary_script` from `"Japn"` to `"Jpan"` (the canonical 4-letter code for Japanese). Edit is outside the `source { ... }` block; no source-block impact.

--- a/ofl/zain/upstream_info.md
+++ b/ofl/zain/upstream_info.md
@@ -9,3 +9,7 @@
 Zain was designed by Boutros Fonts as a static sans-serif Arabic typeface also covering Latin. The font was sourced from the `googlefonts/zain` repository at the commit listed above. Eight static TTF files were copied from `Fonts/TTF/` to the Google Fonts distribution, covering ExtraLight, Light, Light Italic, Regular, Italic, Bold, ExtraBold, and Black weights.
 
 **Model**: Claude Opus 4.6
+
+## Recent upstream/main activity (post-investigation)
+
+- **2025-10-10** — Emma Marichal, commit [`6e5d44d3a`](https://github.com/google/fonts/commit/6e5d44d3a) ("Zain: Version 2.000; ttfautohint (v1.8.4) added"): version bump to v2.000. METADATA.pb commit field advanced from `20ee949e2aee939aa5986703ce0bf6036dc71b32` to `7c4a81812cee52243a8b52cc362650042b831d28`. Binary updated.

--- a/ofl/zalandosans/upstream_info.md
+++ b/ofl/zalandosans/upstream_info.md
@@ -1,12 +1,18 @@
 # Zalando Sans — Upstream Source Information
 
 **Repo:** https://github.com/zalando/sans
-**Commit:** `2fe06d0700b5b9ccd18a52c240e8927f48e92629`
+**Commit:** `4e44d0864c4e37ab67fa549cd188aec8776dc948` (updated 2026-03-11; was `2fe06d0700b5b9ccd18a52c240e8927f48e92629`)
 **Branch:** main
 **Config:** `sources/config.yaml`
+
+**Model**: Claude Opus 4.6 / Claude Opus 4.7 (1M context) [appendix]
 
 ## Summary
 
 Zalando Sans was designed by Jakob Ekelund, KH Type, and Zalando as a variable sans-serif typeface with both width and weight axes, supporting Latin and Latin Extended subsets. The font was sourced from the `zalando/sans` repository at the commit listed above (shared with Zalando Sans Expanded and Zalando Sans SemiExpanded). Two variable font files were copied from `fonts/variable/` to the Google Fonts distribution: `ZalandoSans[wdth,wght].ttf` and `ZalandoSans-Italic[wdth,wght].ttf`. The width axis spans from 75 (Condensed) to 125 (Expanded) and the weight axis spans from 200 to 900.
 
-**Model**: Claude Opus 4.6
+## Recent upstream/main activity (post-investigation)
+
+- **2026-03-11** — Emma Marichal, commit [`7644e9a8c`](https://github.com/google/fonts/commit/7644e9a8c) ("Zalando Sans: Version 1.800 added"): advanced the recorded commit from `2fe06d0700b5b9ccd18a52c240e8927f48e92629` to `4e44d0864c4e37ab67fa549cd188aec8776dc948` and updated the binaries to v1.800. The same upstream commit also produced v1.800 binaries for Zalando Sans Expanded and Zalando Sans SemiExpanded (sibling families); see their respective `upstream_info.md`.
+
+The shipping `ZalandoSans[wdth,wght].ttf` (281728 bytes, md5 `5f48eb1963e54fe8ca1a6334d31bbb08`) is byte-identical to upstream `fonts/variable/ZalandoSans[wdth,wght].ttf` at commit `4e44d0864`. `head.fontRevision = 1.8000`, `name` ID 5 = "Version 1.800".

--- a/ofl/zalandosansexpanded/upstream_info.md
+++ b/ofl/zalandosansexpanded/upstream_info.md
@@ -1,12 +1,18 @@
 # Zalando Sans Expanded — Upstream Source Information
 
 **Repo:** https://github.com/zalando/sans
-**Commit:** `2fe06d0700b5b9ccd18a52c240e8927f48e92629`
+**Commit:** `4e44d0864c4e37ab67fa549cd188aec8776dc948` (updated 2026-03-11; was `2fe06d0700b5b9ccd18a52c240e8927f48e92629`)
 **Branch:** main
 **Config:** `sources/config.yaml`
+
+**Model**: Claude Opus 4.6 / Claude Opus 4.7 (1M context) [appendix]
 
 ## Summary
 
 Zalando Sans Expanded was designed by Jakob Ekelund, KH Type, and Zalando as a variable sans-serif typeface in the expanded width, supporting Latin and Latin Extended subsets. The font was sourced from the `zalando/sans` repository at the commit listed above (shared with Zalando Sans and Zalando Sans SemiExpanded). Two variable font files were copied from `fonts/variable/` to the Google Fonts distribution: `ZalandoSansExpanded[wght].ttf` and `ZalandoSansExpanded-Italic[wght].ttf`. The weight axis spans from 200 to 900.
 
-**Model**: Claude Opus 4.6
+## Recent upstream/main activity (post-investigation)
+
+- **2026-03-11** — Emma Marichal, commit [`11dd65db3`](https://github.com/google/fonts/commit/11dd65db3) ("Zalando Sans Expanded: Version 1.800 added"): advanced the recorded commit from `2fe06d0700b5b9ccd18a52c240e8927f48e92629` to `4e44d0864c4e37ab67fa549cd188aec8776dc948` and updated the binaries to v1.800. The same upstream commit also produced v1.800 for Zalando Sans and Zalando Sans SemiExpanded (sibling families).
+
+The shipping `ZalandoSansExpanded[wght].ttf` (146688 bytes, md5 `df4134248fec358a0b9f8189f64692a0`) is byte-identical to upstream `fonts/variable/ZalandoSansExpanded[wght].ttf` at commit `4e44d0864`. `head.fontRevision = 1.8000`, `name` ID 5 = "Version 1.800".

--- a/ofl/zalandosanssemiexpanded/upstream_info.md
+++ b/ofl/zalandosanssemiexpanded/upstream_info.md
@@ -1,12 +1,18 @@
 # Zalando Sans SemiExpanded — Upstream Source Information
 
 **Repo:** https://github.com/zalando/sans
-**Commit:** `2fe06d0700b5b9ccd18a52c240e8927f48e92629`
+**Commit:** `4e44d0864c4e37ab67fa549cd188aec8776dc948` (updated 2026-03-11; was `2fe06d0700b5b9ccd18a52c240e8927f48e92629`)
 **Branch:** main
 **Config:** `sources/config.yaml`
+
+**Model**: Claude Opus 4.6 / Claude Opus 4.7 (1M context) [appendix]
 
 ## Summary
 
 Zalando Sans SemiExpanded was designed by Jakob Ekelund, KH Type, and Zalando as a variable sans-serif typeface in the semi-expanded width, supporting Latin and Latin Extended subsets. The font was sourced from the `zalando/sans` repository at the commit listed above (shared with Zalando Sans and Zalando Sans Expanded). Two variable font files were copied from `fonts/variable/` to the Google Fonts distribution: `ZalandoSansSemiExpanded[wght].ttf` and `ZalandoSansSemiExpanded-Italic[wght].ttf`. The weight axis spans from 200 to 900.
 
-**Model**: Claude Opus 4.6
+## Recent upstream/main activity (post-investigation)
+
+- **2026-03-11** — Emma Marichal, commit [`7b157e89b`](https://github.com/google/fonts/commit/7b157e89b) ("Zalando Sans SemiExpanded: Version 1.800 added"): advanced the recorded commit from `2fe06d0700b5b9ccd18a52c240e8927f48e92629` to `4e44d0864c4e37ab67fa549cd188aec8776dc948` and updated the binaries to v1.800. The same upstream commit also produced v1.800 for Zalando Sans and Zalando Sans Expanded (sibling families).
+
+The shipping `ZalandoSansSemiExpanded[wght].ttf` (148796 bytes, md5 `c5e73466a91290fba040ea08360ed865`) is byte-identical to upstream `fonts/variable/ZalandoSansSemiExpanded[wght].ttf` at commit `4e44d0864`. `head.fontRevision = 1.8000`, `name` ID 5 = "Version 1.800".

--- a/ofl/zcoolkuaile/upstream_info.md
+++ b/ofl/zcoolkuaile/upstream_info.md
@@ -24,3 +24,13 @@ Branch: main (default)
 Status: commit hash added
 Confidence: high (verified via GitHub API)
 ```
+
+## Recent upstream/main activity (post-investigation)
+
+Three Aaron Bell commits affected the family between 2025-11-21 and 2026-01-29:
+
+- **2025-11-21** — Aaron Bell, commit [`9b9bd8a16`](https://github.com/google/fonts/commit/9b9bd8a16) ("Update ZCOOLKuaiLe-Regular.ttf"): replaced the binary (3275404 → 1514832 bytes — substantial size reduction, likely subset/build optimisation). Binary-only commit; METADATA.pb untouched.
+- **2026-01-29** — Aaron Bell, commit [`a606d6f31`](https://github.com/google/fonts/commit/a606d6f31) ("Updating the font to fix fonspector fails"): broader fix touching the binary, DESCRIPTION.en_us.html, OFL.txt, and METADATA.pb (B+D+L+M flags). Source block change was minor — not a `commit`/`repository_url` change but a sibling field tweak.
+- **2026-01-29** — Aaron Bell, commit [`1874af3a7`](https://github.com/google/fonts/commit/1874af3a7) ("URL fix"): URL formatting cleanup in DESCRIPTION.en_us.html and OFL.txt.
+
+The recorded `commit` field in METADATA.pb still refers to the post-onboarding upstream state; it has not advanced to reflect Aaron's local rebuild. Per the same pattern documented for Kurale, this is a known gap — the rebuild was done locally with post-processing, not pushed upstream, so the recorded commit identifies the *source state* but does not byte-reproduce the shipping binary.


### PR DESCRIPTION
> **Note**: This post was generated by an AI agent (Claude) working under the guidance of @felipesanches, who is now reviewing it.

## Summary

This PR closes a **9-month gap between the existing `upstream_info.md` investigation reports and the current state of `upstream/main`**. For every substantive commit on `upstream/main` between **2025-08-01 and 2026-04-27** other than the investigation report ones (198 commits across 78 families), the corresponding family's `upstream_info.md` now explicitly documents the change, and a small set of real bugs in METADATA.pb `source { ... }` blocks have been corrected.

The bulk of the changes are mechanical "Recent upstream/main activity" appendix sections appended to existing reports. A handful of families needed real source-block fixes (Kurale, Noto Sans Kannada, Coustard) and four families needed a `upstream_info.md` written from scratch (BJCree, Estedad, Saira Stencil, Strichpunkt Sans).

## Scope and approach

- **Audit window**: 2026-04-24 → 2025-08-01 on `upstream/main`.
- **Total substantive commits considered**: 198 (out of 1,885 commits in that window — 987 by @felipesanches, the rest filtered out as cosmetic-only or out-of-scope).
- **Methodology**: walked the commits newest-first, grouped by family, classified each commit's signature (binary / METADATA / config / license / description), spawned parallel investigation agents only for the four families that lacked `upstream_info.md`, and authored or appended provenance text per family.
- **Verification**: for version-bump commits, the shipping TTF was md5-compared against the upstream binary blob at the recorded commit, where the upstream tree-of-record contains the binary. Identified mismatches led to either source-block fixes (Notosanskannada, Coustard, Kurale documentation) or explicit "rebuild not pushed upstream" provenance notes (Kurale, Zcool Kuaile).

## Statistics

| Item | Count |
|---|---|
| Commits on the branch | 90 |
| Unique families touched | 78 |
| `upstream_info.md` files **created** | 4 (BJCree, Estedad, Saira Stencil, Strichpunkt Sans) |
| `upstream_info.md` files **modified** (appendix added) | 76 |
| `METADATA.pb` files **modified** | 7 (Coustard, Estedad, Kurale, Noto Sans Kannada, Saira Stencil, Strichpunkt Sans, plus the Coustard copyright fix) |

## Notable real bug fixes (not just appendices)

These are the changes a reviewer should look at most carefully:

### `ofl/kurale/METADATA.pb` — three bugs in the source block

Simon Cozens' 2026-02-27 "Rebuild and update kurale" commit introduced three issues that this PR corrects:

1. `repository_url` had a redundant `www.` prefix → trimmed to `https://github.com/etunni/kurale`.
2. `source_file: "fonts/ttf/Kurale-Regular.ttf"` referenced a non-existent path → corrected to `fonts/Kurale-Regular.ttf` (the actual location at the recorded commit).
3. `branch: "main"` did not match the upstream default → corrected to `branch: "master"` (verified against `etunni/kurale` HEAD).

The `upstream_info.md` also documents a provenance caveat: the shipping `Kurale-Regular.ttf` is *not* byte-identical to the upstream binary at the recorded commit because Simon ran `ttfautohint` locally and never pushed the autohinted result upstream. The recorded `commit` therefore identifies the source state but does not reproduce the shipping binary directly.

### `ofl/notosanskannada/METADATA.pb` — out-of-sync after binary-only update

Aaron Bell's 2026-02-25 "Updating Noto Sans Kannada" commit replaced the shipping binary (v2.005 → v2.006) but didn't touch METADATA.pb, leaving `commit` and `archive_url` referencing v2.005. Both fields are now updated:

- `commit`: `6387faa16…` → `7eeac8993f890e3d8568ba909ae67f554113ea92` (the v2.006 tag commit upstream).
- `archive_url`: `…NotoSansKannada-v2.005/…` → `…NotoSansKannada-v2.006/…`.

### `ofl/coustard/METADATA.pb` — modernised upstream + copyright typo

Two changes:
1. `config_yaml: "sources/config.yaml"` added — the new `googlefonts/coustardFont` fork (Emma's modernisation of the legacy `vernnobile/coustardFont`) ships a working `gftools-builder` config at the recorded commit, so the field can finally be set. This resolves a long-standing `missing_config` status.
2. Both `fonts { ... copyright }` strings corrected from `https://github.com/googlefonts/bangers` (a copy-paste typo introduced by Emma's `gftools-packager` run for v1.100) to `https://github.com/googlefonts/coustardFont`.

### `ofl/estedad/METADATA.pb`, `ofl/sairastencil/METADATA.pb`, `ofl/strichpunktsans/METADATA.pb` — `config_yaml` field added

For each of these families, the upstream repo ships a working `sources/config.yaml` at the recorded commit, but the field was missing from METADATA.pb. Adding it lets `gftools-builder` and `fontc_crater` build directly from upstream sources.

### `ofl/balsamiqsans/upstream_info.md` — status promoted

The original investigation flagged the recorded commit as wrong; @felipesanches fixed that on 2026-02-27 (commit `f31a1ea94`) but the report's "Status: needs_correction" line never got updated. Promoted to `complete`.

### `ofl/grenze/upstream_info.md` — significant upstream improvements documented

The original 2026-02 investigation called out three issues with `Omnibus-Type/Grenze`: a single squashed commit (no history), a `config.yaml` STAT table copy-pasta from Texturina, and a case-mismatch on `Sources/` vs `sources/`. **All three are resolved upstream as of the recorded commit `e1be2f305`** — full history is back, the STAT table targets `Grenze[wght].ttf` correctly, and both glyphs sources now live at lowercase `sources/`. Status promoted from `needs_correction` / MEDIUM to `complete` / HIGH.

## Provenance verifications I performed

For every binary-bump commit where the upstream tree-of-record contains the binary, I md5-compared the shipping TTF against the upstream blob at the recorded commit:

- **Byte-identical confirmed**: EB Garamond v1.002, Geist v1.800, Geist Mono v1.700, Grenze v1.003, Strichpunkt Sans v1.000, Saira Stencil v1.101, Estedad v8.5, BJCree v7.000, Climate Crisis v1.007, Mingzat v1.200, Zalando Sans / Expanded / SemiExpanded v1.800, Coustard v1.100.
- **Not byte-identical, with documented provenance caveat**: Kurale (ttfautohint applied locally and not pushed upstream), Zcool Kuaile (Aaron's local fontspector-fixes rebuild not pushed upstream).
- **Archive-based families** (binaries from a release zip, not the git tree): not md5-verified directly; provenance follows the recorded `commit` + `archive_url` pair.

## Files changed

84 files total: 80 modified + 4 created. All under `ofl/`. No `apache/`, `ufl/`, or non-family-directory changes.

Out-of-scope deletions captured but not modified: 9 commit-family pairs touched the `ofl/bbhsanshegarty/`, `ofl/bbhsansbogle/`, `ofl/bbhsansbartle/` directories which were renamed away (Sep–Nov 2025) and no longer exist. Their semantic content (the rename) is captured in the new `bbhhegarty`, `bbhbogle`, `bbhbartle` family reports already on `upstream/main`.

## Interesting findings worth flagging to maintainers

- **Repo migrations**: Coustard moved from the dormant `vernnobile/coustardFont` (SFD-only) to the modernised `googlefonts/coustardFont` fork. Cossette moved from `cossette/cossette-fonts` to `googlefonts/cossette-fonts`.
- **Static-to-variable migration**: Capriola v1.007 onboarded a `Capriola[wght].ttf` variable file replacing the static `Capriola-Regular.ttf`, with the upstream pointing to a `SorkinType/Capriola-VF` fork.
- **EB Garamond v1.001-vs-v1.002 labelling discrepancy**: Emma's commit subject says "Version 1.001 added" but the binaries produced by upstream `106a4a6d3` are actually v1.002 (`fontRevision = 1.0020`, name table reads "Version 1.002"). The commit subject is a labelling slip by `gftools-packager`; the binary itself is v1.002 and matches md5 with the upstream blob.

## Out of scope / follow-ups

- Two unmerged upstream PR branches (`upstream/cousine-ofl` and `upstream/tinos-ofl`) propose OFL relicensing of Cousine and Tinos. Those will be candidates for a follow-up sync once they merge.
- Several `upstream_info.md` files have remaining "Open Questions" that this audit did not address (e.g., Adamina v1.013-vs-v1.012 source provenance; Bpmf trio's `aaronbell/bpmfvs` vs `ButTaiwan/bpmfvs` repo URL question; Roboto Mono's exact commit hash provenance pre-rebuild). These are pre-existing open items, not introduced by this PR.


**AI assistant model**: Claude Opus 4.7 (1M context).