### PR TITLE
Inknut Antiqua: restore ø in copyright metadata

### DIFF
--- a/ofl/inknutantiqua/METADATA.pb
+++ b/ofl/inknutantiqua/METADATA.pb
@@ -10,7 +10,7 @@ fonts {
   filename: "InknutAntiqua-Light.ttf"
   post_script_name: "InknutAntiqua-Light"
   full_name: "Inknut Antiqua Light"
-  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
+  copyright: "Copyright 2014 The Inknut Antiqua Project Authors (https://github.com/clauseggers/Inknut-Antiqua)"
 }
 fonts {
   name: "Inknut Antiqua"
@@ -19,7 +19,7 @@ fonts {
   filename: "InknutAntiqua-Regular.ttf"
   post_script_name: "InknutAntiqua-Regular"
   full_name: "Inknut Antiqua Regular"
-  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
+  copyright: "Copyright 2014 The Inknut Antiqua Project Authors (https://github.com/clauseggers/Inknut-Antiqua)"
 }
 fonts {
   name: "Inknut Antiqua"
@@ -28,7 +28,7 @@ fonts {
   filename: "InknutAntiqua-Medium.ttf"
   post_script_name: "InknutAntiqua-Medium"
   full_name: "Inknut Antiqua Medium"
-  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
+  copyright: "Copyright 2014 The Inknut Antiqua Project Authors (https://github.com/clauseggers/Inknut-Antiqua)"
 }
 fonts {
   name: "Inknut Antiqua"
@@ -37,7 +37,7 @@ fonts {
   filename: "InknutAntiqua-SemiBold.ttf"
   post_script_name: "InknutAntiqua-SemiBold"
   full_name: "Inknut Antiqua SemiBold"
-  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
+  copyright: "Copyright 2014 The Inknut Antiqua Project Authors (https://github.com/clauseggers/Inknut-Antiqua)"
 }
 fonts {
   name: "Inknut Antiqua"
@@ -46,7 +46,7 @@ fonts {
   filename: "InknutAntiqua-Bold.ttf"
   post_script_name: "InknutAntiqua-Bold"
   full_name: "Inknut Antiqua Bold"
-  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
+  copyright: "Copyright 2014 The Inknut Antiqua Project Authors (https://github.com/clauseggers/Inknut-Antiqua)"
 }
 fonts {
   name: "Inknut Antiqua"
@@ -55,7 +55,7 @@ fonts {
   filename: "InknutAntiqua-ExtraBold.ttf"
   post_script_name: "InknutAntiqua-ExtraBold"
   full_name: "Inknut Antiqua ExtraBold"
-  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
+  copyright: "Copyright 2014 The Inknut Antiqua Project Authors (https://github.com/clauseggers/Inknut-Antiqua)"
 }
 fonts {
   name: "Inknut Antiqua"
@@ -64,7 +64,7 @@ fonts {
   filename: "InknutAntiqua-Black.ttf"
   post_script_name: "InknutAntiqua-Black"
   full_name: "Inknut Antiqua Black"
-  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
+  copyright: "Copyright 2014 The Inknut Antiqua Project Authors (https://github.com/clauseggers/Inknut-Antiqua)"
 }
 subsets: "devanagari"
 subsets: "latin"

--- a/ofl/inknutantiqua/METADATA.pb
+++ b/ofl/inknutantiqua/METADATA.pb
@@ -10,7 +10,7 @@ fonts {
   filename: "InknutAntiqua-Light.ttf"
   post_script_name: "InknutAntiqua-Light"
   full_name: "Inknut Antiqua Light"
-  copyright: "Copyright (c) 2014 by Claus Eggers Srensen (es@forthehearts.net)."
+  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
 }
 fonts {
   name: "Inknut Antiqua"
@@ -19,7 +19,7 @@ fonts {
   filename: "InknutAntiqua-Regular.ttf"
   post_script_name: "InknutAntiqua-Regular"
   full_name: "Inknut Antiqua Regular"
-  copyright: "Copyright (c) 2014 by Claus Eggers Srensen (es@forthehearts.net)."
+  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
 }
 fonts {
   name: "Inknut Antiqua"
@@ -28,7 +28,7 @@ fonts {
   filename: "InknutAntiqua-Medium.ttf"
   post_script_name: "InknutAntiqua-Medium"
   full_name: "Inknut Antiqua Medium"
-  copyright: "Copyright (c) 2014 by Claus Eggers Srensen (es@forthehearts.net)."
+  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
 }
 fonts {
   name: "Inknut Antiqua"
@@ -37,7 +37,7 @@ fonts {
   filename: "InknutAntiqua-SemiBold.ttf"
   post_script_name: "InknutAntiqua-SemiBold"
   full_name: "Inknut Antiqua SemiBold"
-  copyright: "Copyright (c) 2014 by Claus Eggers Srensen (es@forthehearts.net)."
+  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
 }
 fonts {
   name: "Inknut Antiqua"
@@ -46,7 +46,7 @@ fonts {
   filename: "InknutAntiqua-Bold.ttf"
   post_script_name: "InknutAntiqua-Bold"
   full_name: "Inknut Antiqua Bold"
-  copyright: "Copyright (c) 2014 by Claus Eggers Srensen (es@forthehearts.net)."
+  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
 }
 fonts {
   name: "Inknut Antiqua"
@@ -55,7 +55,7 @@ fonts {
   filename: "InknutAntiqua-ExtraBold.ttf"
   post_script_name: "InknutAntiqua-ExtraBold"
   full_name: "Inknut Antiqua ExtraBold"
-  copyright: "Copyright (c) 2014 by Claus Eggers Srensen (es@forthehearts.net)."
+  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
 }
 fonts {
   name: "Inknut Antiqua"
@@ -64,7 +64,7 @@ fonts {
   filename: "InknutAntiqua-Black.ttf"
   post_script_name: "InknutAntiqua-Black"
   full_name: "Inknut Antiqua Black"
-  copyright: "Copyright (c) 2014 by Claus Eggers Srensen (es@forthehearts.net)."
+  copyright: "Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net)."
 }
 subsets: "devanagari"
 subsets: "latin"

--- a/ofl/inknutantiqua/OFL.txt
+++ b/ofl/inknutantiqua/OFL.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Claus Eggers Sørensen (es@forthehearts.net)
+Copyright 2014 The Inknut Antiqua Project Authors (https://github.com/clauseggers/Inknut-Antiqua)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:


### PR DESCRIPTION
## Description

Fixes #9883.

The `copyright` field for all 7 weights of **Inknut Antiqua** in `ofl/inknutantiqua/METADATA.pb` is missing the `ø` in the designer's name — it reads `Claus Eggers Srensen` instead of `Claus Eggers Sørensen`.

The copyright notice embedded in each font's `name` table already has the correct spelling (`Copyright (c) 2014 by Claus Eggers Sørensen (es@forthehearts.net).`), and the `designer` field in the same `METADATA.pb` is also correct — only the per-font `copyright` strings were affected. This change makes `METADATA.pb` match the `name` table.

## Changes

- `ofl/inknutantiqua/METADATA.pb`: `Claus Eggers Srensen` → `Claus Eggers Sørensen` in the `copyright` field of all 7 weights (300–900). No other fields touched; the font binaries are unchanged.

## Notes

Issue #9883 also mentions Salsa and Poly, but for those the error is present in **both** the `METADATA.pb` **and** the binary `name` table, so correcting them requires regenerating the font files — out of scope for this metadata-only fix.