### PR TITLE
Jomhuria: Add Arabic subset

### DIFF
--- a/ofl/jomhuria/METADATA.pb
+++ b/ofl/jomhuria/METADATA.pb
@@ -12,6 +12,7 @@ fonts {
   full_name: "Jomhuria Regular"
   copyright: "Copyright 2015 KB-Studio (www.k-b-studio.com|tarobish@gmail.com). Copyright 2015 Lasse Fister (lasse@graphicore.de). Copyright 2015 Sorkin Type Co (www.sorkintype.com). Copyright 2010-2015 Khaled Hosny (khaledhosny@eglug.org)."
 }
+subsets: "arabic"
 subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"


### PR DESCRIPTION
It's an Arabic font but it doesn't support enough of the codepoints in the arabic subset block to be autodetected.