### PR TITLE
[Knowledge] Several small article fixes

### DIFF
--- a/cc-by-sa/knowledge/glossary/terms/flar_axis/content.md
+++ b/cc-by-sa/knowledge/glossary/terms/flar_axis/content.md
@@ -10,7 +10,7 @@ The [Google Fonts CSS v2 API](https://developers.google.com/fonts/docs/css2) def
 
 ![An image showing two type specimens, each with an axis slider underneath. The specimen on the left shows the effects of the axis’ lowest value. The specimen on the right shows the effects of the axis’ highest value.](images/thumbnail.svg)
 
-<figcaption>Typeface: [Commissioner](https://fonts.google.com/specimen/Commissioner)</figcaption>
+<figcaption>Typeface: <a href="https://fonts.google.com/specimen/Commissioner">Commissioner</a></figcaption>
 </figure>
 
 Left at the minimum value, the [strokes](/glossary/stroke) are [monolinear](/glossary/monolinear); at the maximum value, more contrast is introduced to the letterforms. The effect is more noticeable in heavier font weights.

--- a/cc-by-sa/knowledge/glossary/terms/year_axis/content.md
+++ b/cc-by-sa/knowledge/glossary/terms/year_axis/content.md
@@ -11,7 +11,7 @@ The [Google Fonts CSS v2 API](https://developers.google.com/fonts/docs/css2) def
 
 ![An image showing two type specimens, each with an axis slider underneath. The specimen on the left shows the effects of the axis’ lowest value. The specimen on the right shows the effects of the axis’ highest value.](images/thumbnail.svg)
 
-<figcaption>The [Climate Crisis font](https://fonts.google.com/specimen/Climate+Crisis) has a ‘Year’ axis that starts in 1979 with fully formed letters and progresses to 2050 where the letters appear melted away to the point that they are almost illegible.</figcaption>
+<figcaption>The <a href="https://fonts.google.com/specimen/Climate+Crisis">Climate Crisis font</a> has a 'Year' axis that starts in 1979 with fully formed letters and progresses to 2050 where the letters appear melted away to the point that they are almost illegible.</figcaption>
 </figure>
 
 The axis’ first use, in the Climate Crisis font created by Finnish newspaper Helsingin Sanomat, shows how Arctic ice has and will continue to shrink because of climate change, based on current forecasts. It was informed by the US National Snow and Ice Data Center’s Arctic sea ice data from 1979 to 2019, plus the Intergovernmental Panel on Climate Change’s predictions for Arctic sea ice all the way to 2050. 

--- a/cc-by-sa/knowledge/modules/the_canadian_syllabics/lessons/inuktut_syllabics/content.md
+++ b/cc-by-sa/knowledge/modules/the_canadian_syllabics/lessons/inuktut_syllabics/content.md
@@ -18,7 +18,7 @@ Both forms are mutually intelligible between either community, with the only dif
 
 ![A map of the Nunavut and Nunavik regions and their respective communities who use Syllabics](images/article_03_figure_01_png.png)
 
-<figcaption>Inuktut communities across Nunavik & Nunavut (blue), Cree communities** (red), Naskapi communities** (red). The above map shows Nunavik and Nunavut communities with their preferred form of ng depicted above the community place name (ᐊᖓᒃᑯᓄᑦ,  ᐊᖓᒃᑯᓄᑦ). The Nunavik region—while complying with the ICI orthographic standards—prefers an "ng" form that is different than that of the Nunavut region.</figcaption>
+<figcaption>Inuktut communities across Nunavik & Nunavut (blue), Cree communities (red), Naskapi communities (red). The above map shows Nunavik and Nunavut communities with their preferred form of ng depicted above the community place name (ᐊᖓᒃᑯᓄᑦ,  ᐊᖓᒃᑯᓄᑦ). The Nunavik region—while complying with the ICI orthographic standards—prefers an "ng" form that is different than that of the Nunavut region.</figcaption>
 
 </figure>
 


### PR DESCRIPTION
Fixed: 

```
❌ Found 3 markdown-in-HTML error(s):

  cc-by-sa/knowledge/glossary/terms/flar_axis/content.md:13: markdown link [text](url) inside inline HTML tag:
  '<figcaption>Typeface: [Commissioner](https://fonts.google.com/specimen/Commissioner)</figcaption>'

  cc-by-sa/knowledge/glossary/terms/year_axis/content.md:14: markdown link [text](url) inside inline HTML tag:
  '<figcaption>The [Climate Crisis font](https://fonts.google.com/specimen/Climate+Crisis) has a ‘Year’ axis that starts in 1979 with fully formed letters and progresses to 2050 where the letters appear '

  cc-by-sa/knowledge/modules/the_canadian_syllabics/lessons/inuktut_syllabics/content.md:21: markdown bold **text** inside inline HTML tag:
  '<figcaption>Inuktut communities across Nunavik & Nunavut (blue), Cree communities** (red), Naskapi communities** (red). The above map shows Nunavik and Nunavut communities with their preferred form of'
```

@aaronbell @davelab6 