### PR TITLE
Modify CI workflow paths for knowledge directory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,15 +6,15 @@ on:
     branches: [main]
     tags: ["v*.*.*"]
     paths:
-      - "cc-by-sa/knowledge/**"
-      - ".github/workflows/ci.yaml"
-      - ".github/workflows/knowledge_graph.py"
+    - "cc-by-sa/knowledge/**"
+    - ".github/workflows/ci.yaml"
+    - ".github/workflows/knowledge_graph.py"
   pull_request:
     branches: ['**']
     paths:
-      - "cc-by-sa/knowledge/**"
-      - ".github/workflows/ci.yaml"
-      - ".github/workflows/knowledge_graph.py"
+    - "cc-by-sa/knowledge/**"
+    - ".github/workflows/ci.yaml"
+    - ".github/workflows/knowledge_graph.py"
 
 jobs:
   check_knowledge_graph:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,15 +6,15 @@ on:
     branches: [main]
     tags: ["v*.*.*"]
     paths:
-    - "cc-by-sa/*"
-    - ".github/workflows/ci.yaml"
-    - "/.github/workflows/knowledge_graph.py"
+      - "cc-by-sa/knowledge/**"
+      - ".github/workflows/ci.yaml"
+      - ".github/workflows/knowledge_graph.py"
   pull_request:
     branches: ['**']
     paths:
-    - "cc-by-sa/*"
-    - "to_*.txt"
-    - ".github/workflows/ci.yaml"
+      - "cc-by-sa/knowledge/**"
+      - ".github/workflows/ci.yaml"
+      - ".github/workflows/knowledge_graph.py"
 
 jobs:
   check_knowledge_graph:


### PR DESCRIPTION
Updated paths in CI workflow to include knowledge directory.

@simoncozens @m4rc1e 

For a long time, knowledge checks were applied in the wrong place and didn't trigger automatically when a pull request related to the knowledge folder was opened (They ran, for example, on the PRs of list updates.). I hope this small change will fix that!