### PR TITLE
Remove primary_script

### DIFF
--- a/ofl/genos/METADATA.pb
+++ b/ofl/genos/METADATA.pb
@@ -53,6 +53,5 @@ source {
   branch: "master"
   config_yaml: "sources/config.yml"
 }
-primary_script: "Cher"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"


### PR DESCRIPTION
Remove 'primary_script: "Cher"' as we currently required both upper- and lower-case characters for Cherokee support and Genos only has the upper-case characters