### PR TITLE
[Knowledge] Arrr article - fixes

### DIFF
--- a/cc-by-sa/knowledge/glossary/terms/arrr_axis/content.md
+++ b/cc-by-sa/knowledge/glossary/terms/arrr_axis/content.md
@@ -11,7 +11,7 @@ The [Google Fonts CSS v2 API](https://developers.google.com/fonts/docs/css2) def
 
 ![An image showing two type specimens, each with an axis slider underneath. The specimen on the left shows the effects of the axis’ lowest value. The specimen on the right shows the effects of the axis’ highest value.](images/thumbnail.svg)
 
-<figcaption>Typeface: [AR One Sans](https://fonts.google.com/specimen/AR+One+Sans)</figcaption>
+<figcaption>Typeface: <a href="https://fonts.google.com/specimen/AR+One+Sans">AR One Sans</a></figcaption>
 </figure>
 
 In practice, this means that parts of the [letterforms](/glossary/letterform)’ [strokes](/glossary/stroke) are tapered — either flaring out at the ends of stems, or (much like [ink traps](/glossary/ink_trap)) indenting where strokes meet. The primary goal of this axis is to ensure the quality of the reading experience is the same for users with low- and high-resolution headsets. Therefore, all adjustments are intended to make the text render appear equal to all users.


### PR DESCRIPTION
Caption wasn't displayed correctly (url)

<img width="717" height="484" alt="Screenshot 2026-05-08 at 14 30 00" src="https://github.com/user-attachments/assets/eb1f646d-755a-462d-9a82-6a262dddf32c" />


cc @aaronbell @davelab6 