### PR TITLE
Workflow fix - Uploard artifact

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload check results
         if: steps.check_files.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: qa-${{ matrix.os }}
           path: out/
@@ -128,7 +128,7 @@ jobs:
 
       - name: Upload check results
         if: steps.check_files.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: qa-diffenator
           path: out/
@@ -161,3 +161,4 @@ jobs:
           python-version: "3.10"
       - name: Test font with ftxvalidator
         run: python3 .ci/ftxvalidator.py
+        

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -161,4 +161,3 @@ jobs:
           python-version: "3.10"
       - name: Test font with ftxvalidator
         run: python3 .ci/ftxvalidator.py
-        


### PR DESCRIPTION
[CI is failing](https://github.com/google/fonts/actions/runs/25808417937/job/75949197647?pr=10527), I tried to fix it by changing artifact versions (using Claude)

```
Run actions/upload-artifact/merge@v4
Found 0 artifact(s)
Error: No artifacts found matching pattern 'qa-*'
```

@m4rc1e or @simoncozens can you have a look?
