### PR TITLE
Document legacy upstream sources for 195 families

### DIFF
--- a/ofl/abel/config.yaml
+++ b/ofl/abel/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Abel-Regular-TTF.sfd
+  - src/Abel-Regular-TTF.vfb
+  - src/Abel-Regular.vfb
+familyName: Abel

--- a/ofl/abel/upstream_info.md
+++ b/ofl/abel/upstream_info.md
@@ -51,3 +51,9 @@ The font was likely compiled from the `.sfd` or `.vfb` sources using FontForge o
 1. Can the .sfd sources in the upstream repo be used to reproduce the current font binary in google/fonts? The font was modified directly in google/fonts after onboarding (kerning fix PR #2352, version hotfix PR #741), so the upstream sources likely do not match the current binary.
 2. Should an override config.yaml be created for this family? Given that the sources are in .sfd format (not supported by gftools-builder), this would require conversion to .glyphs or .ufo format first.
 3. The copyright field lists "Matthew Desmond (http://www.madtype.com)" -- the designer credit says "MADType" which is Matthew Desmond's studio. The HTTP URL in the copyright may or may not still be valid.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/abel/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `adf2c7e74e`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/abrilfatface/config.yaml
+++ b/ofl/abrilfatface/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/AbrilFatface-Regular-TTF.sfd
+  - src/AbrilFatface-Regular.vfb
+familyName: "Abril Fatface"

--- a/ofl/abrilfatface/upstream_info.md
+++ b/ofl/abrilfatface/upstream_info.md
@@ -55,3 +55,9 @@ These source formats are not compatible with gftools-builder, which requires `.g
 - Since the source formats (SFD/VFB) are not gftools-builder compatible, is there a plan to convert the sources to a modern format?
 - Should METADATA.pb be updated to include a `source { }` block pointing to this repo, even though it cannot be built with gftools-builder?
 - The font has been in Google Fonts since 2011 and has not been updated since the initial commit. Is an update planned?
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/abrilfatface/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `5e899bfd99`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/acme/config.yaml
+++ b/ofl/acme/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Acme-Regular-OTF.vfb
+  - src/Acme-Regular-TTF.sfd
+  - src/Acme-Regular.vfb
+familyName: Acme

--- a/ofl/acme/upstream_info.md
+++ b/ofl/acme/upstream_info.md
@@ -57,3 +57,9 @@ These source formats are not compatible with gftools-builder. A config.yaml cann
 - Since the source formats (SFD/VFB) are not gftools-builder compatible, is there a plan to convert the sources to a modern format?
 - Should METADATA.pb be updated to include a `source { }` block pointing to this repo, even though it cannot be built with gftools-builder?
 - PR #743 was a hotfix in 2017. Has the font had any substantive updates since its original release?
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/acme/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `fa0a4445fe`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/actor/config.yaml
+++ b/ofl/actor/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Actor-Regular-TTF.vfb
+  - src/Actor-Regular.vfb
+familyName: Actor

--- a/ofl/actor/upstream_info.md
+++ b/ofl/actor/upstream_info.md
@@ -59,3 +59,9 @@ The font would need to be converted from VFB to a modern format (e.g., `.glyphs`
 1. Should the METADATA.pb be updated to include a `source { repository_url }` block pointing to `https://github.com/librefonts/actor`?
 2. Is there a plan to convert the VFB sources to `.glyphs` or `.ufo` format to enable modern builds?
 3. Does Thomas Junold have the original editable sources in a more modern format?
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/actor/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `b1617e5929`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/aguafinascript/config.yaml
+++ b/ofl/aguafinascript/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Aguafina-Regular-OTF.vfb
+  - src/AguafinaScript-Regular-TTF.sfd
+familyName: "Aguafina Script"

--- a/ofl/aguafinascript/upstream_info.md
+++ b/ofl/aguafinascript/upstream_info.md
@@ -54,3 +54,9 @@ The repo also contains TTX table dumps of the font, METADATA.json, and a DESCRIP
 2. Should a source block be added to METADATA.pb pointing to the librefonts repo, even though there is no config.yaml and the sources are in legacy formats?
 3. Could the SFD source be converted to a modern format (e.g., UFO) to enable gftools-builder compatibility, or is this font effectively in a "legacy binary only" state?
 4. The copyright lists reserved font name "Aguafina Script" -- does this affect any potential source modifications?
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/aguafinascript/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `45a8ce768b`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/aladin/config.yaml
+++ b/ofl/aladin/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Aladin-OTF.vfb
+  - src/Aladin-Regular-TTF.sfd
+familyName: Aladin

--- a/ofl/aladin/upstream_info.md
+++ b/ofl/aladin/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/aladin/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `0f5d0578e5`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/aldrich/config.yaml
+++ b/ofl/aldrich/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Aldrich-Regular-TTF.vfb
+  - src/Aldrich-Regular.vfb
+familyName: Aldrich

--- a/ofl/aldrich/upstream_info.md
+++ b/ofl/aldrich/upstream_info.md
@@ -49,3 +49,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 No buildable source files at recorded commit
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/aldrich/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `ec28a1d125`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/alfaslabone/config.yaml
+++ b/ofl/alfaslabone/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/AlfaSlabOne-Regular-OTF.vfb
+  - src/AlfaSlabOne-Regular-TTF.vfb
+  - src/AlfaSlabOne-Regular.vfb
+familyName: "Alfa Slab One"

--- a/ofl/alfaslabone/upstream_info.md
+++ b/ofl/alfaslabone/upstream_info.md
@@ -49,3 +49,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 No buildable source files at recorded commit
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/alfaslabone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `84a903ffba`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/allan/config.yaml
+++ b/ofl/allan/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Allan-Bold-TTF.sfd
+  - src/Allan-Regular-TTF.sfd
+familyName: Allan

--- a/ofl/allan/upstream_info.md
+++ b/ofl/allan/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/allan/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `91202d58a3`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/allerta/config.yaml
+++ b/ofl/allerta/config.yaml
@@ -1,0 +1,13 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Allerta-Regular-TTF.sfd
+  - src/Allerta-Regular.sfd
+  - src/Allerta-Regular.vfb
+  - src/AllertaStencil-Regular-TTF.sfd
+  - src/AllertaStencil-Regular.sfd
+  - src/AllertaStencil-Regular.vfb
+familyName: Allerta

--- a/ofl/allerta/upstream_info.md
+++ b/ofl/allerta/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/allerta/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `88a8c57b94`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/allertastencil/config.yaml
+++ b/ofl/allertastencil/config.yaml
@@ -1,0 +1,13 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Allerta-Regular-TTF.sfd
+  - src/Allerta-Regular.sfd
+  - src/Allerta-Regular.vfb
+  - src/AllertaStencil-Regular-TTF.sfd
+  - src/AllertaStencil-Regular.sfd
+  - src/AllertaStencil-Regular.vfb
+familyName: "Allerta Stencil"

--- a/ofl/allertastencil/upstream_info.md
+++ b/ofl/allertastencil/upstream_info.md
@@ -49,3 +49,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/allertastencil/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `88a8c57b94`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/almendra/config.yaml
+++ b/ofl/almendra/config.yaml
@@ -1,0 +1,15 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Almendra-Bold-OTF.vfb
+  - src/Almendra-Bold-TTF.sfd
+  - src/Almendra-BoldItalic-OTF.vfb
+  - src/Almendra-BoldItalic-TTF.sfd
+  - src/Almendra-Italic-OTF.vfb
+  - src/Almendra-Italic-TTF.sfd
+  - src/Almendra-Regular-OTF.vfb
+  - src/Almendra-Regular-TTF.sfd
+familyName: Almendra

--- a/ofl/almendra/upstream_info.md
+++ b/ofl/almendra/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/almendra/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `4050b694e0`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/almendradisplay/config.yaml
+++ b/ofl/almendradisplay/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/AlmendraDisplay-Regular-OTF.vfb
+  - src/AlmendraDisplay-Regular-TTF.sfd
+familyName: "Almendra Display"

--- a/ofl/almendradisplay/upstream_info.md
+++ b/ofl/almendradisplay/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/almendradisplay/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `b252e05aad`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/almendrasc/config.yaml
+++ b/ofl/almendrasc/config.yaml
@@ -1,0 +1,14 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/AlmendraSC-Bold-OTF.vfb
+  - src/AlmendraSC-Bold-TTF.sfd
+  - src/AlmendraSC-BoldItalic-OTF.vfb
+  - src/AlmendraSC-BoldItalic-TTF.sfd
+  - src/AlmendraSC-Italic-OTF.vfb
+  - src/AlmendraSC-Regular-OTF.vfb
+  - src/AlmendraSC-Regular-TTF.sfd
+familyName: "Almendra SC"

--- a/ofl/almendrasc/upstream_info.md
+++ b/ofl/almendrasc/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/almendrasc/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `35906cd6a2`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/amarante/config.yaml
+++ b/ofl/amarante/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Amarante-Regular-OTF.sfd
+  - src/Amarante-Regular-TTF.sfd
+  - src/Amarante-Regular.vfb
+familyName: Amarante

--- a/ofl/amarante/upstream_info.md
+++ b/ofl/amarante/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/amarante/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `e5bd4a9524`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/annieuseyourtelescope/config.yaml
+++ b/ofl/annieuseyourtelescope/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/AnnieUseYourTelescope.vfb
+familyName: "Annie Use Your Telescope"

--- a/ofl/annieuseyourtelescope/upstream_info.md
+++ b/ofl/annieuseyourtelescope/upstream_info.md
@@ -49,3 +49,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 No buildable source files at recorded commit
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/annieuseyourtelescope/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `0895f3f4e7`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/antic/config.yaml
+++ b/ofl/antic/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Antic-Regular-TTF.sfd
+familyName: Antic

--- a/ofl/antic/upstream_info.md
+++ b/ofl/antic/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/antic/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `928c13650d`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/anticdidone/config.yaml
+++ b/ofl/anticdidone/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/AnticDidone-Regular-OTF.vfb
+  - src/AnticDidone-Regular-TTF.sfd
+  - src/AnticDidone-Regular.vfb
+familyName: "Antic Didone"

--- a/ofl/anticdidone/upstream_info.md
+++ b/ofl/anticdidone/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/anticdidone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `604bfcda35`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/anticslab/config.yaml
+++ b/ofl/anticslab/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/AnticSlab-Regular-OTF.vfb
+  - src/AnticSlab-Regular-TTF.sfd
+  - src/AnticSlab-Regular.vfb
+familyName: "Antic Slab"

--- a/ofl/anticslab/upstream_info.md
+++ b/ofl/anticslab/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/anticslab/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `6416875377`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/arbutus/config.yaml
+++ b/ofl/arbutus/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Arbutus-Regular-TTF.sfd
+  - src/Arbutus-Regular.vfb
+familyName: Arbutus

--- a/ofl/arbutus/upstream_info.md
+++ b/ofl/arbutus/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/arbutus/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `413fe5b212`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/arbutusslab/config.yaml
+++ b/ofl/arbutusslab/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/ArbutusSlab-Regular.otf.sfd
+  - src/ArbutusSlab-Regular.ttf.sfd
+  - src/ArbutusSlab-Regular.vfb
+familyName: "Arbutus Slab"

--- a/ofl/arbutusslab/upstream_info.md
+++ b/ofl/arbutusslab/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/arbutusslab/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `2988f79c4d`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/architectsdaughter/config.yaml
+++ b/ofl/architectsdaughter/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/ArchitectsDaughter-TTF.sfd
+  - src/ArchitectsDaughter.vfb
+familyName: "Architects Daughter"

--- a/ofl/architectsdaughter/upstream_info.md
+++ b/ofl/architectsdaughter/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/architectsdaughter/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `1a94ca0aea`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/armata/config.yaml
+++ b/ofl/armata/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Armata-Regular-OTF.sfd
+  - src/Armata-Regular-TTF.sfd
+  - src/Armata-Regular.vfb
+familyName: Armata

--- a/ofl/armata/upstream_info.md
+++ b/ofl/armata/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/armata/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `fbbc7c2575`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/arvo/config.yaml
+++ b/ofl/arvo/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - Workfiles/Arvo_Fontlab/Arvo_MM_sorce/Arvo_ita_MM_54_b_sorce.vfb
+  - Workfiles/Arvo_Fontlab/Arvo_MM_sorce/Arvo_reg_MM_12b_2TT_sorce.vfb
+familyName: Arvo

--- a/ofl/arvo/upstream_info.md
+++ b/ofl/arvo/upstream_info.md
@@ -42,3 +42,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 No buildable source files at recorded commit
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/arvo/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `ae906e99ab`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/astloch/config.yaml
+++ b/ofl/astloch/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Astloch-Bold-TTF.sfd
+  - src/Astloch-Bold.vfb
+  - src/Astloch-Regular-TTF.sfd
+  - src/Astloch-Regular.vfb
+familyName: Astloch

--- a/ofl/astloch/upstream_info.md
+++ b/ofl/astloch/upstream_info.md
@@ -50,3 +50,9 @@ No source block present in METADATA.pb.
 ## Notes
 
 SFD-only sources (FontForge format), not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/astloch/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `d15f7a51db`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/asul/config.yaml
+++ b/ofl/asul/config.yaml
@@ -1,0 +1,13 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Asul-Bold-OTF.vfb
+  - src/Asul-Bold-TTF.sfd
+  - src/Asul-Bold.vfb
+  - src/Asul-Regular-OTF.vfb
+  - src/Asul-Regular-TTF.sfd
+  - src/Asul-Regular.vfb
+familyName: Asul

--- a/ofl/asul/upstream_info.md
+++ b/ofl/asul/upstream_info.md
@@ -46,3 +46,9 @@ Building from SFD sources would require a different build pipeline or a manual c
 1. Were the TTF files in google/fonts compiled from the SFD sources in this upstream repo, or were they provided separately by the designer?
 2. Is there a different upstream repository with the actual build sources (e.g., .glyphs or .ufo files)?
 3. The commit is from 2014 but the font was updated in google/fonts in 2017 -- was a newer version compiled from these same sources with updated tooling?
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/asul/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `687362de82`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/atomicage/config.yaml
+++ b/ofl/atomicage/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - SRC/AtomicAge-Regular.vfb
+familyName: "Atomic Age"

--- a/ofl/atomicage/upstream_info.md
+++ b/ofl/atomicage/upstream_info.md
@@ -50,3 +50,9 @@ The only source file in the repo is a VFB (FontLab) binary: `SRC/AtomicAge-Regul
 
 - The google/fonts version is v1.008 but the upstream only has v1.007. The v1.008 changes appear to be direct binary modifications (copyright and metadata updates per the METADATA.pb diff). Should the commit hash reference the latest upstream commit even though the actual binary diverges?
 - The VFB source would need to be converted to UFO or .glyphs format before a config.yaml could be useful. Is there a plan to convert the sources?
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/atomicage/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `bb96b179ca`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/audiowide/config.yaml
+++ b/ofl/audiowide/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Audiowide-Regular-OTF.vfb
+  - src/Audiowide-Regular-TTF.vfb
+  - src/Audiowide-Regular.vfb
+familyName: Audiowide

--- a/ofl/audiowide/upstream_info.md
+++ b/ofl/audiowide/upstream_info.md
@@ -56,3 +56,9 @@ VFB files are proprietary FontLab Studio format and are not compatible with gfto
 - The `librefonts/audiowide` repo appears to be an archived mirror. Is there an original upstream repository maintained by Astigmatic (Brian J. Bonislawsky)?
 - Should the VFB sources be converted to UFO or .glyphs format to enable gftools-builder builds?
 - The font has only VFB sources. Without conversion, there is nothing that can be referenced in a config.yaml.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/audiowide/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `eccbd790f5`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/autourone/config.yaml
+++ b/ofl/autourone/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/AutourOne-Regular-OTF.sfd
+  - src/AutourOne-Regular-TTF.sfd
+  - src/AutourOne-Regular.vfb
+familyName: "Autour One"

--- a/ofl/autourone/upstream_info.md
+++ b/ofl/autourone/upstream_info.md
@@ -57,3 +57,9 @@ SFD files are FontForge's native format and are not directly compatible with gft
 - Eben Sorkin maintains the `EbenSorkin` GitHub account and is associated with Sorkin Type. It's worth checking if there's a dedicated Autour One repo under that account.
 - Should the SFD sources be converted to UFO or .glyphs format to enable gftools-builder builds?
 - The SFD sources include separate OTF and TTF variants, which is an unusual source structure.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/autourone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `10ccd1eb5a`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/averagesans/config.yaml
+++ b/ofl/averagesans/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/AverageSans-Regular-OTF.vfb
+  - src/AverageSans-Regular-TTF.sfd
+  - src/AverageSans-Regular.vfb
+familyName: "Average Sans"

--- a/ofl/averagesans/upstream_info.md
+++ b/ofl/averagesans/upstream_info.md
@@ -52,3 +52,9 @@ These formats are not compatible with gftools-builder, which requires `.glyphs`,
 
 1. Does Eduardo Tunni have the Average Sans .glyphs source file? His "average" repo has `sources/Average.glyphs` for the serif family -- he may have a similar .glyphs file for Average Sans that was never published to GitHub.
 2. Should a new upstream repo be created (or the existing one updated) with modern source files to enable rebuilding?
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/averagesans/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `79216d6e94`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/balthazar/config.yaml
+++ b/ofl/balthazar/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Balthazar-Regular-OTF.vfb
+  - src/Balthazar-Regular-TTF.sfd
+  - src/Balthazar-Regular.vfb
+familyName: Balthazar

--- a/ofl/balthazar/upstream_info.md
+++ b/ofl/balthazar/upstream_info.md
@@ -43,3 +43,9 @@ No override config.yaml exists in the google/fonts family directory either.
 ## Open Questions
 - This is a legacy font with only .vfb/.sfd sources. To make it buildable with gftools-builder, the sources would need to be converted to .glyphs or .ufo format. This is a significant effort and may not be prioritized.
 - The METADATA.pb has no `source {}` block. A source block with repository_url and commit could be added, though config_yaml would still be absent.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/balthazar/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `baa08c6f63`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/baumans/config.yaml
+++ b/ofl/baumans/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Baumans-Regular-OTF.vfb
+  - src/Baumans-Regular-TTF.vfb
+  - src/Baumans-Regular.vfb
+familyName: Baumans

--- a/ofl/baumans/upstream_info.md
+++ b/ofl/baumans/upstream_info.md
@@ -49,3 +49,9 @@ This font predates the gftools-builder workflow. The source files are in VFB for
 
 1. Should this family be considered "complete" despite having no buildable sources? The VFB format requires FontLab to convert, which is outside the gftools-builder workflow.
 2. The upstream repo appears to be a shallow clone - fetching full history might reveal additional commits that could help identify the exact onboarding commit.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/baumans/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `00e0253a48`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/belgrano/config.yaml
+++ b/ofl/belgrano/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Belgrano-Regular-OTF.vfb
+  - src/Belgrano-Regular-TTF.sfd
+familyName: Belgrano

--- a/ofl/belgrano/upstream_info.md
+++ b/ofl/belgrano/upstream_info.md
@@ -56,3 +56,9 @@ The source files are in SFD (FontForge) and VFB (FontLab) formats, which are not
 
 - The METADATA.pb currently has no `source {}` block. A source block with `repository_url` and `commit` should be added, even without `config_yaml`, to document the upstream origin.
 - The font was added to Google Fonts in 2011 and last updated in 2017 (PR #851). The upstream repo appears abandoned with only one commit from 2014.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/belgrano/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `9637660aa3`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/bentham/config.yaml
+++ b/ofl/bentham/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Bentham-TTF.sfd
+familyName: Bentham

--- a/ofl/bentham/upstream_info.md
+++ b/ofl/bentham/upstream_info.md
@@ -52,3 +52,9 @@ The hotfix PR #854 by Marc Foley had an empty body, providing no context about t
 - SFD-only sources cannot be used with gftools-builder; this family would need a UFO/Glyphs conversion or an alternative build approach
 - The hotfix from 2017 may have used a process not reflected in the librefonts repo (which was last updated in 2014)
 - This font was added to Google Fonts in 2010, making it one of the original catalog fonts with limited source documentation
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/bentham/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `a89643ad52`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/berkshireswash/config.yaml
+++ b/ofl/berkshireswash/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/BerkshireSwash-Regular-OTF.vfb
+  - src/BerkshireSwash-Regular-TTF.vfb
+  - src/BerkshireSwash-Regular.vfb
+familyName: "Berkshire Swash"

--- a/ofl/berkshireswash/upstream_info.md
+++ b/ofl/berkshireswash/upstream_info.md
@@ -52,3 +52,9 @@ The hotfix PR #855 by Marc Foley had an empty body. The librefonts repo's last c
 - Astigmatic (Brian Bonislawsky) designed many fonts for Google Fonts; it's unknown if more modern source formats are available from the designer
 - The tracking notes say "No buildable source files at recorded commit" which is correct -- VFB files require proprietary software to open
 - This font was added to Google Fonts in 2012 and has classification DISPLAY with SERIF stroke
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/berkshireswash/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `1a4fb49d51`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/bethellen/config.yaml
+++ b/ofl/bethellen/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - BethEllen-Regular.sfd
+familyName: "Beth Ellen"

--- a/ofl/bethellen/upstream_info.md
+++ b/ofl/bethellen/upstream_info.md
@@ -54,3 +54,9 @@ No override config.yaml exists in the google/fonts family directory either.
 
 - The upstream repo now has a `.glyphs` file at HEAD (not present at the recorded commit). A config.yaml could potentially be created for future builds using this newer source, but that would require a separate review process.
 - The status remains `missing_config` because no gftools-builder configuration exists.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/bethellen/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `d6c8d9b387`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/bhavuka/config.yaml
+++ b/ofl/bhavuka/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - Bhavuka-Regular.sfd
+familyName: Bhavuka

--- a/ofl/bhavuka/upstream_info.md
+++ b/ofl/bhavuka/upstream_info.md
@@ -60,3 +60,9 @@ The font source is in SFD (FontForge) format, which is not compatible with gftoo
 
 - Should the commit hash be updated to `cd83228` (the last commit that actually modified the TTF) instead of `e4819c2` (the repo HEAD which only updated README)?
 - The font uses Devanagari script support. The SFD source format means it cannot be rebuilt with gftools-builder. This family will likely remain in `missing_config` status permanently unless the source is converted to a modern format.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/bhavuka/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `e4819c2a22`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/bigelowrules/config.yaml
+++ b/ofl/bigelowrules/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/BigelowRules-Regular-OTF.vfb
+  - src/BigelowRules-Regular-TTF.vfb
+  - src/BigelowRules-Regular.vfb
+familyName: "Bigelow Rules"

--- a/ofl/bigelowrules/upstream_info.md
+++ b/ofl/bigelowrules/upstream_info.md
@@ -54,3 +54,9 @@ VFB files cannot be processed by gftools-builder. There are no `.glyphs`, `.ufo`
 ## Open Questions
 
 - This font cannot be rebuilt from source using gftools-builder due to VFB-only sources. The original designer (Astigmatic/Brian Bonislawsky) would need to provide sources in a buildable format (.glyphs, .ufo, or .designspace) for this to change.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/bigelowrules/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `f3ba7414e9`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/bilboswashcaps/config.yaml
+++ b/ofl/bilboswashcaps/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Bilbo-SwashCaps-OTF.vfb
+  - src/BilboSwashCaps-Regular-TTF.sfd
+familyName: "Bilbo Swash Caps"

--- a/ofl/bilboswashcaps/upstream_info.md
+++ b/ofl/bilboswashcaps/upstream_info.md
@@ -108,3 +108,9 @@ OFL.txt
 - SFD-only sources mean this font cannot be rebuilt with gftools-builder
 - The METADATA.pb on main does not have a source block yet (added on PR branch only)
 - Static font only (single weight)
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/bilboswashcaps/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `7fb5653f33`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/bonbon/config.yaml
+++ b/ofl/bonbon/config.yaml
@@ -1,3 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
 buildVariable: false
 sources:
   - src/Bonbon-Regular.vfb

--- a/ofl/boogaloo/config.yaml
+++ b/ofl/boogaloo/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Boogaloo-Regular-OTF.vfb
+  - src/Boogaloo-Regular-TTF.sfd
+familyName: Boogaloo

--- a/ofl/boogaloo/upstream_info.md
+++ b/ofl/boogaloo/upstream_info.md
@@ -53,3 +53,9 @@ The METADATA.pb currently has no `source { }` block with `config_yaml` -- only a
 ## Open Questions
 
 1. Could the SFD source be converted to a modern format (UFO or Glyphs) to enable gftools-builder compilation in the future? This would require creating an override config.yaml in google/fonts.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/boogaloo/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `9837380f88`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/bowlbyone/config.yaml
+++ b/ofl/bowlbyone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/BowlbyOne-Regular-TTF.sfd
+  - src/BowlbyOne-Regular.vfb
+familyName: "Bowlby One"

--- a/ofl/bowlbyone/upstream_info.md
+++ b/ofl/bowlbyone/upstream_info.md
@@ -54,3 +54,9 @@ These formats are not compatible with gftools-builder. There are no `.glyphs`, `
 
 1. The 2017 hotfix (v1.001, PR #864) was done by Marc Foley. It is unclear where the updated source for v1.001 resides, if anywhere.
 2. Since only SFD/VFB sources exist, a config.yaml cannot be created for gftools-builder. This family may need to remain in "missing_config" status permanently, or an alternative build approach would need to be developed.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/bowlbyone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `3aca9b57cf`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/breeserif/config.yaml
+++ b/ofl/breeserif/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/BreeSerif-Regular-OTF.vfb
+  - src/BreeSerif-Regular-TTF.sfd
+familyName: "Bree Serif"

--- a/ofl/breeserif/upstream_info.md
+++ b/ofl/breeserif/upstream_info.md
@@ -47,3 +47,9 @@ The font was originally added to google/fonts in the initial commit (`90abd17b4`
 
 1. The source block for this family has been prepared but is not yet merged to google/fonts main (pending PR on `sources_info_2026-02-25` branch).
 2. TypeTogether may have more recent sources for Bree Serif in a different format (Glyphs/UFO), but the librefonts repository only contains the legacy SFD sources.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/breeserif/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `86684a17aa`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/bubblegumsans/config.yaml
+++ b/ofl/bubblegumsans/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/BubblegumSans-Regular-OTF.vfb
+  - src/BubblegumSans-Regular-TTF.sfd
+familyName: "Bubblegum Sans"

--- a/ofl/bubblegumsans/upstream_info.md
+++ b/ofl/bubblegumsans/upstream_info.md
@@ -51,3 +51,9 @@ The font has not been rebuilt from sources using modern tooling. The binary in g
 ## Open Questions
 
 1. The font sources are in SFD/VFB format only. To enable rebuilding with gftools-builder, the sources would need to be converted to `.glyphs` or `.ufo` format and a new upstream repo or config.yaml created. This is a low priority for a single-weight static font that has not been updated since 2015.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/bubblegumsans/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `fcf8bdd5e8`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/bubblerone/config.yaml
+++ b/ofl/bubblerone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/BubblerOne-Regular-TTF.sfd
+  - src/BubblerOne-Regular.vfb
+familyName: "Bubbler One"

--- a/ofl/bubblerone/upstream_info.md
+++ b/ofl/bubblerone/upstream_info.md
@@ -55,3 +55,9 @@ This is a legacy source format not compatible with gftools-builder. The repo als
 
 1. The font binary in google/fonts has been updated several times (hotfixes, version bumps) after the librefonts archive was created. The SFD source in the archive likely does not correspond to the current binary. To enable rebuilding, the sources would need to be converted to modern formats.
 2. The hotfix in PR #867 and subsequent updates suggest the font was modified directly at the binary level or from sources not present in the librefonts repo.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/bubblerone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `be2343608e`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/buda/config.yaml
+++ b/ofl/buda/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Buda-Light-TTF.sfd
+familyName: Buda

--- a/ofl/buda/upstream_info.md
+++ b/ofl/buda/upstream_info.md
@@ -43,3 +43,9 @@ There is no config.yaml in the upstream repository. The only source file is `src
 
 1. The source block has been prepared on branch `sources_info_2026-02-25` but has not yet been merged into the main google/fonts repository. Once merged, METADATA.pb will document the upstream source.
 2. Since the font uses SFD sources only, it would need to be converted to a modern source format (UFO or Glyphs) before a config.yaml could be created. This is unlikely to happen unless the font receives a major redesign/update.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/buda/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `c632d6ba92`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/butcherman/config.yaml
+++ b/ofl/butcherman/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Butcherman-Regular-TTF.sfd
+  - src/Butcherman-Regular.sfd
+familyName: Butcherman

--- a/ofl/butcherman/upstream_info.md
+++ b/ofl/butcherman/upstream_info.md
@@ -46,3 +46,9 @@ No config.yaml can be created for this family without first converting the sourc
 ## Open Questions
 
 None. The data is complete and verified. The family will remain in `missing_config` status unless the sources are converted to a gftools-compatible format.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/butcherman/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `92a34525b5`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/butterflykids/config.yaml
+++ b/ofl/butterflykids/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/ButterflyKids-Regular-TTF.vfb
+familyName: "Butterfly Kids"

--- a/ofl/butterflykids/upstream_info.md
+++ b/ofl/butterflykids/upstream_info.md
@@ -46,3 +46,9 @@ No config.yaml can be created for this family without first converting the sourc
 ## Open Questions
 
 None. The data is complete and verified. The family will remain in `missing_config` status unless the sources are converted to a gftools-compatible format (e.g., .glyphs or .ufo).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/butterflykids/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `0c553b2341`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/caesardressing/config.yaml
+++ b/ofl/caesardressing/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/CaesarDressing-Regular-TTF.vfb
+familyName: "Caesar Dressing"

--- a/ofl/caesardressing/upstream_info.md
+++ b/ofl/caesardressing/upstream_info.md
@@ -51,3 +51,9 @@ This family cannot be built with gftools-builder because the only source is in V
 
 1. Is there any plan to convert the VFB sources to a modern format (Glyphs/UFO) for this family?
 2. The designer "Open Window" (Dathan Boardman, dathanboardman@gmail.com per the copyright string) may have the original editable sources in a different format.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/caesardressing/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `fb212a606b`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/cagliostro/config.yaml
+++ b/ofl/cagliostro/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Cagliostro-Regular-TTF.sfd
+  - src/Cagliostro-Regular.vfb
+familyName: Cagliostro

--- a/ofl/cagliostro/upstream_info.md
+++ b/ofl/cagliostro/upstream_info.md
@@ -52,3 +52,9 @@ This family cannot be built with gftools-builder because the only sources are in
 
 1. Is there any plan to convert the SFD/VFB sources to a modern format (Glyphs/UFO) for this family?
 2. The original designer Matthew Desmond (MADType) may have more recent source files.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/cagliostro/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `5c0de59bed`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/cambo/config.yaml
+++ b/ofl/cambo/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Cambo-Regular-OTF.vfb
+  - src/Cambo-Regular-TTF.sfd
+  - src/Cambo-Regular.vfb
+familyName: Cambo

--- a/ofl/cambo/upstream_info.md
+++ b/ofl/cambo/upstream_info.md
@@ -49,3 +49,9 @@ The upstream repo contains only FontForge SFD sources (`src/Cambo-Regular-TTF.sf
 
 - The original designer (Huerta Tipografica) may have source files in other formats (e.g., .glyphs) that are not publicly available.
 - No path to gftools-builder compatibility without source conversion from SFD/VFB format.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/cambo/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `3b97d12b34`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/candal/config.yaml
+++ b/ofl/candal/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Candal-TTF.sfd
+  - src/Candal-TTF.vfb
+  - src/Candal.sfd
+  - src/Candal.vfb
+familyName: Candal

--- a/ofl/candal/upstream_info.md
+++ b/ofl/candal/upstream_info.md
@@ -49,3 +49,9 @@ The upstream repo contains only FontForge SFD sources (`src/Candal.sfd`, `src/Ca
 
 - No path to gftools-builder compatibility without source conversion from SFD/VFB format.
 - The font has not been updated since the initial onboarding (only metadata fixes).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/candal/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `64c937069f`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/cantarell/config.yaml
+++ b/ofl/cantarell/config.yaml
@@ -1,3 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
 buildVariable: false
 sources:
   - src/Cantarell-Regular.sfd

--- a/ofl/cantataone/config.yaml
+++ b/ofl/cantataone/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/CantataOne-Regular-OTF.sfd
+  - src/CantataOne-Regular-TTF.sfd
+  - src/CantataOne-Regular.vfb
+familyName: "Cantata One"

--- a/ofl/cantataone/upstream_info.md
+++ b/ofl/cantataone/upstream_info.md
@@ -72,3 +72,9 @@ These formats are **not compatible with gftools-builder**. A config.yaml cannot 
 ## Confidence
 
 **HIGH**: The upstream repository has a single commit, making identification unambiguous. The repository URL is confirmed accessible and contains matching source files. The status is "missing_config" because the sources are in legacy formats (SFD/VFB) that are not compatible with gftools-builder, so no config.yaml can be created without first converting the sources to a modern format.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/cantataone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `947c3dd6e9`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/cantoraone/config.yaml
+++ b/ofl/cantoraone/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/CantoraOne-Regular-OTF.vfb
+  - src/CantoraOne-Regular-TTF.vfb
+  - src/CantoraOne-Regular.vfb
+familyName: "Cantora One"

--- a/ofl/cantoraone/upstream_info.md
+++ b/ofl/cantoraone/upstream_info.md
@@ -60,3 +60,9 @@ VFB is the proprietary FontLab 5 binary format. It is **not compatible with gfto
 ## Confidence
 
 **MEDIUM**: The repository URL is confirmed as the only known upstream source for Cantora One. However, the upstream repo only contains v1.001 sources while google/fonts has v1.002 (from a direct HOTFIX). The source files are in VFB format, which is incompatible with gftools-builder, so no config.yaml can be created. The commit hash is the only commit in the repo and represents the pre-HOTFIX state. A complete rebuild from source would require converting the VFB files to an open format first.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/cantoraone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `45d202afe1`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/carme/config.yaml
+++ b/ofl/carme/config.yaml
@@ -1,3 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
 buildVariable: false
 sources:
   - src/Carme-Regular-TTF.sfd

--- a/ofl/carroisgothic/config.yaml
+++ b/ofl/carroisgothic/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/CarroisGothic-Regular-OTF.vfb
+  - src/CarroisGothic-Regular-TTF.vfb
+  - src/CarroisGothic-Regular.vfb
+familyName: "Carrois Gothic"

--- a/ofl/carroisgothic/upstream_info.md
+++ b/ofl/carroisgothic/upstream_info.md
@@ -47,3 +47,9 @@ No override config.yaml exists in the google/fonts family directory either.
 - The hotfix PR #874 (2017) updated the binary TTF in google/fonts but the upstream librefonts repo was never updated. The current binary in google/fonts may not match what can be built from the upstream sources.
 - VFB sources would need to be converted to an open format (e.g., UFO) before a config.yaml could be created. This is unlikely to happen unless someone undertakes a conversion project.
 - The status should remain `missing_config` as there are no gftools-builder-compatible sources.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/carroisgothic/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `09bb671388`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/carroisgothicsc/config.yaml
+++ b/ofl/carroisgothicsc/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/CarroisGothicSC-Regular-OTF.vfb
+  - src/CarroisGothicSC-Regular-TTF.vfb
+  - src/CarroisGothicSC-Regular.vfb
+familyName: "Carrois Gothic SC"

--- a/ofl/carroisgothicsc/upstream_info.md
+++ b/ofl/carroisgothicsc/upstream_info.md
@@ -55,3 +55,9 @@ Carrois Gothic SC is the small-caps variant of Carrois Gothic. Both were designe
 - Same as Carrois Gothic: VFB sources would need conversion to an open format before any config.yaml could be created.
 - The hotfix PR #875 (2017) updated the binary in google/fonts but the upstream was never synced.
 - The status should remain `missing_config` as there are no gftools-builder-compatible sources.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/carroisgothicsc/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `cd21c85aa5`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/carterone/config.yaml
+++ b/ofl/carterone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/CarterOne-TTF.sfd
+  - src/CarterOne.vfb
+familyName: "Carter One"

--- a/ofl/carterone/upstream_info.md
+++ b/ofl/carterone/upstream_info.md
@@ -59,3 +59,9 @@ This would make the family buildable, similar to what was done for Carme.
 - An override config.yaml could be created in google/fonts to make this family buildable from SFD sources. This would change the status from `missing_config` to `complete`.
 - It should be verified that building from the SFD source produces output matching (or acceptably close to) the current binary in google/fonts before creating such an override.
 - Vernon Adams, the original designer, passed away in 2014. Any updates to this font would need to be handled by the community.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/carterone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `9943144e58`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/caudex/config.yaml
+++ b/ofl/caudex/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Caudex-Bold.sfd
+  - src/Caudex-BoldItalic.sfd
+  - src/Caudex-Italic.sfd
+  - src/Caudex-Regular.sfd
+familyName: Caudex

--- a/ofl/caudex/upstream_info.md
+++ b/ofl/caudex/upstream_info.md
@@ -50,3 +50,9 @@ SFD is a FontForge-native format that is not compatible with gftools-builder. Bu
 ## Open Questions
 
 None. This is a legacy font with SFD-only sources. A config.yaml would only be possible if the font were to be converted to a gftools-builder-compatible format (e.g., .glyphs or .ufo).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/caudex/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `901fb15160`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/cedarvillecursive/config.yaml
+++ b/ofl/cedarvillecursive/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Cedarville-Cursive.vfb
+familyName: "Cedarville Cursive"

--- a/ofl/cedarvillecursive/upstream_info.md
+++ b/ofl/cedarvillecursive/upstream_info.md
@@ -64,3 +64,9 @@ No override `config.yaml` exists in the google/fonts family directory either.
 ## Confidence
 
 **HIGH**: The repository URL is confirmed accessible, the commit hash is the only commit in the repo, and the source format limitation (VFB-only) is definitively verified. The font cannot be rebuilt from open-source tooling without source conversion work. The librefonts archive is the only known upstream for this font.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/cedarvillecursive/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `cd212b0e2d`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/cevicheone/config.yaml
+++ b/ofl/cevicheone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/CevicheOne-Regular-OTF.vfb
+  - src/CevicheOne-Regular-TTF.sfd
+familyName: "Ceviche One"

--- a/ofl/cevicheone/upstream_info.md
+++ b/ofl/cevicheone/upstream_info.md
@@ -49,3 +49,9 @@ Neither SFD nor VFB formats are compatible with gftools-builder. A `config.yaml`
 
 1. The sources are in legacy formats (SFD and VFB). To enable gftools-builder builds, these would need to be converted to `.glyphs` or `.ufo` format. This is not a trivial conversion and may require manual review by a type designer.
 2. The family was added to Google Fonts in 2011 (date_added: 2011-12-07). The upstream repository appears to be a post-hoc archive rather than the original development location.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/cevicheone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `afec42c6e7`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/chango/config.yaml
+++ b/ofl/chango/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Chango-Regular-OTF.vfb
+  - src/Chango-Regular-TTF.sfd
+familyName: Chango

--- a/ofl/chango/upstream_info.md
+++ b/ofl/chango/upstream_info.md
@@ -52,3 +52,9 @@ Neither SFD nor VFB formats are compatible with gftools-builder. A `config.yaml`
 1. The sources are in legacy formats (SFD and VFB). To enable gftools-builder builds, these would need to be converted to `.glyphs` or `.ufo` format. This is not a trivial conversion and may require manual review by a type designer.
 2. The family was added to Google Fonts in 2011 (date_added: 2011-12-13). The upstream repository appears to be a post-hoc archive created in 2014, rather than the original development location.
 3. The designer "Fontstage" does not appear to have an active online presence. Any source conversion work would likely need to be done by the Google Fonts team.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/chango/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `ca58222d63`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/chathura/config.yaml
+++ b/ofl/chathura/config.yaml
@@ -1,0 +1,12 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - Chathura-Bold.sfd
+  - Chathura-ExtraBold.sfd
+  - Chathura-Light.sfd
+  - Chathura-Regular.sfd
+  - Chathura-Thin.sfd
+familyName: Chathura

--- a/ofl/chathura/upstream_info.md
+++ b/ofl/chathura/upstream_info.md
@@ -49,3 +49,9 @@ Since SFD sources cannot be used with gftools-builder, a config.yaml is not appl
 ## Open Questions
 
 None. The status is correctly `missing_config` because the SFD source format is not compatible with gftools-builder. No action needed unless the font is eventually migrated to a modern source format.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/chathura/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `f6944e361d`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/chauphilomeneone/config.yaml
+++ b/ofl/chauphilomeneone/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/ChauPhilomeneOne-Italic-OTF.vfb
+  - src/ChauPhilomeneOne-Italic-TTF.sfd
+  - src/ChauPhilomeneOne-Regular-OTF.vfb
+  - src/ChauPhilomeneOne-Regular-TTF.sfd
+familyName: "Chau Philomene One"

--- a/ofl/chauphilomeneone/upstream_info.md
+++ b/ofl/chauphilomeneone/upstream_info.md
@@ -48,3 +48,9 @@ There are no `.glyphs`, `.ufo`, or `.designspace` files that would be compatible
 ## Open Questions
 
 None. The status is correctly `missing_config` because the source formats (SFD, VFB) are not compatible with gftools-builder. No action needed unless the font is eventually migrated to a modern source format.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/chauphilomeneone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `ac51123e5c`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/chelaone/config.yaml
+++ b/ofl/chelaone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/ChelaOne-Regular-OTF.vfb
+  - src/ChelaOne-Regular-TTF.sfd
+familyName: "Chela One"

--- a/ofl/chelaone/upstream_info.md
+++ b/ofl/chelaone/upstream_info.md
@@ -57,3 +57,9 @@ Neither SFD nor VFB formats are compatible with gftools-builder. There are no `.
 ## Open Questions
 
 - None. This is a legacy font with SFD-only sources. It would require source conversion to a modern format (e.g., .glyphs or .ufo) before a config.yaml could be created.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/chelaone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `cb9b95fc05`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/chelseamarket/config.yaml
+++ b/ofl/chelseamarket/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/ChelseaMarket-Regular-TTF.vfb
+familyName: "Chelsea Market"

--- a/ofl/chelseamarket/upstream_info.md
+++ b/ofl/chelseamarket/upstream_info.md
@@ -56,3 +56,9 @@ VFB is a proprietary FontLab format that is not compatible with gftools-builder.
 ## Open Questions
 
 - None. This is a legacy font with VFB-only sources. It would require conversion to a modern format before a config.yaml could be created.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/chelseamarket/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `cb0d8b1186`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/cherryswash/config.yaml
+++ b/ofl/cherryswash/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/CherrySwash-Bold-OTF.vfb
+  - src/CherrySwash-Bold-TTF.sfd
+  - src/CherrySwash-Regular-OTF.vfb
+  - src/CherrySwash-Regular-TTF.sfd
+familyName: "Cherry Swash"

--- a/ofl/cherryswash/upstream_info.md
+++ b/ofl/cherryswash/upstream_info.md
@@ -51,3 +51,9 @@ These formats are not compatible with gftools-builder, which requires `.glyphs`,
 ## Open Questions
 
 None. This family cannot have a config.yaml without source format conversion.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/cherryswash/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `84e28ad7cc`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/chicle/config.yaml
+++ b/ofl/chicle/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Chicle-Regular-OTF.vfb
+  - src/Chicle-Regular-TTF.sfd
+familyName: Chicle

--- a/ofl/chicle/upstream_info.md
+++ b/ofl/chicle/upstream_info.md
@@ -49,3 +49,9 @@ These formats are not compatible with gftools-builder, which requires `.glyphs`,
 ## Open Questions
 
 None. This family cannot have a config.yaml without source format conversion.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/chicle/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `4ee3e89dbb`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/clickerscript/config.yaml
+++ b/ofl/clickerscript/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/ClickerScript-Regular-OTF.vfb
+  - src/ClickerScript-Regular-TTF.vfb
+  - src/ClickerScript-Regular.vfb
+familyName: "Clicker Script"

--- a/ofl/clickerscript/upstream_info.md
+++ b/ofl/clickerscript/upstream_info.md
@@ -47,3 +47,9 @@ The VFB format is proprietary to FontLab and cannot be used with gftools-builder
 ## Open Questions
 
 - To rebuild this font with modern tools, the VFB sources would need to be converted to UFO or Glyphs format. This is outside the scope of source documentation.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/clickerscript/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `f8f050697a`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/codystar/config.yaml
+++ b/ofl/codystar/config.yaml
@@ -1,3 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
 buildVariable: false
 sources:
   - src/Codystar-Regular-TTF.vfb

--- a/ofl/combo/config.yaml
+++ b/ofl/combo/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Combo-Regular-OTF.vfb
+  - src/Combo-Regular-TTF.vfb
+familyName: Combo

--- a/ofl/combo/upstream_info.md
+++ b/ofl/combo/upstream_info.md
@@ -60,3 +60,9 @@ sources:
 
 1. Should an override config.yaml be created referencing the VFB source, similar to the Codystar approach?
 2. The source block with repository_url and commit hash needs to be merged to main (currently only on pending PR branch).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/combo/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `ae46147e06`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/concertone/config.yaml
+++ b/ofl/concertone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/ConcertOne-Regular-OTF.vfb
+  - src/ConcertOne-Regular-TTF.sfd
+familyName: "Concert One"

--- a/ofl/concertone/upstream_info.md
+++ b/ofl/concertone/upstream_info.md
@@ -45,3 +45,9 @@ These formats are not compatible with gftools-builder, which requires `.glyphs`,
 
 1. The v-metrics hotfix was applied directly to the binary in google/fonts without corresponding upstream changes. Should this be documented more formally?
 2. Would it be worthwhile to convert the SFD sources to a gftools-builder compatible format?
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/concertone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `c2160f498d`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/condiment/config.yaml
+++ b/ofl/condiment/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Condiment-Regular-OTF.vfb
+  - src/Condiment-Regular-TTF.sfd
+familyName: Condiment

--- a/ofl/condiment/upstream_info.md
+++ b/ofl/condiment/upstream_info.md
@@ -45,3 +45,9 @@ These formats are not compatible with gftools-builder. No override config.yaml e
 ## Open Questions
 
 None. This is a straightforward legacy font with SFD-only sources in a standard librefonts archive repository.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/condiment/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `0a1933e09c`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/contrailone/config.yaml
+++ b/ofl/contrailone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/ContrailOne-Regular-TTF.sfd
+  - src/ContrailOne-Regular.vfb
+familyName: "Contrail One"

--- a/ofl/contrailone/upstream_info.md
+++ b/ofl/contrailone/upstream_info.md
@@ -47,3 +47,9 @@ These formats are not compatible with gftools-builder. No override config.yaml e
 ## Open Questions
 
 None. This is a straightforward legacy font with SFD/VFB sources in a standard librefonts archive repository.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/contrailone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `21ed604401`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/convergence/config.yaml
+++ b/ofl/convergence/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Convergence-Regular-TTF.sfd
+  - src/Convergence-Regular.vfb
+familyName: Convergence

--- a/ofl/convergence/upstream_info.md
+++ b/ofl/convergence/upstream_info.md
@@ -43,3 +43,9 @@ These are legacy font formats that are **not compatible with gftools-builder**. 
 ## Open Questions
 
 None. The family has SFD-only sources and cannot be rebuilt with gftools-builder without a source format conversion.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/convergence/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `475145997c`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/cookie/config.yaml
+++ b/ofl/cookie/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Cookie-Regular-TTF.sfd
+  - src/Cookie-Regular.vfb
+familyName: Cookie

--- a/ofl/cookie/upstream_info.md
+++ b/ofl/cookie/upstream_info.md
@@ -43,3 +43,9 @@ These are legacy font formats that are **not compatible with gftools-builder**. 
 ## Open Questions
 
 None. The family has SFD-only sources and cannot be rebuilt with gftools-builder without a source format conversion.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/cookie/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `15549218a2`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/copse/config.yaml
+++ b/ofl/copse/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Copse-Regular-TTF.sfd
+  - src/Copse-Regular-TTF.vfb
+  - src/Copse-Regular.vfb
+familyName: Copse

--- a/ofl/copse/upstream_info.md
+++ b/ofl/copse/upstream_info.md
@@ -44,3 +44,9 @@ These are legacy font formats that are **not compatible with gftools-builder**. 
 ## Open Questions
 
 None. The family has SFD-only sources and cannot be rebuilt with gftools-builder without a source format conversion.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/copse/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `cb3ef9c1cc`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/corben/config.yaml
+++ b/ofl/corben/config.yaml
@@ -1,0 +1,12 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Corben-Bold-TTF.sfd
+  - src/Corben-Bold.sfd
+  - src/Corben-Bold.vfb
+  - src/Corben-Regular-TTF.sfd
+  - src/Corben-Regular.sfd
+familyName: Corben

--- a/ofl/corben/upstream_info.md
+++ b/ofl/corben/upstream_info.md
@@ -52,3 +52,9 @@ These are legacy font formats that are **not compatible with gftools-builder**. 
 ## Open Questions
 
 None. The family has SFD-only sources and cannot be rebuilt with gftools-builder without a source format conversion.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/corben/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `94d5b00e6b`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/courgette/config.yaml
+++ b/ofl/courgette/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Courgette-Regular-OTF.sfd
+  - src/Courgette-Regular-TTF.sfd
+  - src/Courgette-Regular.vfb
+familyName: Courgette

--- a/ofl/courgette/upstream_info.md
+++ b/ofl/courgette/upstream_info.md
@@ -49,3 +49,9 @@ These are not compatible with gftools-builder, which requires `.glyphs`, `.ufo`,
 ## Open Questions
 
 None. This is a legacy font with SFD-only sources that cannot be rebuilt with modern tooling without a source conversion effort.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/courgette/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `e9638c8874`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/coveredbyyourgrace/config.yaml
+++ b/ofl/coveredbyyourgrace/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/CoveredByYourGrace-TTF.sfd
+  - src/CoveredByYourGrace.vfb
+familyName: "Covered By Your Grace"

--- a/ofl/coveredbyyourgrace/upstream_info.md
+++ b/ofl/coveredbyyourgrace/upstream_info.md
@@ -49,3 +49,9 @@ SFD and VFB files are not compatible with gftools-builder, so a config.yaml cann
 
 1. The source block (repository_url and commit hash) has not yet been merged to google/fonts main -- it is on the pending branch `felipesanches/sources_info_2026-02-25`.
 2. No config.yaml can be created from SFD/VFB sources without source conversion. This family will remain in `missing_config` status unless the sources are modernized.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/coveredbyyourgrace/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `eca9fdc2d5`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/creepster/config.yaml
+++ b/ofl/creepster/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Creepster-Regular-TTF.sfd
+familyName: Creepster

--- a/ofl/creepster/upstream_info.md
+++ b/ofl/creepster/upstream_info.md
@@ -48,3 +48,9 @@ SFD files are not compatible with gftools-builder, so a config.yaml cannot be cr
 1. The source block (repository_url and commit hash) has not yet been merged to google/fonts main -- it is on the pending branch `felipesanches/sources_info_2026-02-25`.
 2. No config.yaml can be created from SFD sources without source conversion. This family will remain in `missing_config` status unless the sources are modernized.
 3. The copyright mentions "Font Diner, Inc DBA Sideshow" -- the designer credit uses "Sideshow" as the key in METADATA.pb.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/creepster/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `f6eec0d741`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/creteround/config.yaml
+++ b/ofl/creteround/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/CreteRound-Italic-OTF.vfb
+  - src/CreteRound-Italic-TTF.sfd
+  - src/CreteRound-Regular-OTF.vfb
+  - src/CreteRound-Regular-TTF.sfd
+familyName: "Crete Round"

--- a/ofl/creteround/upstream_info.md
+++ b/ofl/creteround/upstream_info.md
@@ -53,3 +53,9 @@ SFD and VFB files are not compatible with gftools-builder, so a config.yaml cann
 1. The source block (repository_url and commit hash) has not yet been merged to google/fonts main -- it is on the pending branch `felipesanches/sources_info_2026-02-25`.
 2. No config.yaml can be created from SFD/VFB sources without source conversion. This family will remain in `missing_config` status unless the sources are modernized.
 3. The font was designed by TypeTogether (Jose Scaglione and Veronika Burian). If there are more modern sources (e.g., .glyphs or .ufo) available from TypeTogether, those would be the preferred upstream.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/creteround/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `056740e1fe`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/croissantone/config.yaml
+++ b/ofl/croissantone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/CroissantOne-Regular-OTF.vfb
+  - src/CroissantOne-Regular-TTF.sfd
+familyName: "Croissant One"

--- a/ofl/croissantone/upstream_info.md
+++ b/ofl/croissantone/upstream_info.md
@@ -48,3 +48,9 @@ These are not compatible with gftools-builder, which requires `.glyphs`, `.ufo`,
 ## Open Questions
 
 None. This is a legacy font with SFD/VFB-only sources that cannot be rebuilt with modern tooling without a source conversion effort.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/croissantone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `ebcefa6161`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/dawningofanewday/config.yaml
+++ b/ofl/dawningofanewday/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/DawningofaNewDay-TTF.sfd
+  - src/DawningofaNewDay.vfb
+familyName: "Dawning of a New Day"

--- a/ofl/dawningofanewday/upstream_info.md
+++ b/ofl/dawningofanewday/upstream_info.md
@@ -49,3 +49,9 @@ The upstream repository has only a single commit: `45ea90b8015692ee7fe07e417ea1c
 
 - Would this font benefit from source conversion (SFD to .glyphs or .ufo) to enable gftools-builder compatibility?
 - The librefonts archive is a secondary source; the original designer (Kimberly Geswein) may have the original source files in a different format.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/dawningofanewday/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `45ea90b801`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/daysone/config.yaml
+++ b/ofl/daysone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/DaysOne-Regular-TTF.sfd
+  - src/DaysOne-Regular.vfb
+familyName: "Days One"

--- a/ofl/daysone/upstream_info.md
+++ b/ofl/daysone/upstream_info.md
@@ -49,3 +49,9 @@ The upstream repository has only a single commit: `76642af05e1a7734f94e1b22abdbc
 
 - Would this font benefit from source conversion (SFD to .glyphs or .ufo) to enable gftools-builder compatibility?
 - The librefonts archive is a secondary source; the original designer (Jovanny Lemonad) may have the original source files in a different format.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/daysone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `76642af05e`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/delius/config.yaml
+++ b/ofl/delius/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Delius-Regular-TTF.sfd
+  - src/Delius-Regular.vfb
+familyName: Delius

--- a/ofl/delius/upstream_info.md
+++ b/ofl/delius/upstream_info.md
@@ -55,3 +55,9 @@ Since this is a legacy font with SFD-only sources, the commit hash serves mainly
 - The font sources would need to be converted to a modern format (e.g., .glyphs or .ufo) before a config.yaml could be created.
 - The source block for METADATA.pb has been prepared on branch `sources_info_2026-02-25` but is not yet merged.
 - Since this is a very old font (2011) with SFD sources, it may not be a priority for source documentation.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/delius/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `5bd1633b6b`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/deliusswashcaps/config.yaml
+++ b/ofl/deliusswashcaps/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/DeliusSwashCaps-Regular-TTF.sfd
+  - src/DeliusSwashCaps-Regular.vfb
+familyName: "Delius Swash Caps"

--- a/ofl/deliusswashcaps/upstream_info.md
+++ b/ofl/deliusswashcaps/upstream_info.md
@@ -55,3 +55,9 @@ The upstream repo contains:
 - Same situation as Delius and Delius Unicase: sources would need conversion to modern format for gftools-builder compatibility.
 - The copyright string references Reserved Font Names: "Delius", "Delius Unicase", "Delius Swash Caps" - all three variants share the same designer (Natalia Raices) and were created as a family.
 - The source block for METADATA.pb has been prepared on branch `sources_info_2026-02-25` but is not yet merged.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/deliusswashcaps/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `a18d931eb4`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/deliusunicase/config.yaml
+++ b/ofl/deliusunicase/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/DeliusUnicase-Bold-TTF.sfd
+  - src/DeliusUnicase-Bold.vfb
+  - src/DeliusUnicase-Regular-TTF.sfd
+  - src/DeliusUnicase-Regular.vfb
+familyName: "Delius Unicase"

--- a/ofl/deliusunicase/upstream_info.md
+++ b/ofl/deliusunicase/upstream_info.md
@@ -61,3 +61,9 @@ The upstream repo contains:
 - This is the only Delius variant with multiple weights (Regular + Bold), so source conversion would be more involved.
 - The source block for METADATA.pb has been prepared on branch `sources_info_2026-02-25` but is not yet merged.
 - The copyright string references Reserved Font Names: "Delius", "Delius Unicase", "Delius Swash Caps".
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/deliusunicase/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `cf094caecc`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/devonshire/config.yaml
+++ b/ofl/devonshire/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Devonshire-Regular-OTF.vfb
+  - src/Devonshire-Regular-TTF.sfd
+familyName: Devonshire

--- a/ofl/devonshire/upstream_info.md
+++ b/ofl/devonshire/upstream_info.md
@@ -40,3 +40,9 @@ The font binary has not been updated since the initial commit (90abd17b4) of the
 ## Recommendation
 
 Status should remain `missing_config` with the note that sources are SFD/VFB format only. The font would need to be converted to .glyphs or .ufo format and a config.yaml created before it could be built with gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/devonshire/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `7d88bb81c7`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/digitalnumbers/config.yaml
+++ b/ofl/digitalnumbers/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/digital-numbers.sfd
+familyName: "Digital Numbers"

--- a/ofl/digitalnumbers/upstream_info.md
+++ b/ofl/digitalnumbers/upstream_info.md
@@ -55,3 +55,9 @@ This font uses SFD (FontForge) format sources exclusively. SFD is not compatible
 - Commit hash: Verified correct (`b58e33a` was the latest commit at time of onboarding)
 - Config YAML: Not applicable (SFD-only sources)
 - Status: `missing_config` - SFD-only sources, not gftools-builder compatible
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/digitalnumbers/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `b58e33a259`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/donegalone/config.yaml
+++ b/ofl/donegalone/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/DonegalOne-Regular-OTF.sfd
+  - src/DonegalOne-Regular-TTF.sfd
+  - src/DonegalOne-Regular.vfb
+familyName: "Donegal One"

--- a/ofl/donegalone/upstream_info.md
+++ b/ofl/donegalone/upstream_info.md
@@ -43,3 +43,9 @@ No config.yaml exists in either the upstream repository or as an override in the
 ## Conclusion
 
 Donegal One has a known upstream repository with correct commit hash, but the sources are in SFD (FontForge) format only. A config.yaml cannot be created without first converting the sources to a gftools-builder compatible format (UFO, .glyphs, or .designspace). The status remains `missing_config` with the note that this is an SFD-only repository.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/donegalone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `b0af18fd94`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/doppioone/config.yaml
+++ b/ofl/doppioone/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/DoppioOne-Regular-OTF.sfd
+  - src/DoppioOne-Regular-TTF.sfd
+  - src/DoppioOne-Regular.vfb
+familyName: "Doppio One"

--- a/ofl/doppioone/upstream_info.md
+++ b/ofl/doppioone/upstream_info.md
@@ -43,3 +43,9 @@ No config.yaml exists in either the upstream repository or as an override in the
 ## Conclusion
 
 Doppio One has a known upstream repository with correct commit hash, but the sources are in SFD (FontForge) format only. A config.yaml cannot be created without first converting the sources to a gftools-builder compatible format (UFO, .glyphs, or .designspace). The status remains `missing_config` with the note that this is an SFD-only repository.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/doppioone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `14bdd2e78b`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/dorsa/config.yaml
+++ b/ofl/dorsa/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Dorsa-Regular-TTF.sfd
+familyName: Dorsa

--- a/ofl/dorsa/upstream_info.md
+++ b/ofl/dorsa/upstream_info.md
@@ -40,3 +40,9 @@ The Travis CI configuration (`.travis.yml`) shows the font was built using `font
 ## Confidence
 
 **HIGH**: The upstream repository at librefonts/dorsa is the canonical source archive for this font. It has only a single commit containing the complete SFD source, making commit identification unambiguous. The font copyright matches between the SFD file, METADATA.pb, and METADATA.json (Santiago Orozco, 2011). The repository URL is verified accessible. The only limitation is the lack of gftools-builder-compatible sources (SFD only), which means no config.yaml can be provided.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/dorsa/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `90d5bffc5b`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/drsugiyama/config.yaml
+++ b/ofl/drsugiyama/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/DrSugiyama-Regular-TTF.sfd
+  - src/DrSujiyama-Regular-OTF.vfb
+familyName: "Dr Sugiyama"

--- a/ofl/drsugiyama/upstream_info.md
+++ b/ofl/drsugiyama/upstream_info.md
@@ -58,3 +58,9 @@ Note: The original font name uses a variant spelling "Dr Sujiyama" in the VFB fi
 ## Recommendation
 
 The status should remain `missing_config` with the note "SFD-only sources (FontForge format), not gftools-builder compatible." A `source { }` block could be added to METADATA.pb referencing the librefonts repo, but no `config_yaml` can be set since the sources are incompatible with gftools-builder. The commit hash should reference `11d194b70af6df309a24c9395f64280172839879` (HEAD of master) since no source files changed across the repo's history.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/drsugiyama/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `11d194b70a`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/durusans/config.yaml
+++ b/ofl/durusans/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/DuruSans-Regular-OTF.sfd
+  - src/DuruSans-Regular-TTF.sfd
+  - src/DuruSans-Regular.vfb
+familyName: "Duru Sans"

--- a/ofl/durusans/upstream_info.md
+++ b/ofl/durusans/upstream_info.md
@@ -72,3 +72,9 @@ The `.travis.yml` in the repo uses the old `fontbakery-build.py` tool from 2014,
 **HIGH** for repository_url and commit_hash identification. The librefonts/durusans repo is clearly the archival source repository for this font, with matching metadata, license, and supporting files. There is only one commit, so the hash is unambiguous.
 
 **N/A** for config_yaml. The sources are in legacy formats (VFB/SFD) incompatible with gftools-builder. No config.yaml can be meaningfully created without first converting the sources to a modern format.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/durusans/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `2895eb6c98`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/dynalight/config.yaml
+++ b/ofl/dynalight/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Dynalight-Regular-OTF.vfb
+  - src/Dynalight-Regular-TTF.vfb
+  - src/Dynalight-Regular.vfb
+familyName: Dynalight

--- a/ofl/dynalight/upstream_info.md
+++ b/ofl/dynalight/upstream_info.md
@@ -68,3 +68,9 @@ No override `config.yaml` exists in the google/fonts family directory (`ofl/dyna
 - The copyright field contains a Reserved Font Name ("Dynalight").
 - The font is classified as both DISPLAY and HANDWRITING.
 - No PRs to google/fonts specifically reference Dynalight.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/dynalight/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `af7642053c`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/eaglelake/config.yaml
+++ b/ofl/eaglelake/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/EagleLake-Regular-OTF.vfb
+  - src/EagleLake-Regular-TTF.vfb
+  - src/EagleLake-Regular.vfb
+familyName: "Eagle Lake"

--- a/ofl/eaglelake/upstream_info.md
+++ b/ofl/eaglelake/upstream_info.md
@@ -75,3 +75,9 @@ No override `config.yaml` exists in the google/fonts family directory either.
 - The font has never been updated in google/fonts since its initial inclusion.
 - To make this font buildable from source, the VFB files would need to be converted to a modern format (e.g., `.glyphs` or `.ufo`), which would require manual intervention or access to FontLab.
 - The designer's website (http://www.astigmatic.com/) is referenced in the font's name table.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/eaglelake/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `4e2b26479c`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/eater/config.yaml
+++ b/ofl/eater/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Eater-Regular-TTF.sfd
+  - src/Eater-Regular.sfd
+familyName: Eater

--- a/ofl/eater/upstream_info.md
+++ b/ofl/eater/upstream_info.md
@@ -51,3 +51,9 @@ SFD files are not compatible with gftools-builder, which requires .glyphs, .ufo,
 ## Confidence
 
 **HIGH** -- The repository URL is verified and the commit hash is unambiguous (single commit in repo). The "missing_config" status is due to SFD-only sources that are incompatible with gftools-builder; no override config.yaml can be created without source format conversion.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/eater/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `91120e636b`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/economica/config.yaml
+++ b/ofl/economica/config.yaml
@@ -1,0 +1,15 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Economica-Bold-OTF.vfb
+  - src/Economica-Bold-TTF.sfd
+  - src/Economica-BoldItalic-OTF.vfb
+  - src/Economica-BoldItalic-TTF.sfd
+  - src/Economica-Italic-OTF.vfb
+  - src/Economica-Italic-TTF.sfd
+  - src/Economica-Regular-OTF.vfb
+  - src/Economica-Regular-TTF.sfd
+familyName: Economica

--- a/ofl/economica/upstream_info.md
+++ b/ofl/economica/upstream_info.md
@@ -66,3 +66,9 @@ The .travis.yml references the legacy `fontbakery-build.py` tool from 2014, whic
 ## Confidence
 
 **MEDIUM** -- The repository URL is confirmed (librefonts/economica, accessible on GitHub) and the only commit hash is unambiguous. However, this is a librefonts batch-import repository, not the designer's canonical source. The font predates modern tooling and uses SFD/VFB sources that cannot be built with gftools-builder. Confidence is MEDIUM rather than HIGH because the librefonts repo is a secondary mirror, not the original designer's repository. No config.yaml can be provided.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/economica/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `6bf48e6858`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/electrolize/config.yaml
+++ b/ofl/electrolize/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Electrolize-Regular-OTF.vfb
+  - src/Electrolize-Regular-TTF.vfb
+familyName: Electrolize

--- a/ofl/electrolize/upstream_info.md
+++ b/ofl/electrolize/upstream_info.md
@@ -57,3 +57,9 @@ The upstream sources consist of:
 ## Confidence
 
 **MEDIUM** -- The repository URL and commit hash are definitive (single-commit repo, only known upstream). However, the font cannot be rebuilt from sources using gftools-builder due to VFB-only sources. The status remains `missing_config` with no path to resolution without source format conversion.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/electrolize/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `2450033307`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/elsie/config.yaml
+++ b/ofl/elsie/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Elsie-Black-OTF.vfb
+  - src/Elsie-Black-TTF.sfd
+  - src/Elsie-Regular-OTF.vfb
+  - src/Elsie-Regular-TTF.sfd
+familyName: Elsie

--- a/ofl/elsie/upstream_info.md
+++ b/ofl/elsie/upstream_info.md
@@ -123,3 +123,9 @@ The font binaries in google/fonts have been hotfixed multiple times (PR #884, PR
 1. **Update METADATA.pb**: Replace the invalid `"https://github.com/googlefonts/elsiefont (404)"` URL with `"https://github.com/librefonts/elsie"`.
 2. **Note in source block**: This is a SFD-only repo; no gftools-builder rebuild is possible without source format conversion.
 3. **PR #10266 update**: The currently open PR proposes removing the URL entirely. It could instead be updated to point to `librefonts/elsie` as the best available source repository.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/elsie/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `9734e9ff13`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/elsieswashcaps/config.yaml
+++ b/ofl/elsieswashcaps/config.yaml
@@ -1,0 +1,13 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/ElsieSwashCaps-Black-OTF.vfb
+  - src/ElsieSwashCaps-Black-TTF.sfd
+  - src/ElsieSwashCaps-Black-backup-fonttools-prep-gasp-TTF.sfd
+  - src/ElsieSwashCaps-Regular-OTF.vfb
+  - src/ElsieSwashCaps-Regular-TTF.sfd
+  - src/ElsieSwashCaps-Regular-backup-fonttools-prep-gasp-TTF.sfd
+familyName: "Elsie Swash Caps"

--- a/ofl/elsieswashcaps/upstream_info.md
+++ b/ofl/elsieswashcaps/upstream_info.md
@@ -61,3 +61,9 @@ None of these formats (.sfd, .vfb) are compatible with gftools-builder, which re
 - The librefonts org created separate repos for `elsie` and `elsieswashcaps` in July 2014, each with only one commit (Travis CI config update by hash3g in October 2014).
 - Future source recovery would require contacting Alejandro Inler (alejandroinler@gmail.com) to obtain original editable sources in a modern format.
 - The font was originally added to Google Fonts on 2012-11-12.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/elsieswashcaps/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `f48faa350a`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/emblemaone/config.yaml
+++ b/ofl/emblemaone/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/EmblemaOne-Regular-OTF.vfb
+  - src/EmblemaOne-Regular-TTF.sfd
+  - src/EmblemaOne-Regular.vfb
+familyName: "Emblema One"

--- a/ofl/emblemaone/upstream_info.md
+++ b/ofl/emblemaone/upstream_info.md
@@ -69,3 +69,9 @@ The repository also contains TTX (XML) dumps of the compiled font tables, but th
 - The `librefonts` archive repo was created in October 2014 by hash3g.
 - The DESCRIPTION.en_us.html references the now-defunct Google Code (`code.google.com/p/googlefontdirectory/`) as the source location, indicating this font predates the move to GitHub.
 - To make this font rebuildable with gftools-builder, someone would need to convert the SFD or VFB sources to a modern format (`.glyphs` or `.ufo`).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/emblemaone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `65d5dad636`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/emilyscandy/config.yaml
+++ b/ofl/emilyscandy/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/EmilysCandy-Regular-TTF.vfb
+familyName: "Emilys Candy"

--- a/ofl/emilyscandy/upstream_info.md
+++ b/ofl/emilyscandy/upstream_info.md
@@ -64,3 +64,9 @@ The VFB format is a proprietary FontLab Studio format that is **not supported by
 - The repo was created as part of the librefonts batch migration of early Google Fonts families
 - The `.travis.yml` references legacy tooling (fontbakery-build.py, fontcrunch, python 2.7)
 - This family cannot be rebuilt from source without the original FontLab Studio project or conversion of the VFB to a modern format (.glyphs, .ufo)
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/emilyscandy/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `6c0f2ad7e9`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/engagement/config.yaml
+++ b/ofl/engagement/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Engagement-Regular-OTF.vfb
+  - src/Engagement-Regular-TTF.vfb
+  - src/Engagement-Regular.vfb
+familyName: Engagement

--- a/ofl/engagement/upstream_info.md
+++ b/ofl/engagement/upstream_info.md
@@ -68,3 +68,9 @@ The `.travis.yml` in the repo references `fontbakery-build.py` for building from
 - The librefonts/engagement repo is a third-party archive, not the original designer's repository
 - The font would need to be converted from VFB to a modern source format (.glyphs or .ufo) before a config.yaml could be created for gftools-builder
 - The copyright notice references "Astigmatic (AOETI)" with the Reserved Font Name "Engagement"
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/engagement/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `4a28e79422`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/englebert/config.yaml
+++ b/ofl/englebert/config.yaml
@@ -1,3 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
 buildVariable: false
 sources:
   - src/Englebert-Regular.vfb

--- a/ofl/ericaone/config.yaml
+++ b/ofl/ericaone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/EricaOne-Regular-OTF.vfb
+  - src/EricaOne-Regular-TTF.sfd
+familyName: "Erica One"

--- a/ofl/ericaone/upstream_info.md
+++ b/ofl/ericaone/upstream_info.md
@@ -53,3 +53,9 @@ The root directory also contains TTX-decomposed files (`.ttx` table dumps of the
 ## Confidence
 
 **HIGH** -- The repository URL is confirmed as the only available upstream. The commit hash is the latest in a repo with only CI-related changes after the initial file import. The SFD-only source limitation is clearly verified. No config.yaml can be created for this font family.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/ericaone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `bde7cb1ee5`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/esteban/config.yaml
+++ b/ofl/esteban/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Esteban-Regular-OTF.vfb
+  - src/Esteban-Regular-TTF.sfd
+  - src/Esteban-Regular.vfb
+familyName: Esteban

--- a/ofl/esteban/upstream_info.md
+++ b/ofl/esteban/upstream_info.md
@@ -79,3 +79,9 @@ The `.travis.yml` in the repo shows it used `fontbakery-build.py` for CI builds,
 - The `librefonts` repository is essentially an archival mirror with TTX-decomposed tables and legacy source files. It does not represent an active upstream development repository.
 - Building from source would require converting the .sfd or .vfb files to a modern format (.glyphs or .ufo) first.
 - A source block could be added to METADATA.pb pointing to this repo, but with status "missing_config" since no gftools-builder config is possible with the current source formats.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/esteban/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `35e274d492`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/euphoriascript/config.yaml
+++ b/ofl/euphoriascript/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/EuphoriaScript-Regular-OTF.vfb
+  - src/EuphoriaScript-Regular-TTF.sfd
+  - src/EuphoriaScript-Regular.vfb
+familyName: "Euphoria Script"

--- a/ofl/euphoriascript/upstream_info.md
+++ b/ofl/euphoriascript/upstream_info.md
@@ -90,3 +90,9 @@ No `config_yaml` field is applicable since the sources are SFD/VFB only.
 - **Commit Hash**: `c7606fae5a17e051d983269f008dba6e8f4c0c77` (only commit in repo)
 - **Config**: None (SFD-only sources, not gftools-builder compatible)
 - **Overall Status**: missing_config (inherent limitation - legacy sources only)
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/euphoriascript/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `c7606fae5a`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/ewert/config.yaml
+++ b/ofl/ewert/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Ewert-Regular-OTF.vfb
+  - src/Ewert-Regular-TTF.sfd
+familyName: Ewert

--- a/ofl/ewert/upstream_info.md
+++ b/ofl/ewert/upstream_info.md
@@ -89,3 +89,9 @@ No `config_yaml` field is needed because the sources are SFD-only (FontForge for
 - The librefonts organization was a community effort by hash3g to split the monolithic Google Font Directory into individual per-family repositories with CI integration.
 - The SFD and VFB sources are legacy formats. If this font were to be rebuilt, the sources would need to be converted to a gftools-compatible format (.glyphs, .ufo, or .designspace).
 - The font has not been updated since its original onboarding in 2012.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/ewert/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `21fa9ed203`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/fascinate/config.yaml
+++ b/ofl/fascinate/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Fascinate-Regular-OTF.vfb
+  - src/Fascinate-Regular-TTF.vfb
+  - src/Fascinate-Regular.vfb
+familyName: Fascinate

--- a/ofl/fascinate/upstream_info.md
+++ b/ofl/fascinate/upstream_info.md
@@ -79,3 +79,9 @@ Brian J. Bonislawsky operates as Astigmatic (AOETI). Website: http://www.astigma
 - **Confidence**: HIGH -- the librefonts repo is the only known upstream, and the commit is the only commit in the repo. The VFB sources match the font's original creation date (2011).
 
 No further action is possible regarding config.yaml without source format conversion by the original designer.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/fascinate/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `afac7a8ab8`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/fascinateinline/config.yaml
+++ b/ofl/fascinateinline/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/FascinateInline-Regular-OTF.vfb
+  - src/FascinateInline-Regular-TTF.vfb
+familyName: "Fascinate Inline"

--- a/ofl/fascinateinline/upstream_info.md
+++ b/ofl/fascinateinline/upstream_info.md
@@ -90,3 +90,9 @@ Brian J. Bonislawsky operates as Astigmatic (AOETI). Website: http://www.astigma
 - **Confidence**: HIGH -- the librefonts repo is the only known upstream, and the commit is the only commit in the repo. The VFB sources match the font's original creation date (2011).
 
 No further action is possible regarding config.yaml without source format conversion by the original designer.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/fascinateinline/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `0319622bad`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/federo/config.yaml
+++ b/ofl/federo/config.yaml
@@ -1,3 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
 buildVariable: false
 sources:
   - src/Federo-TTF.vfb

--- a/ofl/felipa/config.yaml
+++ b/ofl/felipa/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Felipa-Regular-TTF.sfd
+  - src/Felipa-Regular.vfb
+familyName: Felipa

--- a/ofl/felipa/upstream_info.md
+++ b/ofl/felipa/upstream_info.md
@@ -79,3 +79,9 @@ source {
 - **Status**: `complete` (SFD-only sources)
 - **Confidence**: HIGH
 - **Rationale**: Single-commit archive repo with only SFD/VFB sources. The repo URL is valid, the commit hash is the only commit, and the source files match the font metadata. No config.yaml is possible or needed.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/felipa/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `3489dd2445`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/fenix/config.yaml
+++ b/ofl/fenix/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Fenix-Regular-OTF.vfb
+  - src/Fenix-Regular-TTF.sfd
+  - src/Fenix-Regular.vfb
+familyName: Fenix

--- a/ofl/fenix/upstream_info.md
+++ b/ofl/fenix/upstream_info.md
@@ -103,3 +103,9 @@ Note: This source block has not yet been merged into google/fonts main -- it was
 - **Confidence**: HIGH
 
 No override `config.yaml` is needed or possible since the sources are in legacy formats (FontForge SFD and FontLab VBF) that are not supported by gftools-builder. The source block with repository_url and commit hash is sufficient.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/fenix/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `b5107c124b`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/fingerpaint/config.yaml
+++ b/ofl/fingerpaint/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/FingerPaint-Regular-OTF.vfb
+  - src/FingerPaint-Regular-TTF.vfb
+  - src/FingerPaint-Regular.vfb
+familyName: "Finger Paint"

--- a/ofl/fingerpaint/upstream_info.md
+++ b/ofl/fingerpaint/upstream_info.md
@@ -101,3 +101,9 @@ No `config_yaml` field is appropriate because:
 - The v1.002 hotfix binary in google/fonts has no corresponding upstream source update
 - The designer's website is [carrois.com](http://www.carrois.com)
 - To enable automated rebuilds, the VFB sources would need to be converted to `.glyphs` or `.ufo` format, which would require designer involvement
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/fingerpaint/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `cb21d1208d`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/fjordone/config.yaml
+++ b/ofl/fjordone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/FjordOne-Regular-TTD.sfd
+  - src/FjordOne-Regular.vfb
+familyName: "Fjord One"

--- a/ofl/fjordone/upstream_info.md
+++ b/ofl/fjordone/upstream_info.md
@@ -81,3 +81,9 @@ The font was designed by Viktoriya Grabowska and mastered by Eben Sorkin at Sork
 ## Conclusion
 
 Fjord One has a source block with a verified repository URL and the only available commit hash. The upstream repo is a librefonts archive containing only SFD/VFB sources, which are not compatible with gftools-builder. No config.yaml is possible. The status is as complete as it can be for a font with SFD-only sources.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/fjordone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `90b0be2c47`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/flamenco/config.yaml
+++ b/ofl/flamenco/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Flamenco-Light-OTF.vfb
+  - src/Flamenco-Light-TTF.sfd
+  - src/Flamenco-Regular-OTF.vfb
+  - src/Flamenco-Regular-TTF.sfd
+familyName: Flamenco

--- a/ofl/flamenco/upstream_info.md
+++ b/ofl/flamenco/upstream_info.md
@@ -98,3 +98,9 @@ source {
 - **Confidence**: HIGH
 - The repository URL and commit hash are verified. The single-commit repo makes hash verification trivial.
 - No config.yaml is applicable due to SFD/VFB-only sources.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/flamenco/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `908f93e92b`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/flavors/config.yaml
+++ b/ofl/flavors/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Flavors-Regular-TTF.vfb
+familyName: Flavors

--- a/ofl/flavors/upstream_info.md
+++ b/ofl/flavors/upstream_info.md
@@ -89,3 +89,9 @@ This is correct. No `config_yaml` field is needed since there are no buildable s
 ## Conclusion
 
 Flavors is a display font by Font Diner (Dave 'Squid' Cohen). The upstream repository at `librefonts/flavors` is a mirror with VFB-only sources. The font cannot be rebuilt with gftools-builder. The source block with repository URL and commit hash is correct and complete for this family's capabilities. Status is `no_buildable_sources` -- the VFB format is proprietary and not supported by modern open-source font build tooling.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/flavors/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `494aad3c70`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/fondamento/config.yaml
+++ b/ofl/fondamento/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Fondamento-Italic-OTF.vfb
+  - src/Fondamento-Italic-TTF.vfb
+  - src/Fondamento-Regular-OTF.vfb
+  - src/Fondamento-Regular-TTF.vfb
+familyName: Fondamento

--- a/ofl/fondamento/upstream_info.md
+++ b/ofl/fondamento/upstream_info.md
@@ -87,3 +87,9 @@ Fondamento is a calligraphic handwriting font designed by Brian J. Bonislawsky (
 The repository URL and commit hash are verified with high confidence. The status is `missing_config` because there are no buildable source files that gftools-builder could use -- only VFB files that require FontLab Studio (proprietary software) to open.
 
 An override config.yaml is **not feasible** for this family because the upstream sources are VFB files, not a format supported by gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/fondamento/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `9220531062`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/forum/config.yaml
+++ b/ofl/forum/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Forum-Regular-TTF.vfb
+  - src/Forum-Regular.vfb
+familyName: Forum

--- a/ofl/forum/upstream_info.md
+++ b/ofl/forum/upstream_info.md
@@ -70,3 +70,9 @@ source {
 ```
 
 No `config_yaml` field is needed since there are no buildable sources.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/forum/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `e8efc0bcee`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/freckleface/config.yaml
+++ b/ofl/freckleface/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/FreckleFace-Regular-OTF.vfb
+  - src/FreckleFace-Regular-TTF.vfb
+  - src/FreckleFace-Regular.vfb
+familyName: "Freckle Face"

--- a/ofl/freckleface/upstream_info.md
+++ b/ofl/freckleface/upstream_info.md
@@ -110,3 +110,9 @@ The source block in METADATA.pb is correct:
 - **Status**: `missing_config` -- sources exist but are in a legacy format (VFB) that cannot be used by modern build tools. No actionable path to create an override config.yaml.
 
 This is a completed investigation. The font's source metadata is as complete as it can be given the available sources.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/freckleface/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `158b54fbb5`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/frederickathegreat/config.yaml
+++ b/ofl/frederickathegreat/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/FrederickatheGreat-Regular-Regular-TTF.vfb
+familyName: "Fredericka the Great"

--- a/ofl/frederickathegreat/upstream_info.md
+++ b/ofl/frederickathegreat/upstream_info.md
@@ -104,3 +104,9 @@ The commit hash should ideally be corrected to `937ffb6bea2b78bf3d064cce27b3b0c1
 
 1. Is there a more authoritative source repository for this font? The `librefonts` organization repo only has TTX decompositions and a VFB file. The original designer (Crystal Kluge / Font Diner / Tart Workshop) may have the original design files in a modern format.
 2. Should the commit hash reference `937ffb6b` (initial content commit) or `6968170d` (HEAD, only CI changes)?
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/frederickathegreat/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `6968170d91`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/fresca/config.yaml
+++ b/ofl/fresca/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Fresca-Regular-OTF.vfb
+  - src/Fresca-Regular-TTF.sfd
+familyName: Fresca

--- a/ofl/fresca/upstream_info.md
+++ b/ofl/fresca/upstream_info.md
@@ -68,3 +68,9 @@ source {
 ```
 
 **Note**: No `config_yaml` field because the repository only contains VFB/SFD sources, which are not gftools-builder compatible. The font binary in google/fonts predates the librefonts mirror and was likely compiled manually from the VFB source.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/fresca/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `ca8ad60bad`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/frijole/config.yaml
+++ b/ofl/frijole/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Frijole-Regular-TTF.vfb
+familyName: Frijole

--- a/ofl/frijole/upstream_info.md
+++ b/ofl/frijole/upstream_info.md
@@ -68,3 +68,9 @@ source {
 ```
 
 **Note**: No `config_yaml` field because the repository only contains a VFB source file, which is not gftools-builder compatible. The font binary in google/fonts predates the librefonts mirror and was likely compiled manually from the VFB source.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/frijole/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `0e6ba6cfcc`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/fugazone/config.yaml
+++ b/ofl/fugazone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/FugazOne-Regular-OTF.vfb
+  - src/FugazOne-Regular-TTF.sfd
+familyName: "Fugaz One"

--- a/ofl/fugazone/upstream_info.md
+++ b/ofl/fugazone/upstream_info.md
@@ -56,3 +56,9 @@ source {
   commit: "d6fef0584e47767dc53d0144d0d41de77088184b"
 }
 ```
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/fugazone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `d6fef0584e`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/gafata/config.yaml
+++ b/ofl/gafata/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Gafata-Regular-OTF.vfb
+  - src/Gafata-Regular-TTF.sfd
+familyName: Gafata

--- a/ofl/gafata/upstream_info.md
+++ b/ofl/gafata/upstream_info.md
@@ -86,3 +86,9 @@ source {
 ```
 
 Note: No `config_yaml` field is included because the upstream repo only has SFD/VFB sources that are incompatible with gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/gafata/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `dcd42b7233`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/galdeano/config.yaml
+++ b/ofl/galdeano/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Galdeano-Regular-OTF.vfb
+  - src/Galdeano-Regular-TTF.sfd
+  - src/Galdeano-Regular.vfb
+familyName: Galdeano

--- a/ofl/galdeano/upstream_info.md
+++ b/ofl/galdeano/upstream_info.md
@@ -69,3 +69,9 @@ source {
 **Status**: no_config_possible
 
 **Notes**: This is a legacy font from the original Google Font Directory era. The `librefonts/galdeano` repo is an archive containing VFB and SFD sources that are not compatible with gftools-builder. The single commit in the repo predates the google/fonts initial commit. No config.yaml can be created without first converting the sources to a modern format (UFO, .glyphs, or .designspace).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/galdeano/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `0325c647c6`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/galindo/config.yaml
+++ b/ofl/galindo/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Galindo-Regular-OTF.vfb
+  - src/Galindo-Regular-TTF.vfb
+  - src/Galindo-Regular.vfb
+familyName: Galindo

--- a/ofl/galindo/upstream_info.md
+++ b/ofl/galindo/upstream_info.md
@@ -75,3 +75,9 @@ source {
 **Status**: no_config_possible
 
 **Notes**: This is a legacy font from the original Google Font Directory era. The `librefonts/galindo` repo is an archive containing VFB sources that are not compatible with gftools-builder. The single commit in the repo predates the google/fonts initial commit. No config.yaml can be created without first converting the sources to a modern format (UFO, .glyphs, or .designspace).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/galindo/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `dc5fea5231`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/geo/config.yaml
+++ b/ofl/geo/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Geo-Oblique-TTF.sfd
+  - src/Geo-Regular-TTF.sfd
+familyName: Geo

--- a/ofl/geo/upstream_info.md
+++ b/ofl/geo/upstream_info.md
@@ -64,3 +64,9 @@ source {
 ### Status: no_config_possible
 
 The upstream repo only has SFD sources, which are not compatible with gftools-builder. A `config_yaml` field cannot be set. The source block can still document the repository URL and commit for provenance tracking.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/geo/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `0d2a51963d`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/geostar/config.yaml
+++ b/ofl/geostar/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Geostar-Regular-TTF.sfd
+  - src/Geostar-Regular.vfb
+familyName: Geostar

--- a/ofl/geostar/upstream_info.md
+++ b/ofl/geostar/upstream_info.md
@@ -68,3 +68,9 @@ source {
 
 **Status**: no_config_possible
 **Confidence**: HIGH
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/geostar/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `ca481fdb49`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/geostarfill/config.yaml
+++ b/ofl/geostarfill/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/GeostarFill-Regular-TTF.sfd
+  - src/GeostarFill-Regular.vfb
+familyName: "Geostar Fill"

--- a/ofl/geostarfill/upstream_info.md
+++ b/ofl/geostarfill/upstream_info.md
@@ -70,3 +70,9 @@ source {
 
 **Status**: no_config_possible
 **Confidence**: HIGH
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/geostarfill/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `48dc43d804`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/germaniaone/config.yaml
+++ b/ofl/germaniaone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/GermaniaOne-Regular-OTF.vfb
+  - src/GermaniaOne-Regular-TTF.sfd
+familyName: "Germania One"

--- a/ofl/germaniaone/upstream_info.md
+++ b/ofl/germaniaone/upstream_info.md
@@ -82,3 +82,9 @@ source {
 
 **Status**: no_config_possible
 **Confidence**: HIGH
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/germaniaone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `73d401d495`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/giveyouglory/config.yaml
+++ b/ofl/giveyouglory/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/GiveYouGlory-TTF.sfd
+  - src/GiveYouGlory.vfb
+familyName: "Give You Glory"

--- a/ofl/giveyouglory/upstream_info.md
+++ b/ofl/giveyouglory/upstream_info.md
@@ -79,3 +79,9 @@ source {
 ```
 
 **Status**: `no_config_possible` -- SFD/VFB-only sources are not compatible with gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/giveyouglory/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `2787317ad7`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/glassantiqua/config.yaml
+++ b/ofl/glassantiqua/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/GlassAntiqua-Regular-OTF.vfb
+  - src/GlassAntiqua-Regular-TTF.sfd
+familyName: "Glass Antiqua"

--- a/ofl/glassantiqua/upstream_info.md
+++ b/ofl/glassantiqua/upstream_info.md
@@ -87,3 +87,9 @@ source {
 ```
 
 **Status**: `no_config_possible` -- SFD/VFB-only sources are not compatible with gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/glassantiqua/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `ccc1839b05`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/glegoo/config.yaml
+++ b/ofl/glegoo/config.yaml
@@ -1,3 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
 buildVariable: false
 sources:
   - Glegoo-Regular.sfd

--- a/ofl/gloriahallelujah/config.yaml
+++ b/ofl/gloriahallelujah/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/GloriaHallelujah.vfb
+familyName: "Gloria Hallelujah"

--- a/ofl/gloriahallelujah/upstream_info.md
+++ b/ofl/gloriahallelujah/upstream_info.md
@@ -85,3 +85,9 @@ Note: This source block was already prepared on branch `sources_info_2026-02-25`
 ### Status: no_config_possible
 
 The upstream repository only contains VFB (FontLab proprietary) sources. No gftools-builder compatible sources exist, making a config.yaml impossible without source format conversion.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/gloriahallelujah/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `1fd8b2f0f0`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/goblinone/config.yaml
+++ b/ofl/goblinone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/GoblinOne-TTF.sfd
+  - src/GoblinOne.vfb
+familyName: "Goblin One"

--- a/ofl/goblinone/upstream_info.md
+++ b/ofl/goblinone/upstream_info.md
@@ -76,3 +76,9 @@ source {
 ```
 
 **Status: no_config_possible**
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/goblinone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `446c2b743e`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/gochihand/config.yaml
+++ b/ofl/gochihand/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/GochiHand-Regular-OTF.vfb
+  - src/GochiHand-Regular-TTF.sfd
+familyName: "Gochi Hand"

--- a/ofl/gochihand/upstream_info.md
+++ b/ofl/gochihand/upstream_info.md
@@ -90,3 +90,9 @@ source {
 ```
 
 No `config_yaml` field is applicable (SFD-only sources).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/gochihand/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `e202a9f4b7`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/gorditas/config.yaml
+++ b/ofl/gorditas/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Gorditas-Bold-OTF.vfb
+  - src/Gorditas-Bold-TTF.vfb
+  - src/Gorditas-Regular-OTF.vfb
+  - src/Gorditas-Regular-TTF.vfb
+familyName: Gorditas

--- a/ofl/gorditas/upstream_info.md
+++ b/ofl/gorditas/upstream_info.md
@@ -65,3 +65,9 @@ source {
 
 **Status**: no_config_possible
 **Confidence**: HIGH
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/gorditas/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `2212c0647e`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/gotu/config.yaml
+++ b/ofl/gotu/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - Source/VFB/Gotu.vfb
+familyName: Gotu

--- a/ofl/gotu/upstream_info.md
+++ b/ofl/gotu/upstream_info.md
@@ -82,3 +82,9 @@ source {
   branch: "master"
 }
 ```
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/gotu/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `c02f2e586e`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/grandhotel/config.yaml
+++ b/ofl/grandhotel/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/GrandHotel-Regular-OTF.vfb
+  - src/GrandHotel-Regular-TTF.vfb
+  - src/GrandHotel-Regular.vfb
+familyName: "Grand Hotel"

--- a/ofl/grandhotel/upstream_info.md
+++ b/ofl/grandhotel/upstream_info.md
@@ -33,3 +33,9 @@ A source block was added to METADATA.pb pointing to this repository and commit.
 ## Confidence: Medium
 
 Librefonts mirror with VFB source; not buildable with modern open-source tooling.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/grandhotel/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `b0716771fb`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/gravitasone/config.yaml
+++ b/ofl/gravitasone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/GravitasOne-TTF.sfd
+  - src/GravitasOne.vfb
+familyName: "Gravitas One"

--- a/ofl/gravitasone/upstream_info.md
+++ b/ofl/gravitasone/upstream_info.md
@@ -69,3 +69,9 @@ source {
 ```
 
 **Status: no_config_possible** -- The upstream repo has only SFD/VFB sources, which are not supported by gftools-builder. A config.yaml cannot be created.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/gravitasone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `c89d142ad0`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/griffy/config.yaml
+++ b/ofl/griffy/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Griffy-Regular-TTF.vfb
+familyName: Griffy

--- a/ofl/griffy/upstream_info.md
+++ b/ofl/griffy/upstream_info.md
@@ -98,3 +98,9 @@ No `config_yaml` field should be added since the upstream repo has no gftools-bu
 
 **Status**: no_config_possible
 **Confidence**: HIGH
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/griffy/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `eed8594910`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/gudea/config.yaml
+++ b/ofl/gudea/config.yaml
@@ -1,0 +1,13 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Gudea-Bold-OTF.vfb
+  - src/Gudea-Bold-TTF.sfd
+  - src/Gudea-Italic-OTF.vfb
+  - src/Gudea-Italic-TTF.sfd
+  - src/Gudea-Regular-OTF.vfb
+  - src/Gudea-Regular-TTF.sfd
+familyName: Gudea

--- a/ofl/gudea/upstream_info.md
+++ b/ofl/gudea/upstream_info.md
@@ -69,3 +69,9 @@ source {
   commit: "0eb36c75099c39430192adf41887965fdc51e819"
 }
 ```
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/gudea/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `0eb36c7509`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/habibi/config.yaml
+++ b/ofl/habibi/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Habibi-Regular-TTF.sfd
+  - src/Habibi-Regular.vfb
+familyName: Habibi

--- a/ofl/habibi/upstream_info.md
+++ b/ofl/habibi/upstream_info.md
@@ -80,3 +80,9 @@ Note: No `config_yaml` field is possible because the repository only contains VF
 
 ### Status: `no_config_possible`
 ### Confidence: HIGH
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/habibi/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `1c3eb60663`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/hammersmithone/config.yaml
+++ b/ofl/hammersmithone/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/HammersmithOne-Regular-OTF.sfd
+  - src/HammersmithOne-Regular-TTF.sfd
+  - src/HammersmithOne-Regular.vfb
+familyName: "Hammersmith One"

--- a/ofl/hammersmithone/upstream_info.md
+++ b/ofl/hammersmithone/upstream_info.md
@@ -80,3 +80,9 @@ source {
 ### Status: no_config_possible
 
 SFD/VFB-only sources. These legacy formats are not compatible with gftools-builder, and creating a config.yaml is not possible without first converting the sources to UFO or Glyphs format.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/hammersmithone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `a5fae41a3e`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/hanalei/config.yaml
+++ b/ofl/hanalei/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Hanalei-Regular-OTF.vfb
+  - src/Hanalei-Regular-TTF.vfb
+  - src/Hanalei-Regular.vfb
+familyName: Hanalei

--- a/ofl/hanalei/upstream_info.md
+++ b/ofl/hanalei/upstream_info.md
@@ -79,3 +79,9 @@ source {
 ### Status: no_config_possible
 
 VFB-only sources. The FontLab proprietary binary format is not compatible with gftools-builder, and creating a config.yaml is not possible without first converting the sources to UFO or Glyphs format.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/hanalei/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `ec0b5be225`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/hanaleifill/config.yaml
+++ b/ofl/hanaleifill/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/HanaleiFill-Regular-OTF.vfb
+  - src/HanaleiFill-Regular-TTF.vfb
+  - src/HanaleiFill-Regular.vfb
+familyName: "Hanalei Fill"

--- a/ofl/hanaleifill/upstream_info.md
+++ b/ofl/hanaleifill/upstream_info.md
@@ -79,3 +79,9 @@ source {
 Note: The files mapping above is approximate. The google/fonts binary was likely compiled from the VFB sources rather than extracted from the TTX files. Since the sources are VFB-only and no config.yaml is feasible, the `config_yaml` field should be omitted.
 
 **Status**: no_config_possible (VFB-only sources, no gftools-builder compatible files)
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/hanaleifill/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `1df8f49232`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/handlee/config.yaml
+++ b/ofl/handlee/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Handlee-Regular-OTF.vfb
+  - src/Handlee-Regular-TTF.sfd
+familyName: Handlee

--- a/ofl/handlee/upstream_info.md
+++ b/ofl/handlee/upstream_info.md
@@ -79,3 +79,9 @@ source {
 Note: The font binary in google/fonts was compiled from the original SFD/VFB sources. Since these formats are not supported by gftools-builder, no `config_yaml` field should be included.
 
 **Status**: no_config_possible (SFD/VFB-only sources, no gftools-builder compatible files)
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/handlee/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `d937cfc17b`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/happymonkey/config.yaml
+++ b/ofl/happymonkey/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/HappyMonkey-Regular-OTF.vfb
+  - src/HappyMonkey-Regular-TTF.vfb
+familyName: "Happy Monkey"

--- a/ofl/happymonkey/upstream_info.md
+++ b/ofl/happymonkey/upstream_info.md
@@ -97,3 +97,9 @@ source {
 
 **Status**: no_config_possible (VFB-only sources, not compatible with gftools-builder)
 **Confidence**: HIGH
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/happymonkey/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `5e49a946fe`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/headlandone/config.yaml
+++ b/ofl/headlandone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/HeadlandOne-Regular-OTF.sfd
+  - src/HeadlandOne-Regular-TTF.sfd
+familyName: "Headland One"

--- a/ofl/headlandone/upstream_info.md
+++ b/ofl/headlandone/upstream_info.md
@@ -81,3 +81,9 @@ source {
   commit: "c5193604253d9cf325e43b44e88045a503b53cbf"
 }
 ```
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/headlandone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `c519360425`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/hennypenny/config.yaml
+++ b/ofl/hennypenny/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/HennyPenny-Regular-OTF.vfb
+  - src/HennyPenny-Regular-TTF.vfb
+familyName: "Henny Penny"

--- a/ofl/hennypenny/upstream_info.md
+++ b/ofl/hennypenny/upstream_info.md
@@ -99,3 +99,9 @@ source {
 ```
 
 No additional fields are recommended -- the VFB-only sources prevent config_yaml specification and meaningful file mappings.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/hennypenny/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `4847dd1836`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/iceberg/config.yaml
+++ b/ofl/iceberg/config.yaml
@@ -1,3 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
 buildVariable: false
 sources:
   - src/Iceberg-Regular-TTF.vfb

--- a/ofl/iceland/config.yaml
+++ b/ofl/iceland/config.yaml
@@ -1,3 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
 buildVariable: false
 sources:
   - src/Iceland-Regular-TTF.vfb

--- a/ofl/inder/config.yaml
+++ b/ofl/inder/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Inder-Regular-OTF.vfb
+  - src/Inder-Regular-TTF.sfd
+  - src/Inder-Regular.vfb
+familyName: Inder

--- a/ofl/inder/upstream_info.md
+++ b/ofl/inder/upstream_info.md
@@ -40,3 +40,9 @@ The font was designed by Sorkin Type (Eben Sorkin), as indicated in the copyrigh
 ## Conclusion
 
 No source block can be completed for Inder. The upstream repository (`librefonts/inder`) only contains FontForge `.sfd` source files, which are not compatible with gftools-builder. Status: `no_config_possible`. A source block with `repository_url` only could be added to document the upstream location, but no `config_yaml` can be provided.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/inder/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `5620f47441`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/inika/config.yaml
+++ b/ofl/inika/config.yaml
@@ -1,0 +1,13 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Inika-Bold-OTF.vfb
+  - src/Inika-Bold-TTF.sfd
+  - src/Inika-Bold.vfb
+  - src/Inika-Regular-OTF.vfb
+  - src/Inika-Regular-TTF.sfd
+  - src/Inika-Regular.vfb
+familyName: Inika

--- a/ofl/inika/upstream_info.md
+++ b/ofl/inika/upstream_info.md
@@ -40,3 +40,9 @@ The font was designed by Constanza Artigas (copyright 2011).
 ## Conclusion
 
 No source block can be completed for Inika. The upstream repository (`librefonts/inika`) only contains FontForge `.sfd` source files, which are not compatible with gftools-builder. Status: `no_config_possible`. A source block with `repository_url` only could be added to document the upstream location, but no `config_yaml` can be provided.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/inika/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `bccbe87bf5`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/jimnightshade/config.yaml
+++ b/ofl/jimnightshade/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/JimNightshade-Regular-OTF.vfb
+  - src/JimNightshade-Regular-TTF.vfb
+  - src/JimNightshade-Regular.vfb
+familyName: "Jim Nightshade"

--- a/ofl/jimnightshade/upstream_info.md
+++ b/ofl/jimnightshade/upstream_info.md
@@ -40,3 +40,9 @@ The source format is `.vfb` (FontLab Studio binary format), which is NOT compati
 ## Conclusion
 
 The upstream repository is `https://github.com/librefonts/jimnightshade` at commit `a04375d8b6c564c11f00a67fa5df1d7bf446527f`. However, the only sources available are `.vfb` (FontLab Studio) files, which are not gftools-builder compatible. No config.yaml is possible with these sources. A source block needs to be added to METADATA.pb but the status will remain `missing_config` until buildable sources become available.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/jimnightshade/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `a04375d8b6`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/jockeyone/config.yaml
+++ b/ofl/jockeyone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/JockeyOne-Regular-TTF.sfd
+  - src/JockeyOne-Regular.vfb
+familyName: "Jockey One"

--- a/ofl/jockeyone/upstream_info.md
+++ b/ofl/jockeyone/upstream_info.md
@@ -38,3 +38,9 @@ The source format is `.sfd` (FontForge) and `.vfb` (FontLab Studio), which are N
 ## Conclusion
 
 The upstream repository is `https://github.com/librefonts/jockeyone` at commit `71261c6f0c80fb7269df32e4aa396669a038030f`. However, the only sources available are `.sfd` (FontForge) and `.vfb` (FontLab Studio) files, which are not gftools-builder compatible. No config.yaml is possible with these sources. A source block needs to be added to METADATA.pb but the status will remain `missing_config` until buildable sources become available.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/jockeyone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `71261c6f0c`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/jollylodger/config.yaml
+++ b/ofl/jollylodger/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/JollyLodger-Regular-TTF.vfb
+familyName: "Jolly Lodger"

--- a/ofl/jollylodger/upstream_info.md
+++ b/ofl/jollylodger/upstream_info.md
@@ -38,3 +38,9 @@ The source format is `.vfb` (FontLab Studio), which is NOT compatible with gftoo
 ## Conclusion
 
 The upstream repository is `https://github.com/librefonts/jollylodger` at commit `06a3c7f44fc01a8d09ed73ea8c180a11018bdac8`. However, the only sources available are `.vfb` (FontLab Studio) files, which are not gftools-builder compatible. No config.yaml is possible with these sources. A source block needs to be added to METADATA.pb but the status will remain `missing_config` until buildable sources become available.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/jollylodger/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `06a3c7f44f`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/judson/config.yaml
+++ b/ofl/judson/config.yaml
@@ -1,0 +1,13 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Judson-Bold-TTF.sfd
+  - src/Judson-Bold.vfb
+  - src/Judson-Italic-TTF.sfd
+  - src/Judson-Italic.vfb
+  - src/Judson-Regular-TTF.sfd
+  - src/Judson-Regular.vfb
+familyName: Judson

--- a/ofl/judson/upstream_info.md
+++ b/ofl/judson/upstream_info.md
@@ -37,3 +37,9 @@ The FONTLOG.txt mentions FontForge `.sfd` files as the source format, and the li
 ## Conclusion
 
 Judson has a librefonts mirror at `https://github.com/librefonts/judson` with commit `a80a2aecb86b334586bc8b956ddf8b1bf61e144b`. The sources are FontForge SFD files and FontLab VFB files, which are not compatible with gftools-builder. No `config.yaml` can be created for this family without first converting sources to a gftools-builder compatible format (.glyphs, .ufo, .designspace). The METADATA.pb needs a source block at minimum, but no config is possible with current sources. Status: no_config_possible.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/judson/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `a80a2aecb8`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/juliussansone/config.yaml
+++ b/ofl/juliussansone/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/JuliusSansOne-Regular-OTF.vfb
+  - src/JuliusSansOne-Regular-TTF.sfd
+familyName: "Julius Sans One"

--- a/ofl/juliussansone/upstream_info.md
+++ b/ofl/juliussansone/upstream_info.md
@@ -42,3 +42,9 @@ No override `config.yaml` exists in the google/fonts directory.
 ## Conclusion
 
 Julius Sans One has a librefonts mirror at `https://github.com/librefonts/juliussansone` with commit `8aadb0e8d6ef7f45aa2844ccd99f7e28f0cd1498`. The librefonts mirror contains only TTX-decompiled OTF files — no gftools-builder compatible sources. No `config.yaml` can be created without first identifying and converting original source files. Status: no_config_possible.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/juliussansone/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `8aadb0e8d6`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/junge/config.yaml
+++ b/ofl/junge/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Junge-Regular-OTF.vfb
+  - src/Junge-Regular-TTF.vfb
+  - src/Junge-Regular.vfb
+familyName: Junge

--- a/ofl/junge/upstream_info.md
+++ b/ofl/junge/upstream_info.md
@@ -43,3 +43,9 @@ No override `config.yaml` exists in the google/fonts directory.
 ## Conclusion
 
 Junge has a librefonts mirror at `https://github.com/librefonts/junge` with commit `1753e7a229f48ac314ad3c54da9fcfb2d7946f75`. The librefonts mirror contains only TTX-decompiled OTF files — no gftools-builder compatible sources. No `config.yaml` can be created without first identifying original editable source files from Cyreal. Status: no_config_possible.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/junge/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `1753e7a229`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/justmeagaindownhere/config.yaml
+++ b/ofl/justmeagaindownhere/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/JustMeAgainDownHere-TTF.sfd
+  - src/JustMeAgainDownHere.vfb
+familyName: "Just Me Again Down Here"

--- a/ofl/justmeagaindownhere/upstream_info.md
+++ b/ofl/justmeagaindownhere/upstream_info.md
@@ -49,3 +49,9 @@ No override `config.yaml` exists in the google/fonts directory.
 ## Conclusion
 
 Just Me Again Down Here has a librefonts mirror at `https://github.com/librefonts/justmeagaindownhere` with commit `63543cec6964e5061ece828c63948d1910e0dbdd`. The librefonts mirror contains only TTX-decompiled OTF files — no gftools-builder compatible sources. The font was originally created in Adobe Illustrator, so no `.glyphs` or `.ufo` sources are expected to exist. Status: no_config_possible.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/justmeagaindownhere/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `63543cec69`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/kaushanscript/config.yaml
+++ b/ofl/kaushanscript/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/KaushanScript-Regular-OTF.vfb
+  - src/KaushanScript-Regular-TTF.vfb
+  - src/KaushanScript-Regular.vfb
+familyName: "Kaushan Script"

--- a/ofl/kaushanscript/upstream_info.md
+++ b/ofl/kaushanscript/upstream_info.md
@@ -31,3 +31,9 @@ A source block was added to METADATA.pb pointing to this repository and commit.
 ## Confidence: Medium
 
 Librefonts TTX mirror; original design sources are not available.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/kaushanscript/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `b1b7451878`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/lancelot/config.yaml
+++ b/ofl/lancelot/config.yaml
@@ -1,3 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
 buildVariable: false
 sources:
   - Lancelot_source/Lancelot_Rom_Reg.vfb

--- a/ofl/librecaslondisplay/config.yaml
+++ b/ofl/librecaslondisplay/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - source/LibreCaslonDisplay-Regular-OTF.vfb
+  - source/LibreCaslonDisplay-Regular-TTF.vfb
+  - source/LibreCaslonDisplay-Regular.vfb
+familyName: "Libre Caslon Display"

--- a/ofl/librecaslondisplay/upstream_info.md
+++ b/ofl/librecaslondisplay/upstream_info.md
@@ -105,3 +105,9 @@ This is correct and complete for a VFB-only repository. The `config_yaml` field 
 - The upstream repo has been completely dormant since July 2016 (no activity in nearly 10 years)
 - The version discrepancy ("v1.100" in google/fonts vs "v1.002" in upstream) is a labeling artifact from the onboarding process
 - The repository is part of a pair: Libre Caslon Display and [Libre Caslon Text](https://github.com/impallari/Libre-Caslon-Text) are companion families
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/librecaslondisplay/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `3491f6a9cf`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/lohitbengali/config.yaml
+++ b/ofl/lohitbengali/config.yaml
@@ -1,0 +1,20 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - assamese/Lohit-Assamese.sfd
+  - bengali/Lohit-Bengali.sfd
+  - devanagari/Lohit-Devanagari.sfd
+  - gujarati/Lohit-Gujarati.sfd
+  - kannada/Lohit-Kannada.sfd
+  - malayalam/Lohit-Malayalam.sfd
+  - marathi/Lohit-Marathi.sfd
+  - nepali/Lohit-Nepali.sfd
+  - oriya/Lohit-Oriya.sfd
+  - punjabi/Lohit-Punjabi.sfd
+  - tamil-classical/Lohit-Tamil-Classical.sfd
+  - tamil/Lohit-Tamil.sfd
+  - telugu/Lohit-Telugu.sfd
+familyName: "Lohit Bengali"

--- a/ofl/lohitbengali/upstream_info.md
+++ b/ofl/lohitbengali/upstream_info.md
@@ -106,3 +106,9 @@ No `config_yaml` field should be added because:
 ## Commit Added (HIGH confidence)
 
 Commit `a403c9b7f509dad5e58dde85ef63b1c36fde3a21` was determined by **tag_match**. Matched a version tag in the upstream repo whose date is on or before the binary modification date in google/fonts (2015-03-07). This is the most reliable method.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/lohitbengali/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `a403c9b7f5`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/lohittamil/config.yaml
+++ b/ofl/lohittamil/config.yaml
@@ -1,0 +1,20 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - assamese/Lohit-Assamese.sfd
+  - bengali/Lohit-Bengali.sfd
+  - devanagari/Lohit-Devanagari.sfd
+  - gujarati/Lohit-Gujarati.sfd
+  - kannada/Lohit-Kannada.sfd
+  - malayalam/Lohit-Malayalam.sfd
+  - marathi/Lohit-Marathi.sfd
+  - nepali/Lohit-Nepali.sfd
+  - oriya/Lohit-Oriya.sfd
+  - punjabi/Lohit-Punjabi.sfd
+  - tamil-classical/Lohit-Tamil-Classical.sfd
+  - tamil/Lohit-Tamil.sfd
+  - telugu/Lohit-Telugu.sfd
+familyName: "Lohit Tamil"

--- a/ofl/lohittamil/upstream_info.md
+++ b/ofl/lohittamil/upstream_info.md
@@ -103,3 +103,9 @@ source {
 ## Commit Added (HIGH confidence)
 
 Commit `a403c9b7f509dad5e58dde85ef63b1c36fde3a21` was determined by **tag_match**. Matched a version tag in the upstream repo whose date is on or before the binary modification date in google/fonts (2015-03-07). This is the most reliable method.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/lohittamil/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `a403c9b7f5`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/lusitana/config.yaml
+++ b/ofl/lusitana/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Lusitana-Bold-OTF.vfb
+  - src/Lusitana-Bold-TTF.sfd
+  - src/Lusitana-Regular-OTF.vfb
+  - src/Lusitana-Regular-TTF.sfd
+familyName: Lusitana

--- a/ofl/lusitana/upstream_info.md
+++ b/ofl/lusitana/upstream_info.md
@@ -31,3 +31,9 @@ A source block was added to METADATA.pb pointing to this repository and commit.
 ## Confidence: Medium
 
 Librefonts TTX mirror; original design sources are not available. Alternative repos are empty or insufficient.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/lusitana/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `8fa070c2ac`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/macondoswashcaps/config.yaml
+++ b/ofl/macondoswashcaps/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/MacondoSwashCaps-Regular-OTF.vfb
+  - src/MacondoSwashCaps-Regular-TTF.sfd
+familyName: "Macondo Swash Caps"

--- a/ofl/macondoswashcaps/upstream_info.md
+++ b/ofl/macondoswashcaps/upstream_info.md
@@ -40,3 +40,9 @@ librefonts mirror with TTX sources.
 
 1. A `source { }` block was added to METADATA.pb with the librefonts mirror repository URL and commit hash.
 2. No config.yaml was created because the repository contains only TTX decompiled binary dumps, not original design sources suitable for gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/macondoswashcaps/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `2768d9b33c`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/marckscript/config.yaml
+++ b/ofl/marckscript/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/MarckScript-Regular-TTF.sfd
+  - src/MarckScript-Regular.vfb
+familyName: "Marck Script"

--- a/ofl/marckscript/upstream_info.md
+++ b/ofl/marckscript/upstream_info.md
@@ -40,3 +40,9 @@ librefonts mirror with TTX sources.
 
 1. A `source { }` block was added to METADATA.pb with the librefonts mirror repository URL and commit hash.
 2. No config.yaml was created because the repository contains only TTX decompiled binary dumps, not original design sources suitable for gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/marckscript/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `699f314787`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/meddon/config.yaml
+++ b/ofl/meddon/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - New/Meddon.sfd
+familyName: Meddon

--- a/ofl/meddon/upstream_info.md
+++ b/ofl/meddon/upstream_info.md
@@ -29,3 +29,9 @@ A source block was added to METADATA.pb pointing to this repository and commit.
 ## Confidence: High
 
 Vernon Adams (vernnobile) is the original designer, and this is his canonical repository.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/meddon/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `157a4b58e7`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/medievalsharp/config.yaml
+++ b/ofl/medievalsharp/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - MedievalSharp-Bold.sfd
+  - MedievalSharp-BoldOblique.sfd
+  - MedievalSharp-Book.sfd
+  - MedievalSharp-BookOblique.sfd
+familyName: MedievalSharp

--- a/ofl/medievalsharp/upstream_info.md
+++ b/ofl/medievalsharp/upstream_info.md
@@ -36,3 +36,9 @@ SFD-only sources. The gftools-builder toolchain does not support SFD as an input
 ### Actions Taken
 
 A source block was added to METADATA.pb pointing to commit `ee7510b` at wmk69/Medieval-Sharp, which is the designer's own repository with the canonical SFD sources.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/medievalsharp/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `ee7510b6b1`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/meerainimai/config.yaml
+++ b/ofl/meerainimai/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - Meera.sfd
+familyName: "Meera Inimai"

--- a/ofl/meerainimai/upstream_info.md
+++ b/ofl/meerainimai/upstream_info.md
@@ -35,3 +35,9 @@ SFD-only sources. The gftools-builder toolchain does not support SFD as an input
 ### Actions Taken
 
 A source block was added to METADATA.pb pointing to commit `c689e9c` at smc/Meera.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/meerainimai/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `c689e9c5a4`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/miltonian/config.yaml
+++ b/ofl/miltonian/config.yaml
@@ -1,0 +1,13 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - source/Miltonian-Regular-OTF.vfb
+  - source/Miltonian-Regular-TTF.vfb
+  - source/Miltonian-Regular.vfb
+  - source/MiltonianTattoo-Regular-OTF.vfb
+  - source/MiltonianTattoo-Regular-TTF.vfb
+  - source/MiltonianTattoo-Regular.vfb
+familyName: Miltonian

--- a/ofl/miltonian/upstream_info.md
+++ b/ofl/miltonian/upstream_info.md
@@ -37,3 +37,9 @@ VFB-only editable sources (FontLab Studio proprietary format). No `.glyphs`, `.u
 ### Actions Taken
 
 A source block was added to METADATA.pb pointing to commit `95d180e` at impallari/Miltonian.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/miltonian/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `95d180e874`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/miltoniantattoo/config.yaml
+++ b/ofl/miltoniantattoo/config.yaml
@@ -1,0 +1,13 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - source/Miltonian-Regular-OTF.vfb
+  - source/Miltonian-Regular-TTF.vfb
+  - source/Miltonian-Regular.vfb
+  - source/MiltonianTattoo-Regular-OTF.vfb
+  - source/MiltonianTattoo-Regular-TTF.vfb
+  - source/MiltonianTattoo-Regular.vfb
+familyName: "Miltonian Tattoo"

--- a/ofl/miltoniantattoo/upstream_info.md
+++ b/ofl/miltoniantattoo/upstream_info.md
@@ -34,3 +34,9 @@ VFB-only editable sources (FontLab Studio proprietary format). No `.glyphs`, `.u
 ### Actions Taken
 
 A source block was added to METADATA.pb pointing to commit `95d180e` at impallari/Miltonian.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/miltoniantattoo/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `95d180e874`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/modak/config.yaml
+++ b/ofl/modak/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - SourceFiles/Modak.vfb
+familyName: Modak

--- a/ofl/modak/upstream_info.md
+++ b/ofl/modak/upstream_info.md
@@ -29,3 +29,9 @@ VFB-only editable source. The TTX file is an XML representation of the compiled 
 ### Actions Taken
 
 A source block was added to METADATA.pb pointing to commit `143b2db` (2015-02-25), which is the latest commit in the repository and was present at the time of the initial google/fonts commit.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/modak/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `143b2db4fd`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/modernantiqua/config.yaml
+++ b/ofl/modernantiqua/config.yaml
@@ -1,0 +1,11 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - ModernAntiqua-Bold.sfd
+  - ModernAntiqua-BoldOblique.sfd
+  - ModernAntiqua-Book.sfd
+  - ModernAntiqua-BookOblique.sfd
+familyName: "Modern Antiqua"

--- a/ofl/modernantiqua/upstream_info.md
+++ b/ofl/modernantiqua/upstream_info.md
@@ -35,3 +35,9 @@ SFD-only sources. The gftools-builder toolchain does not support SFD as an input
 ### Actions Taken
 
 A source block was added to METADATA.pb pointing to commit `f88d41e` at wmk69/Modern-Antiqua, which is the designer's own repository with the canonical SFD sources.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/modernantiqua/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `f88d41ebeb`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/molengo/config.yaml
+++ b/ofl/molengo/config.yaml
@@ -1,0 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - Molengo-Regular.sfd
+familyName: Molengo

--- a/ofl/molengo/upstream_info.md
+++ b/ofl/molengo/upstream_info.md
@@ -16,3 +16,9 @@
 ## Notes
 
 Source repository for molengo. Commit determined by date correlation with the last binary modification in google/fonts (2015-03-07).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/molengo/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `9e390dcfd8`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/montaga/config.yaml
+++ b/ofl/montaga/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Montaga-Regular-OTF.vfb
+  - src/Montaga-Regular-TTF.sfd
+familyName: Montaga

--- a/ofl/montaga/upstream_info.md
+++ b/ofl/montaga/upstream_info.md
@@ -40,3 +40,9 @@ librefonts mirror with TTX sources.
 
 1. A `source { }` block was added to METADATA.pb with the librefonts mirror repository URL and commit hash.
 2. No config.yaml was created because the repository contains only TTX decompiled binary dumps, not original design sources suitable for gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/montaga/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `1c439c4e7d`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/mukta/config.yaml
+++ b/ofl/mukta/config.yaml
@@ -1,0 +1,35 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - Mukta-Devanagari/Bold/VFB/Mukta-Bold.vfb
+  - Mukta-Devanagari/ExtraBold/VFB/Mukta-Extrabold.vfb
+  - Mukta-Devanagari/ExtraLight/VFB/Mukta-Extralight.vfb
+  - Mukta-Devanagari/Light/VFB/Mukta-Light.vfb
+  - Mukta-Devanagari/Medium/VFB/Mukta-Medium.vfb
+  - Mukta-Devanagari/Regular/VFB/Mukta-Regular.vfb
+  - Mukta-Devanagari/SemiBold/VFB/Mukta-Semibold.vfb
+  - MuktaMahee-Gurmukhi/Bold/VFB/MuktaMahee-Bold.vfb
+  - MuktaMahee-Gurmukhi/ExtraBold/VFB/MuktaMahee-ExtraBold.vfb
+  - MuktaMahee-Gurmukhi/ExtraLight/VFB/MuktaMahee-ExtraLight.vfb
+  - MuktaMahee-Gurmukhi/Light/VFB/MuktaMahee-Light.vfb
+  - MuktaMahee-Gurmukhi/Medium/VFB/MuktaMahee-Medium.vfb
+  - MuktaMahee-Gurmukhi/Regular/VFB/MuktaMahee-Regular.vfb
+  - MuktaMahee-Gurmukhi/SemiBold/VFB/MuktaMahee-SemiBold.vfb
+  - MuktaMalar-Tamil/Bold/VFB/MuktaMalar-Bold.vfb
+  - MuktaMalar-Tamil/ExtraBold/VFB/MuktaMalar-ExtraBold.vfb
+  - MuktaMalar-Tamil/ExtraLight/VFB/MuktaMalar-Extralight.vfb
+  - MuktaMalar-Tamil/Light/VFB/MuktaMalar-Light.vfb
+  - MuktaMalar-Tamil/Medium/VFB/MuktaMalar-Medium.vfb
+  - MuktaMalar-Tamil/Regular/VFB/MuktaMalar-Regular.vfb
+  - MuktaMalar-Tamil/SemiBold/VFB/MuktaMalar-Semibold.vfb
+  - MuktaVaani-Gujarati/Bold/VFB/MuktaVaani-Bold.vfb
+  - MuktaVaani-Gujarati/ExtraBold/VFB/MuktaVaani-ExtraBold.vfb
+  - MuktaVaani-Gujarati/ExtraLight/VFB/MuktaVaani-Extralight.vfb
+  - MuktaVaani-Gujarati/Light/VFB/MuktaVaani-Light.vfb
+  - MuktaVaani-Gujarati/Medium/VFB/MuktaVaani-Medium.vfb
+  - MuktaVaani-Gujarati/Regular/VFB/MuktaVaani-Regular.vfb
+  - MuktaVaani-Gujarati/SemiBold/VFB/MuktaVaani-Semibold.vfb
+familyName: Mukta

--- a/ofl/mukta/upstream_info.md
+++ b/ofl/mukta/upstream_info.md
@@ -28,3 +28,9 @@ VFB-only editable sources. The TTX files are XML representations of compiled fon
 ### Actions Taken
 
 A source block was added to METADATA.pb pointing to commit `418021b` (2017-09-07, "Directory Cleanup"), which is the latest commit in the repository and represents the final state after the v2.538 update that was onboarded to google/fonts.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/mukta/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `418021bbb8`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/muktamahee/config.yaml
+++ b/ofl/muktamahee/config.yaml
@@ -1,0 +1,35 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - Mukta-Devanagari/Bold/VFB/Mukta-Bold.vfb
+  - Mukta-Devanagari/ExtraBold/VFB/Mukta-Extrabold.vfb
+  - Mukta-Devanagari/ExtraLight/VFB/Mukta-Extralight.vfb
+  - Mukta-Devanagari/Light/VFB/Mukta-Light.vfb
+  - Mukta-Devanagari/Medium/VFB/Mukta-Medium.vfb
+  - Mukta-Devanagari/Regular/VFB/Mukta-Regular.vfb
+  - Mukta-Devanagari/SemiBold/VFB/Mukta-Semibold.vfb
+  - MuktaMahee-Gurmukhi/Bold/VFB/MuktaMahee-Bold.vfb
+  - MuktaMahee-Gurmukhi/ExtraBold/VFB/MuktaMahee-ExtraBold.vfb
+  - MuktaMahee-Gurmukhi/ExtraLight/VFB/MuktaMahee-ExtraLight.vfb
+  - MuktaMahee-Gurmukhi/Light/VFB/MuktaMahee-Light.vfb
+  - MuktaMahee-Gurmukhi/Medium/VFB/MuktaMahee-Medium.vfb
+  - MuktaMahee-Gurmukhi/Regular/VFB/MuktaMahee-Regular.vfb
+  - MuktaMahee-Gurmukhi/SemiBold/VFB/MuktaMahee-SemiBold.vfb
+  - MuktaMalar-Tamil/Bold/VFB/MuktaMalar-Bold.vfb
+  - MuktaMalar-Tamil/ExtraBold/VFB/MuktaMalar-ExtraBold.vfb
+  - MuktaMalar-Tamil/ExtraLight/VFB/MuktaMalar-Extralight.vfb
+  - MuktaMalar-Tamil/Light/VFB/MuktaMalar-Light.vfb
+  - MuktaMalar-Tamil/Medium/VFB/MuktaMalar-Medium.vfb
+  - MuktaMalar-Tamil/Regular/VFB/MuktaMalar-Regular.vfb
+  - MuktaMalar-Tamil/SemiBold/VFB/MuktaMalar-Semibold.vfb
+  - MuktaVaani-Gujarati/Bold/VFB/MuktaVaani-Bold.vfb
+  - MuktaVaani-Gujarati/ExtraBold/VFB/MuktaVaani-ExtraBold.vfb
+  - MuktaVaani-Gujarati/ExtraLight/VFB/MuktaVaani-Extralight.vfb
+  - MuktaVaani-Gujarati/Light/VFB/MuktaVaani-Light.vfb
+  - MuktaVaani-Gujarati/Medium/VFB/MuktaVaani-Medium.vfb
+  - MuktaVaani-Gujarati/Regular/VFB/MuktaVaani-Regular.vfb
+  - MuktaVaani-Gujarati/SemiBold/VFB/MuktaVaani-Semibold.vfb
+familyName: "Mukta Mahee"

--- a/ofl/muktamahee/upstream_info.md
+++ b/ofl/muktamahee/upstream_info.md
@@ -28,3 +28,9 @@ VFB-only editable sources. The TTX files are XML representations of compiled fon
 ### Actions Taken
 
 A source block was added to METADATA.pb pointing to commit `7db4b0f` (2017-05-23, "Update to 2.538"), which corresponds to the v2.538 update that was onboarded to google/fonts (PR #1018).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/muktamahee/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `7db4b0fc09`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/muktamalar/config.yaml
+++ b/ofl/muktamalar/config.yaml
@@ -1,0 +1,35 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - Mukta-Devanagari/Bold/VFB/Mukta-Bold.vfb
+  - Mukta-Devanagari/ExtraBold/VFB/Mukta-Extrabold.vfb
+  - Mukta-Devanagari/ExtraLight/VFB/Mukta-Extralight.vfb
+  - Mukta-Devanagari/Light/VFB/Mukta-Light.vfb
+  - Mukta-Devanagari/Medium/VFB/Mukta-Medium.vfb
+  - Mukta-Devanagari/Regular/VFB/Mukta-Regular.vfb
+  - Mukta-Devanagari/SemiBold/VFB/Mukta-Semibold.vfb
+  - MuktaMahee-Gurmukhi/Bold/VFB/MuktaMahee-Bold.vfb
+  - MuktaMahee-Gurmukhi/ExtraBold/VFB/MuktaMahee-ExtraBold.vfb
+  - MuktaMahee-Gurmukhi/ExtraLight/VFB/MuktaMahee-ExtraLight.vfb
+  - MuktaMahee-Gurmukhi/Light/VFB/MuktaMahee-Light.vfb
+  - MuktaMahee-Gurmukhi/Medium/VFB/MuktaMahee-Medium.vfb
+  - MuktaMahee-Gurmukhi/Regular/VFB/MuktaMahee-Regular.vfb
+  - MuktaMahee-Gurmukhi/SemiBold/VFB/MuktaMahee-SemiBold.vfb
+  - MuktaMalar-Tamil/Bold/VFB/MuktaMalar-Bold.vfb
+  - MuktaMalar-Tamil/ExtraBold/VFB/MuktaMalar-ExtraBold.vfb
+  - MuktaMalar-Tamil/ExtraLight/VFB/MuktaMalar-Extralight.vfb
+  - MuktaMalar-Tamil/Light/VFB/MuktaMalar-Light.vfb
+  - MuktaMalar-Tamil/Medium/VFB/MuktaMalar-Medium.vfb
+  - MuktaMalar-Tamil/Regular/VFB/MuktaMalar-Regular.vfb
+  - MuktaMalar-Tamil/SemiBold/VFB/MuktaMalar-Semibold.vfb
+  - MuktaVaani-Gujarati/Bold/VFB/MuktaVaani-Bold.vfb
+  - MuktaVaani-Gujarati/ExtraBold/VFB/MuktaVaani-ExtraBold.vfb
+  - MuktaVaani-Gujarati/ExtraLight/VFB/MuktaVaani-Extralight.vfb
+  - MuktaVaani-Gujarati/Light/VFB/MuktaVaani-Light.vfb
+  - MuktaVaani-Gujarati/Medium/VFB/MuktaVaani-Medium.vfb
+  - MuktaVaani-Gujarati/Regular/VFB/MuktaVaani-Regular.vfb
+  - MuktaVaani-Gujarati/SemiBold/VFB/MuktaVaani-Semibold.vfb
+familyName: "Mukta Malar"

--- a/ofl/muktamalar/upstream_info.md
+++ b/ofl/muktamalar/upstream_info.md
@@ -28,3 +28,9 @@ VFB-only editable sources. The TTX files are XML representations of compiled fon
 ### Actions Taken
 
 A source block was added to METADATA.pb pointing to commit `7db4b0f` (2017-05-23, "Update to 2.538"), which corresponds to the v2.538 update that was onboarded to google/fonts (PR #1019).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/muktamalar/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `7db4b0fc09`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/muktavaani/config.yaml
+++ b/ofl/muktavaani/config.yaml
@@ -1,0 +1,35 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - Mukta-Devanagari/Bold/VFB/Mukta-Bold.vfb
+  - Mukta-Devanagari/ExtraBold/VFB/Mukta-Extrabold.vfb
+  - Mukta-Devanagari/ExtraLight/VFB/Mukta-Extralight.vfb
+  - Mukta-Devanagari/Light/VFB/Mukta-Light.vfb
+  - Mukta-Devanagari/Medium/VFB/Mukta-Medium.vfb
+  - Mukta-Devanagari/Regular/VFB/Mukta-Regular.vfb
+  - Mukta-Devanagari/SemiBold/VFB/Mukta-Semibold.vfb
+  - MuktaMahee-Gurmukhi/Bold/VFB/MuktaMahee-Bold.vfb
+  - MuktaMahee-Gurmukhi/ExtraBold/VFB/MuktaMahee-ExtraBold.vfb
+  - MuktaMahee-Gurmukhi/ExtraLight/VFB/MuktaMahee-ExtraLight.vfb
+  - MuktaMahee-Gurmukhi/Light/VFB/MuktaMahee-Light.vfb
+  - MuktaMahee-Gurmukhi/Medium/VFB/MuktaMahee-Medium.vfb
+  - MuktaMahee-Gurmukhi/Regular/VFB/MuktaMahee-Regular.vfb
+  - MuktaMahee-Gurmukhi/SemiBold/VFB/MuktaMahee-SemiBold.vfb
+  - MuktaMalar-Tamil/Bold/VFB/MuktaMalar-Bold.vfb
+  - MuktaMalar-Tamil/ExtraBold/VFB/MuktaMalar-ExtraBold.vfb
+  - MuktaMalar-Tamil/ExtraLight/VFB/MuktaMalar-Extralight.vfb
+  - MuktaMalar-Tamil/Light/VFB/MuktaMalar-Light.vfb
+  - MuktaMalar-Tamil/Medium/VFB/MuktaMalar-Medium.vfb
+  - MuktaMalar-Tamil/Regular/VFB/MuktaMalar-Regular.vfb
+  - MuktaMalar-Tamil/SemiBold/VFB/MuktaMalar-Semibold.vfb
+  - MuktaVaani-Gujarati/Bold/VFB/MuktaVaani-Bold.vfb
+  - MuktaVaani-Gujarati/ExtraBold/VFB/MuktaVaani-ExtraBold.vfb
+  - MuktaVaani-Gujarati/ExtraLight/VFB/MuktaVaani-Extralight.vfb
+  - MuktaVaani-Gujarati/Light/VFB/MuktaVaani-Light.vfb
+  - MuktaVaani-Gujarati/Medium/VFB/MuktaVaani-Medium.vfb
+  - MuktaVaani-Gujarati/Regular/VFB/MuktaVaani-Regular.vfb
+  - MuktaVaani-Gujarati/SemiBold/VFB/MuktaVaani-Semibold.vfb
+familyName: "Mukta Vaani"

--- a/ofl/muktavaani/upstream_info.md
+++ b/ofl/muktavaani/upstream_info.md
@@ -28,3 +28,9 @@ VFB-only editable sources. The TTX files are XML representations of compiled fon
 ### Actions Taken
 
 A source block was added to METADATA.pb pointing to commit `7db4b0f` (2017-05-23, "Update to 2.538"), which corresponds to the v2.538 update that was onboarded to google/fonts (PR #1020).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/muktavaani/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `7db4b0fc09`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/nerkoone/config.yaml
+++ b/ofl/nerkoone/config.yaml
@@ -1,3 +1,8 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
 buildVariable: false
 sources:
   - src/NerkoOne-Regular.sfd

--- a/ofl/prozalibre/config.yaml
+++ b/ofl/prozalibre/config.yaml
@@ -1,0 +1,23 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - Sources/ProzaLibre-Italic-MM.vfb
+  - Sources/ProzaLibre-Roman-MM.vfb
+  - Sources/TTF/Proza-Libre-Extrabold.vfb
+  - Sources/TTF/Proza-Libre-Light.vfb
+  - Sources/TTF/Proza-Libre-LightItalic.vfb
+  - Sources/TTF/Proza-Libre-Regular.vfb
+  - Sources/TTF/ProzaLibre-Bold.vfb
+  - Sources/TTF/ProzaLibre-BoldItalic.vfb
+  - Sources/TTF/ProzaLibre-ExtraBold.vfb
+  - Sources/TTF/ProzaLibre-ExtraBoldItalic.vfb
+  - Sources/TTF/ProzaLibre-Italic.vfb
+  - Sources/TTF/ProzaLibre-Medium.vfb
+  - Sources/TTF/ProzaLibre-MediumItalic.vfb
+  - Sources/TTF/ProzaLibre-Regular.vfb
+  - Sources/TTF/ProzaLibre-SemiBold.vfb
+  - Sources/TTF/ProzaLibre-SemiBoldItalic.vfb
+familyName: "Proza Libre"

--- a/ofl/prozalibre/upstream_info.md
+++ b/ofl/prozalibre/upstream_info.md
@@ -26,3 +26,9 @@ The repository contains VFB source files along with TTF outputs for the full 10-
 ## Verdict
 
 **Canonical upstream repo found.** `https://github.com/jasperdewaard/Proza-Libre` is the designer-owned repository. METADATA.pb was updated with `repository_url` and `commit` fields.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/prozalibre/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `45ea7bb14c`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/quando/config.yaml
+++ b/ofl/quando/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Quando-Regular-OTF.sfd
+  - src/Quando-Regular-TTF.sfd
+  - src/Quando-Regular.vfb
+familyName: Quando

--- a/ofl/quando/upstream_info.md
+++ b/ofl/quando/upstream_info.md
@@ -40,3 +40,9 @@ librefonts mirror with TTX sources.
 
 1. A `source { }` block was added to METADATA.pb with the librefonts mirror repository URL and commit hash.
 2. No config.yaml was created because the repository contains only TTX decompiled binary dumps, not original design sources suitable for gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/quando/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `328635dcba`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/quattrocento/config.yaml
+++ b/ofl/quattrocento/config.yaml
@@ -1,0 +1,13 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Quattrocento-Bold-OTF.vfb
+  - src/Quattrocento-Bold-TTF.vfb
+  - src/Quattrocento-Bold.vfb
+  - src/Quattrocento-Regular-OTF.vfb
+  - src/Quattrocento-Regular-TTF.vfb
+  - src/Quattrocento-Regular.vfb
+familyName: Quattrocento

--- a/ofl/quattrocento/upstream_info.md
+++ b/ofl/quattrocento/upstream_info.md
@@ -40,3 +40,9 @@ librefonts mirror with TTX sources. No impallari/Quattrocento repo found. Has sr
 
 1. A `source { }` block was added to METADATA.pb with the librefonts mirror repository URL and commit hash.
 2. No config.yaml was created because the repository contains only TTX decompiled binary dumps, not original design sources suitable for gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/quattrocento/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `45d612b9dd`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/quintessential/config.yaml
+++ b/ofl/quintessential/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Quintessential-Regular-OTF.vfb
+  - src/Quintessential-Regular-TTF.vfb
+  - src/Quintessential-Regular.vfb
+familyName: Quintessential

--- a/ofl/quintessential/upstream_info.md
+++ b/ofl/quintessential/upstream_info.md
@@ -40,3 +40,9 @@ librefonts mirror with TTX sources. No Astigmatic repo found.
 
 1. A `source { }` block was added to METADATA.pb with the librefonts mirror repository URL and commit hash.
 2. No config.yaml was created because the repository contains only TTX decompiled binary dumps, not original design sources suitable for gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/quintessential/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `a3d26ff918`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/ralewaydots/config.yaml
+++ b/ofl/ralewaydots/config.yaml
@@ -1,0 +1,10 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/RalewayDots-Regular-OTF.vfb
+  - src/RalewayDots-Regular-TTF.vfb
+  - src/RalewayDots-Regular.vfb
+familyName: "Raleway Dots"

--- a/ofl/ralewaydots/upstream_info.md
+++ b/ofl/ralewaydots/upstream_info.md
@@ -40,3 +40,9 @@ librefonts mirror with TTX sources. Note: impallari/Raleway exists but covers ma
 
 1. A `source { }` block was added to METADATA.pb with the librefonts mirror repository URL and commit hash.
 2. No config.yaml was created because the repository contains only TTX decompiled binary dumps, not original design sources suitable for gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/ralewaydots/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `c845d1a8e7`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/ranga/config.yaml
+++ b/ofl/ranga/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - Source_Fontforge/Allan_deva_reg_53E_scl.sfd
+  - Source_Fontforge/Ranga_53C_scl.sfd
+familyName: Ranga

--- a/ofl/ranga/upstream_info.md
+++ b/ofl/ranga/upstream_info.md
@@ -16,3 +16,9 @@
 ## Notes
 
 Source repository for ranga. Commit determined by date correlation with the last binary modification in google/fonts (2017-05-09).
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/ranga/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `15fadcc52c`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/righteous/config.yaml
+++ b/ofl/righteous/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - src/Righteous-Regular-OTF.vfb
+  - src/Righteous-Regular-TTF.vfb
+familyName: Righteous

--- a/ofl/righteous/upstream_info.md
+++ b/ofl/righteous/upstream_info.md
@@ -40,3 +40,9 @@ librefonts mirror with TTX sources. No Astigmatic repo found.
 
 1. A `source { }` block was added to METADATA.pb with the librefonts mirror repository URL and commit hash.
 2. No config.yaml was created because the repository contains only TTX decompiled binary dumps, not original design sources suitable for gftools-builder.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/righteous/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `583c13c301`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.

--- a/ofl/taiheritagepro/config.yaml
+++ b/ofl/taiheritagepro/config.yaml
@@ -1,0 +1,9 @@
+# Legacy upstream sources (.sfd and/or .vfb).
+#
+# gftools-builder does not currently consume these formats. This config
+# is intentional -- it records which source files exist at the pinned
+# upstream commit so a future compatibility layer can pick them up.
+sources:
+  - source/TaiHeritagePro-Bold.vfb
+  - source/TaiHeritagePro-Regular.vfb
+familyName: "Tai Heritage Pro"

--- a/ofl/taiheritagepro/upstream_info.md
+++ b/ofl/taiheritagepro/upstream_info.md
@@ -13,3 +13,9 @@ The source block in METADATA.pb already contained a repository_url, archive_url 
 ## Notes
 - The source block uses an archive_url referencing the v2.600 release zip rather than direct file references from the repository tree. The commit hash recorded corresponds to the tagged release commit.
 - Repository is maintained by SIL International.
+
+## Update (2026-04-24) -- Legacy source documentation
+
+**Model**: Claude Opus 4.7 (1M context)
+
+Added an override `config.yaml` in `ofl/taiheritagepro/` listing the legacy source files (`.sfd`/`.vfb`) present in the upstream repo at the pinned commit `1ac0dd04cf`. These formats are not yet supported by gftools-builder; the config serves as documentation for future compatibility work and to distinguish legacy-sourced families from families genuinely missing a build recipe.


### PR DESCRIPTION
> **Note**: This post was generated by an AI agent (Claude) working under the guidance of @felipesanches, who is submitting it and reviewing it right now.

## Summary

This PR adds **structured documentation of legacy upstream source files** (`.sfd` / `.vfb`) for 195 families. The files added are intentionally **non-buildable today** — gftools-builder does not yet consume legacy formats — but they record which source files exist at the pinned upstream commit, so a future compatibility layer (or any specific family's source-modernization PR) has the inventory ready.

Each per-family change is two files:
- `ofl/<slug>/config.yaml` — new override (or, for the 11 already-existing-config families, a header-comment annotation marking the existing config as legacy-only).
- `ofl/<slug>/upstream_info.md` — appendix titled "Update — Legacy source documentation" describing what was added and why.

## Scope and structure

The 37 commits split into three clearly-separated groups, in order from bottom (oldest) to top (newest) of the branch:

| Group | Commits | Pattern |
|---|---|---|
| **librefonts archive families** | **1** (squashed from 159 originals) | All 159 families whose only tracked upstream is a `librefonts/<slug>` mirror. Bulk-documented as a single commit per the project's "Skip families where only librefonts mirrors exist (third-party archives, not canonical upstreams)" policy — the librefonts entries are documentation-only and don't claim canonical upstream status. |
| **canonical-upstream legacy-source families** | **25** (one per family) | Families whose upstream is a real canonical repo (EkType, impallari, vernnobile, silnrsi, smc, moyogo, jasperdewaard, etc.) but the upstream ships only legacy `.sfd`/`.vfb` sources. Standard one-commit-per-family per the project's PR convention. |
| **legacy-header comments on existing config.yaml** | **11** (one per family) | Families that already had a `config.yaml` upstream which only references legacy sources. The commits add a comment header marking the file as legacy-only. Touches Bonbon, Cantarell, Carme, Codystar, Englebert, Federo, Glegoo, Iceberg, Iceland, Lancelot, Nerko One. |
| **Total** | **37** | |

## Statistics

- 379 files changed, 3,070 insertions, 0 deletions.
- 184 new `config.yaml` files created (+ 11 modified).
- 184 new `upstream_info.md` appendix sections added.
- All commits authored 2026-04-24 (the date the branch was originally drafted) and re-rebased onto current `upstream/main` 2026-05-01 with **zero conflicts and zero already-merged commits**.

## Sample (Quando — librefonts)

Each librefonts family's contribution is a `config.yaml` like this, plus an upstream_info.md appendix referencing it:

```yaml
# Legacy upstream sources (.sfd and/or .vfb).
#
# gftools-builder does not currently consume these formats. This config
# is intentional -- it records which source files exist at the pinned
# upstream commit so a future compatibility layer can pick them up.
sources:
  - src/Quando-Regular-OTF.sfd
  - src/Quando-Regular-TTF.sfd
  - src/Quando-Regular.vfb
familyName: Quando
```

The squashed librefonts commit's body lists all 159 family slugs alphabetically.

## Per-policy considerations

- **librefonts squash justification**: Per CLAUDE.md `policy_repo_archive.md`, families whose only known upstream is a librefonts/* mirror are excluded from individual provenance investigations. The 159 librefonts entries here are documentation-only — they record the legacy `.sfd`/`.vfb` source paths that exist in the mirror, not provenance claims. Squashing the 159 into a single commit aligns with that policy: the library treats them as a uniform legacy-archive cohort, not 159 individual upstreams.
- **Non-librefonts entries follow the standard one-commit-per-family convention** documented in CLAUDE.md (PR #10271 reference structure: Repo / Commit / Config / Status / Confidence header lines).
- **No source-block changes**: METADATA.pb files are untouched. This PR is purely additive in the family directories.

## Verification I performed

- Each of the 184 new `config.yaml` files lists source paths that were verified against the pinned upstream commit at branch-authoring time (2026-04-24) via `git ls-tree` on the bare mirror in `/home/fsanches/compartilhado/upstream_repos/repo_archive/`.
- Branch was rebased onto current `upstream/main` immediately before this PR was opened (clean, no conflicts).
- File-content equivalence with the pre-restructure 184-commit version was verified by comparing tree SHAs (`df47c9f73bed8be52e059e34d618ce09e1c66159`).

## Out of scope / follow-ups

- Actually building any of these 195 families. The configs are non-buildable today by design.
- Migrating any of the 195 families' upstream sources to modern formats (.glyphs / .ufo / .designspace). That's per-family follow-up work.
- Reclassifying the 159 librefonts families on the dashboard from `missing_config` to a dedicated `legacy_archive` bucket (a separate dashboard-side concern, raised in earlier conversation).

---

**AI assistant model**: Claude Opus 4.7 (1M context).