### PR TITLE
[CI – Text Font Tags] Fix duplicate check

### DIFF
--- a/.ci/test_font_tags.py
+++ b/.ci/test_font_tags.py
@@ -78,7 +78,7 @@ def test_no_duplicate_families(family_tags):
     for family, axes, cat, _ in family_tags:
         key = (family, axes, cat)
         if key in seen:
-            dups.append(",".join([family, axes, cat]))
+            dups.append(",".join(key))
         seen.add(key)
     assert not dups, f"Duplicate tags found: {dups}"
 

--- a/.ci/test_font_tags.py
+++ b/.ci/test_font_tags.py
@@ -76,9 +76,9 @@ def test_no_duplicate_families(family_tags):
     seen = set()
     dups = []
     for family, axes, cat, _ in family_tags:
-        key = (family, cat)
+        key = (family, axes, cat)
         if key in seen:
-            dups.append(",".join(key))
+            dups.append(",".join([family, axes, cat]))
         seen.add(key)
     assert not dups, f"Duplicate tags found: {dups}"
 


### PR DESCRIPTION
Ci crashed when we have this:

```
Maven Pro,wght@400,/Expressive/Loud,1
Maven Pro,wght@900,/Expressive/Loud,88
```

I've updated the check

@m4rc1e what do you think?