### PR TITLE
docs(montserrat): add Design Applications section to DESCRIPTION

### DIFF
--- a/ofl/montserrat/DESCRIPTION.en_us.html
+++ b/ofl/montserrat/DESCRIPTION.en_us.html
@@ -17,3 +17,7 @@ In fall, Julieta Ulanovsky, Sol Matas, and Juan Pablo del Peral, led the develop
 The Montserrat project is led by Julieta Ulanovsky, a type designer based in Buenos Aires, Argentina. 
 To contribute, see <a href="https://github.com/JulietaUla/Montserrat">github.com/JulietaUla/Montserrat</a>
 </p>
+
+
+<h3>Design Applications</h3>
+<p>Montserrat works well for display typography, headlines, branding, posters, and web design. Its high contrast and distinctive forms make it excellent for modern, geometric design projects.</p>


### PR DESCRIPTION
## Description

Adds a "Design Applications" section to the Montserrat font DESCRIPTION.en_us.html file.

## Change

Appends information about recommended use cases for Montserrat:
- Display typography
- Headlines & branding
- Posters & web design
- Modern, geometric design projects

## Rationale

Montserrat is one of Google Fonts' most popular families. The existing description covers design history and characteristics, but lacks practical guidance. This section helps designers understand optimal use cases.

## Type

Documentation

Signed-off-by: webdevpraveen <pr4veensingh@proton.me>