### PR TITLE
LXGW Marker Gothic: override config building from committed .ufoz

### DIFF
--- a/ofl/lxgwmarkergothic/METADATA.pb
+++ b/ofl/lxgwmarkergothic/METADATA.pb
@@ -24,7 +24,6 @@ subsets: "vietnamese"
 source {
   repository_url: "https://github.com/aaronbell/LxgwMarkerGothic"
   commit: "fe8357007423a983e696d2d3ff545ac9bb1bb89e"
-  config_yaml: "sources/config.yaml"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/lxgwmarkergothic/config.yaml
+++ b/ofl/lxgwmarkergothic/config.yaml
@@ -1,0 +1,20 @@
+# Override config.yaml for ofl/lxgwmarkergothic
+#
+# The upstream sources/config.yaml builds from `temp/LXGWMarkerGothic-Regular.ufo`,
+# an unzipped copy of the committed `sources/LXGWMarkerGothic-Regular.ufoz` that the
+# repo's Makefile produces at build time (and .gitignores). fontc_crater never runs
+# that Makefile, so it reported `missing source 'temp/LXGWMarkerGothic-Regular.ufo'`.
+#
+# This override builds directly from the committed `.ufoz` (a zipped UFO), with the
+# source path relative to the repository root. fontmake already reads `.ufoz`.
+#
+# Building it in fontc_crater also relies on two PRs:
+#   - googlefonts/fontc#2028   (ufo2fontir reads `.ufoz`)
+#   - googlefonts/gftools#1192 (builder recognises `.ufoz` sources)
+sources:
+  - sources/LXGWMarkerGothic-Regular.ufoz
+familyName: LXGW Marker Gothic
+autohintTTF: False
+buildOTF: False
+buildWebfont: False
+removeOutlineOverlaps: False

--- a/ofl/lxgwmarkergothic/upstream_info.md
+++ b/ofl/lxgwmarkergothic/upstream_info.md
@@ -110,3 +110,17 @@ source {
 ```
 
 **Confidence**: HIGH — Binary hash match confirmed, commit hash verified (only commit in the fork), config path corrected in google/fonts history and now accurate.
+
+## Correction (2026-06-02) — override config builds from the committed `.ufoz`
+
+**Model**: Claude Opus 4.8
+
+fontc_crater reported `missing source 'temp/LXGWMarkerGothic-Regular.ufo'`: the upstream `sources/config.yaml` declares the build-time-extracted `temp/…ufo`, which the repo's Makefile produces by unzipping the committed `sources/LXGWMarkerGothic-Regular.ufoz` and then `.gitignore`s. fontc_crater never runs that Makefile, so the source appears absent.
+
+An override `config.yaml` was added in this family directory that builds **directly from the committed `sources/LXGWMarkerGothic-Regular.ufoz`** (a zipped UFO), with the path relative to the repository root. This removes the dependency on the build-time extraction step. The `.ufoz` is confirmed present at the pinned commit `fe83570`.
+
+Dependencies / caveats:
+- **fontmake** already reads `.ufoz`. Building this override in fontc_crater also relies on two pending PRs, and the override should land together with (or after) them:
+  - **[googlefonts/fontc#2028](https://github.com/googlefonts/fontc/pull/2028)** — `ufo2fontir` reads `.ufoz` (otherwise the fontc side reports an unrecognized extension).
+  - **[googlefonts/gftools#1192](https://github.com/googlefonts/gftools/pull/1192)** — `gftools.builder` recognises `.ufoz` as a font source (otherwise `File.family_name` crashes before the build starts).
+- The shipped binary is produced by gftools-builder **plus** `sources/post.py` (vertical-metrics / GASP / fsSelection overrides), which the config alone does not run. So a crater build from this override will *build successfully* but still differ from the shipped binary by those post-processing changes — i.e. it fixes the "missing source" failure but is not yet a byte-exact reproduction.


### PR DESCRIPTION
fontc_crater reported `missing source 'temp/LXGWMarkerGothic-Regular.ufo'` because the upstream sources/config.yaml points at a build-time-extracted UFO that the repo's Makefile unzips from the committed sources/LXGWMarkerGothic-Regular.ufoz and then .gitignores; fontc_crater never runs that Makefile.

Added an override config.yaml that builds directly from the committed .ufoz (a zipped UFO), repo-root-relative. fontmake already reads .ufoz; building it in fontc_crater also relies on two pending PRs (the override should land together with / after them):
  - googlefonts/fontc#2028   (ufo2fontir reads .ufoz)
  - googlefonts/gftools#1192 (builder recognises .ufoz sources)

Repo:   aaronbell/LxgwMarkerGothic
Commit: fe8357007423a983e696d2d3ff545ac9bb1bb89e (unchanged; .ufoz verified present)
Config: temp/LXGWMarkerGothic-Regular.ufo -> sources/LXGWMarkerGothic-Regular.ufoz
Status: missing-source failure fixed (note: build still differs from shipped
        binary by sources/post.py post-processing; not yet byte-exact)
Confidence: High

Assisted by an AI agent (Claude Opus 4.8)