### PR TITLE
DM Sans: override config for the mis-indented upstream config

### DIFF
--- a/ofl/dmsans/METADATA.pb
+++ b/ofl/dmsans/METADATA.pb
@@ -37,7 +37,6 @@ axes {
 source {
   repository_url: "https://github.com/googlefonts/dm-fonts"
   commit: "d0520ba03bd780f5dccb3024854463d44f699b78"
-  config_yaml: "Sans/Source/config.yaml"
   files {
     source_file: "Sans/OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/dmsans/config.yaml
+++ b/ofl/dmsans/config.yaml
@@ -1,0 +1,111 @@
+# Override config.yaml for ofl/dmsans
+#
+# The upstream Sans/Source/config.yaml is committed with an erroneous 4-space
+# indentation on every line (no top-level key), so it is invalid top-level YAML
+# and fontc_crater reports "no config file was found". This override is the same
+# config, de-indented to valid YAML, with the two source paths made relative to
+# the repository root. The pinned commit (d0520ba) is unchanged.
+sources:
+  - Sans/Source/DMSans.glyphs
+  - Sans/Source/DMSans-Italic.glyphs
+axisOrder:
+  - opsz
+  - wght
+  - ital
+familyName: DM Sans
+stat:
+  DMSans[opsz,wght].ttf:
+  - name: Optical size
+    tag: opsz
+    values:
+    - name: 9pt
+      value: 9
+    - name: 14pt
+      value: 14
+    - name: 18pt
+      value: 18
+    - name: 24pt
+      value: 24
+    - name: 36pt
+      value: 36
+    - name: 40pt
+      value: 40
+  - name: Weight
+    tag: wght
+    values:
+    - name: Thin
+      value: 100
+    - name: ExtraLight
+      value: 200
+    - name: Light
+      value: 300
+    - name: Regular
+      value: 400
+      linkedValue: 700
+      flags: 2
+    - name: Medium
+      value: 500
+    - name: SemiBold
+      value: 600
+    - name: Bold
+      value: 700
+    - name: ExtraBold
+      value: 800
+    - name: Black
+      value: 900
+    - name: ExtraBlack
+      value: 1000
+  - name: Italic
+    tag: ital
+    values:
+    - name: Roman
+      value: 0
+      linkedValue: 1
+      flags: 2
+  DMSans-Italic[opsz,wght].ttf:
+  - name: Optical size
+    tag: opsz
+    values:
+    - name: 9pt
+      value: 9
+    - name: 14pt
+      value: 14
+    - name: 18pt
+      value: 18
+    - name: 24pt
+      value: 24
+    - name: 36pt
+      value: 36
+    - name: 40pt
+      value: 40
+  - name: Weight
+    tag: wght
+    values:
+    - name: Thin
+      value: 100
+    - name: ExtraLight
+      value: 200
+    - name: Light
+      value: 300
+    - name: Regular
+      value: 400
+      linkedValue: 700
+      flags: 2
+    - name: Medium
+      value: 500
+    - name: SemiBold
+      value: 600
+    - name: Bold
+      value: 700
+    - name: ExtraBold
+      value: 800
+    - name: Black
+      value: 900
+    - name: ExtraBlack
+      value: 1000
+  - name: Italic
+    tag: ital
+    values:
+    - name: Italic
+      value: 1
+      

--- a/ofl/dmsans/upstream_info.md
+++ b/ofl/dmsans/upstream_info.md
@@ -50,3 +50,18 @@ DM Sans shares the `googlefonts/dm-fonts` repository with DM Serif Display and D
 ## Issues Found
 
 None. The tracking data is accurate and complete. The METADATA.pb on main already has the correct commit hash, config_yaml, and branch.
+
+
+## Source-metadata correction (2026-06-02) — override config replaces a mis-indented upstream config
+
+**Model**: Claude Opus 4.8
+
+fontc_crater reported `no config file was found` for dm-fonts. The dmsans `source { config_yaml }` pointed at the repo's `Sans/Source/config.yaml`, which at the pinned commit `d0520ba` is committed with an erroneous 4-space indentation on every line (no top-level key) — verified with `cat -A` (first line is `    sources:$`). That makes it invalid top-level YAML, so google-fonts-sources/fontc_crater cannot parse it and treats the family as having no config. The two declared sources (`Sans/Source/DMSans.glyphs`, `Sans/Source/DMSans-Italic.glyphs`) are both present at `d0520ba`, so the only blocker is the indentation.
+
+Fix:
+- Added an override `config.yaml` in this family directory — the same config, de-indented to valid YAML, with the two source paths made relative to the repository root.
+- Removed the now-redundant `config_yaml` field from METADATA.pb so google-fonts-sources auto-detects the local override instead of the broken upstream config.
+
+The pinned commit `d0520ba` is unchanged and is the true build commit (the gftools-packager binaries were committed to google/fonts ~3 minutes after it), so building from this corrected config should reproduce the shipped DM Sans (modulo tool versions) — this is a config-validity fix, not a refresh.
+
+(An upstream fix to `Sans/Source/config.yaml`'s indentation in googlefonts/dm-fonts would also resolve this at the source, but would additionally require bumping the pinned commit; the override is self-contained.)


### PR DESCRIPTION
The dmsans `config_yaml` pointed at `Sans/Source/config.yaml`, which at the pinned commit has a 4-space indent on every line (invalid top-level YAML), so fontc_crater reported "no config file was found".

Added an override `config.yaml` (the same config, de-indented, with repo-root-relative source paths) and removed the now-redundant config_yaml field so **google-fonts-sources** auto-detects the override. Sources verified present; pinned commit unchanged (the true build commit), so this should reproduce rather than refresh.

Repo:   googlefonts/dm-fonts
Commit: d0520ba03bd780f5dccb3024854463d44f699b78 (unchanged)
Config: Sans/Source/config.yaml (invalid YAML) -> ofl/dmsans/config.yaml override
Status: config-validity fix (should reproduce; not refresh)
Confidence: High

Assisted by an AI agent (Claude Opus 4.8)