### PR TITLE
feat: add script and taxonomy tags for Noto Sans Tirhuta

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -16015,6 +16015,8 @@ Noto Sans Tirhuta,,/Quality/Drawing,70
 Noto Sans Tirhuta,,/Quality/Spacing,70
 Noto Sans Tirhuta,,/Quality/Wordspace,100
 Noto Sans Tirhuta,,/Sans/Humanist,100
+Noto Sans Tirhuta,,/Script/Historic,100
+Noto Sans Tirhuta,,/Script/Tirh,100
 Noto Sans Ugaritic,,/Expressive/Business,90
 Noto Sans Ugaritic,,/Expressive/Calm,90
 Noto Sans Ugaritic,,/Expressive/Competent,80


### PR DESCRIPTION
### Description
This PR explicitly registers script classification and taxonomy metadata for the 'Noto Sans Tirhuta' family within the tags collection layout. 

### Justification
While 'Noto Sans Tirhuta' already possesses expressive and quality metric tags within `families.csv`, it currently lacks explicit script categorization hooks (`/Script/Historic` and `/Script/Tirh`). 

Because the Tirhuta script handles the Maithili language—which historically diverges from standard regional Devanagari automation pipelines—adding these specific taxonomy markers is necessary. This configuration change explicitly maps the font family properties to the ISO 15924 'Tirh' script tag designation and ensures correct indexing for upstream platform compilation targets (such as system-wide font fallback configurations in AOSP).

### Changes Matrix
- Added `/Script/Historic` tag to classify the family under the historical scripts collection matrix.
- Added `/Script/Tirh` tag to programmatically link the family asset to the core Unicode script block definition.