### PR TITLE
Add 'Pixel' theme (Appearance tag) for Pixelated fonts just listed as…

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -5983,7 +5983,8 @@ DotGothic16,,/Quality/Spacing,60
 DotGothic16,,/Quality/Wordspace,100
 DotGothic16,,/Sans/Glyphic,80
 DotGothic16,,/Sans/Grotesque,30
-DotGothic16,,/Theme/Techno,100
+DotGothic16,,/Theme/Pixel,100
+DotGothic16,,/Theme/Techno,90
 Doto,,/Expressive/Awkward,54
 Doto,,/Expressive/Cute,5
 Doto,,/Expressive/Futuristic,40
@@ -8515,7 +8516,8 @@ Handjet,,/Quality/Concept,70
 Handjet,,/Quality/Drawing,65
 Handjet,,/Quality/Spacing,70
 Handjet,,/Quality/Wordspace,100
-Handjet,,/Theme/Techno,100
+Handjet,,/Theme/Pixel,100
+Handjet,,/Theme/Techno,90
 Handlee,,/Expressive/Active,5
 Handlee,,/Expressive/Childlike,77
 Handlee,,/Expressive/Cute,50
@@ -17785,7 +17787,8 @@ Pixelify Sans,,/Quality/Concept,60
 Pixelify Sans,,/Quality/Drawing,60
 Pixelify Sans,,/Quality/Spacing,70
 Pixelify Sans,,/Quality/Wordspace,100
-Pixelify Sans,,/Theme/Techno,100
+Pixelify Sans,,/Theme/Pixel,100
+Pixelify Sans,,/Theme/Techno,90
 Plaster,,/Expressive/Active,22
 Plaster,,/Expressive/Artistic,91
 Plaster,,/Expressive/Awkward,83
@@ -19414,7 +19417,8 @@ Press Start 2P,,/Quality/Concept,70
 Press Start 2P,,/Quality/Drawing,50
 Press Start 2P,,/Quality/Spacing,70
 Press Start 2P,,/Quality/Wordspace,100
-Press Start 2P,,/Theme/Techno,100
+Press Start 2P,,/Theme/Pixel,100
+Press Start 2P,,/Theme/Techno,90
 Pridi,,/Expressive/Business,46
 Pridi,,/Expressive/Loud,3
 Pridi,,/Expressive/Rugged,40
@@ -20576,6 +20580,7 @@ Rubik Broken Fax,,/Quality/Concept,65
 Rubik Broken Fax,,/Quality/Drawing,40
 Rubik Broken Fax,,/Quality/Spacing,80
 Rubik Broken Fax,,/Quality/Wordspace,100
+Rubik Broken Fax,,/Theme/Pixel,20
 Rubik Broken Fax,,/Theme/Techno,40
 Rubik Bubbles,,/Expressive/Awkward,73
 Rubik Bubbles,,/Expressive/Cute,30
@@ -20706,6 +20711,7 @@ Rubik Iso,,/Quality/Drawing,40
 Rubik Iso,,/Quality/Spacing,80
 Rubik Iso,,/Quality/Wordspace,100
 Rubik Iso,,/Theme/Distressed,100
+Rubik Iso,,/Theme/Pixel,30
 Rubik Iso,,/Theme/Techno,80
 Rubik Iso,,/Theme/Wacky,40
 Rubik Lines,,/Expressive/Awkward,84
@@ -20797,7 +20803,8 @@ Rubik Pixels,,/Quality/Concept,50
 Rubik Pixels,,/Quality/Drawing,55
 Rubik Pixels,,/Quality/Spacing,70
 Rubik Pixels,,/Quality/Wordspace,100
-Rubik Pixels,,/Theme/Techno,100
+Rubik Pixels,,/Theme/Pixel,90
+Rubik Pixels,,/Theme/Techno,90
 Rubik Puddles,,/Expressive/Awkward,79
 Rubik Puddles,,/Expressive/Excited,78
 Rubik Puddles,,/Expressive/Happy,15
@@ -21952,7 +21959,8 @@ Silkscreen,,/Quality/Concept,70
 Silkscreen,,/Quality/Drawing,65
 Silkscreen,,/Quality/Spacing,90
 Silkscreen,,/Quality/Wordspace,50
-Silkscreen,,/Theme/Techno,100
+Silkscreen,,/Theme/Pixel,100
+Silkscreen,,/Theme/Techno,80
 Simonetta,,/Expressive/Happy,10
 Simonetta,,/Expressive/Innovative,5
 Simonetta,,/Expressive/Rugged,36
@@ -24182,7 +24190,8 @@ VT323,,/Quality/Concept,70
 VT323,,/Quality/Drawing,70
 VT323,,/Quality/Spacing,90
 VT323,,/Quality/Wordspace,50
-VT323,,/Theme/Techno,100
+VT323,,/Theme/Pixel,100
+VT323,,/Theme/Techno,90
 Vampiro One,,/Expressive/Active,77
 Vampiro One,,/Expressive/Artistic,67
 Vampiro One,,/Expressive/Awkward,45


### PR DESCRIPTION
Add '[Pixel](https://fonts.google.com/?preview.script=Latn&categoryFilters=Appearance:%2FTheme%2FPixel)' theme (Appearance tag) for pixelated fonts just listed as [Techno](https://fonts.google.com/?preview.script=Latn&categoryFilters=Appearance:%2FTheme%2FTechno)

- Rubik (Various)
- [Press Start 2P](https://fonts.google.com/specimen/Press+Start+2P)
- [VT323](https://fonts.google.com/specimen/VT323)
- [Pixelify Sans](https://fonts.google.com/specimen/Pixelify+Sans) (Literally the example font but not tagged 😄)
- [DotGothic16](https://fonts.google.com/specimen/DotGothic16)
- [Silkscreen](https://fonts.google.com/specimen/Silkscreen)
- [Handjet](https://fonts.google.com/specimen/Handjet)