### PR TITLE
ci: declare contents: read in four pure-CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,9 @@ on:
     - "to_*.txt"
     - ".github/workflows/ci.yaml"
 
+permissions:
+  contents: read
+
 jobs:
   check_knowledge_graph:
     runs-on: ubuntu-latest

--- a/.github/workflows/designers.yaml
+++ b/.github/workflows/designers.yaml
@@ -5,6 +5,9 @@ on:
     paths:
     - 'catalog/designers/*/*'
 
+permissions:
+  contents: read
+
 jobs:
   test_designer_profiles:
     runs-on: ubuntu-22.04

--- a/.github/workflows/font_tags.yaml
+++ b/.github/workflows/font_tags.yaml
@@ -10,6 +10,9 @@ on:
     - 'tags/all/families.csv'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test_font_tags:
     runs-on: ubuntu-latest

--- a/.github/workflows/pushlists.yaml
+++ b/.github/workflows/pushlists.yaml
@@ -6,6 +6,9 @@ on:
     - 'to_production.txt'
     - '.github/workflows/pushlists.yaml"'
 
+permissions:
+  contents: read
+
 jobs:
   test_server_files:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Four workflows currently run with no  block, so  picks up whatever the repository default is. Each of them only checks out the repo and runs a Python validator (gftools / knowledge_graph.py / designer profiles / pushlist linter). None push commits, comment, or call any GitHub write endpoint.

`scorecard.yml` in this repo already declares `permissions: read-all`; this PR brings the four data-check workflows in line with that explicit-scope convention.

YAML validated locally before commit.