### PR TITLE
Sources info 2026-07-09

### DIFF
--- a/ofl/allan/METADATA.pb
+++ b/ofl/allan/METADATA.pb
@@ -4,8 +4,22 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2012-09-06"
 source {
-  repository_url: "https://github.com/librefonts/allan"
-  commit: "91202d58a376d6f9bca1234b360e977411222085"
+  repository_url: "https://github.com/googlefonts/allan"
+  commit: "1d8c9a6e724cb21b6ff85293761a89ed0d59d20c"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Allan-Bold.ttf"
+    dest_file: "Allan-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Allan-Regular.ttf"
+    dest_file: "Allan-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/allan/upstream_info.md
+++ b/ofl/allan/upstream_info.md
@@ -1,52 +1,26 @@
 # Allan
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Anton Koovit
-**License**: OFL
-**METADATA.pb**: `ofl/allan/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/allan |
-| Commit | `91202d58a376d6f9bca1234b360e977411222085` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+Google Fonts shipped Allan (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/allan. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+- The canonical FontForge SFD sources were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/allan, building the fonts with gftools-builder3 + fontc.
+- An explicit OS/2 WeightClass override (700) was added to Bold, because fontc does not yet derive usWeightClass for a static single-master source.
+- The build was verified against the shipped binaries.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:28:21 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The source now lives at https://github.com/googlefonts/allan (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+Identical to the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths.
 
-### google/fonts history
-- Last font modification: `895f9145a234`
-- Date: 2017-05-08 16:00:37 +0100
-- Subject: "hotfix-allan: v1.002 added (#754)"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/allan`
-- Commit `91202d58a376` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original FontForge sources are at https://github.com/librefonts/allan (`.sfd`), latest at commit `91202d58a376d6f9bca1234b360e977411222085`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/antic/METADATA.pb
+++ b/ofl/antic/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2011-08-31"
 source {
-  repository_url: "https://github.com/librefonts/antic"
-  commit: "928c13650dfb95b24baa3eb44edefadec9635423"
+  repository_url: "https://github.com/googlefonts/antic"
+  commit: "3ec1e049557adb294e645099745789a63feba703"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Antic-Regular.ttf"
+    dest_file: "Antic-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/antic/upstream_info.md
+++ b/ofl/antic/upstream_info.md
@@ -1,52 +1,25 @@
 # Antic
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Santiago Orozco
-**License**: OFL
-**METADATA.pb**: `ofl/antic/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/antic |
-| Commit | `928c13650dfb95b24baa3eb44edefadec9635423` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+Google Fonts shipped Antic (Regular) built from FontForge SFD sources at https://github.com/librefonts/antic. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/antic, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:29:07 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The source now lives at https://github.com/googlefonts/antic (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths.
 
-### google/fonts history
-- Last font modification: `491114018db3`
-- Date: 2017-08-07 21:30:51 +0100
-- Subject: "hotfix-antic: v1.001 added (#816)"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/antic`
-- Commit `928c13650dfb` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original FontForge sources are at https://github.com/librefonts/antic (`.sfd`), latest at commit `928c13650dfb95b24baa3eb44edefadec9635423`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/bentham/METADATA.pb
+++ b/ofl/bentham/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SERIF"
 date_added: "2010-11-30"
 source {
-  repository_url: "https://github.com/librefonts/bentham"
-  commit: "a89643ad524f785a73f5326e6ee901fb042fa765"
+  repository_url: "https://github.com/googlefonts/bentham"
+  commit: "e5fe7fcc66269491f3ccd6cf5ee69d7dfd3b8316"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Bentham-Regular.ttf"
+    dest_file: "Bentham-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/bentham/upstream_info.md
+++ b/ofl/bentham/upstream_info.md
@@ -1,54 +1,26 @@
-# Bentham - Investigation Report
+# Bentham
 
-## Source Data (from tracking)
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Bentham |
-| Repository URL | https://github.com/librefonts/bentham |
-| Commit Hash | a89643ad524f785a73f5326e6ee901fb042fa765 |
-| Config YAML | (none) |
-| Status | missing_config |
-| Category | SERIF |
+## Initial state
 
-## How the Repository URL Was Found
+Google Fonts shipped Bentham (Regular) built from FontForge SFD sources at https://github.com/librefonts/bentham. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/bentham` comes from the librefonts organization on GitHub, a collection of decompiled font repos maintained by Marc Foley. The URL was recorded in the tracking data and added to METADATA.pb in commit `9a14639f3` (on branch `sources_info_2026-02-25`, not yet merged to main).
+## Actions taken
 
-## How the Commit Hash Was Determined
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/bentham, building the fonts with gftools-builder3 + fontc.
+- The conversion and Unified Font Repository setup for this family were done by Simon Cozens.
+- The build was verified against the shipped binaries.
 
-The commit hash `a89643ad524f785a73f5326e6ee901fb042fa765` is the latest (HEAD) commit in the librefonts/bentham repo, dated 2014-10-17. This was set because it is the most recent commit in the repository and corresponds to a Travis CI config update ("update .travis.yml").
+## Final state
 
-**Font history in google/fonts**:
-- Initial commit `90abd17b4`: Font first added to google/fonts
-- `d1b545148`: "Updating ofl/bentham/*ttf with nbspace and fsType fixes"
-- `4e933f27b`: "hotfix-bentham: v2.002 added" (PR #854, by Marc Foley, 2017-08-07)
-
-The hotfix PR #854 by Marc Foley had an empty body, providing no context about the source of the updated TTFs. The librefonts repo's last commit predates the hotfix by about 3 years (2014 vs 2017).
-
-## Config YAML Status
-
-- **No `config.yaml`** exists in the upstream librefonts repo (not at any commit)
-- **No override `config.yaml`** in `google/fonts/ofl/bentham/`
-- The repo contains only **SFD sources** (`src/Bentham-TTF.sfd`) and TTX-decomposed font files
-- SFD (FontForge format) is not compatible with gftools-builder
-- No UFO, Glyphs, or DesignSpace sources are available
+The source now lives at https://github.com/googlefonts/bentham (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
 ## Verification
 
-- Commit hash `a89643a` exists in the repo (message: "update .travis.yml", dated 2014-10-17)
-- It is the HEAD commit of the master branch (11 total commits in the repo)
-- Repository URL is valid and accessible
-- The upstream repo is cached at `upstream_repos/fontc_crater_cache/librefonts/bentham`
-- PR #854 body was empty
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths.
 
-## Confidence Level
+## Original repository (dormant)
 
-**Medium** - The commit hash is simply HEAD of the librefonts mirror repo. The librefonts repo is not the original design source -- it was created by extracting TTX data from the compiled fonts. The original designer is Ben Weiner (ben@readingtype.org.uk). The repo only has SFD and TTX sources, making gftools-builder integration impossible without conversion work.
-
-## Open Questions
-
-- The font's original source files from Ben Weiner are not known to be publicly available outside this librefonts mirror
-- SFD-only sources cannot be used with gftools-builder; this family would need a UFO/Glyphs conversion or an alternative build approach
-- The hotfix from 2017 may have used a process not reflected in the librefonts repo (which was last updated in 2014)
-- This font was added to Google Fonts in 2010, making it one of the original catalog fonts with limited source documentation
+The original FontForge sources are at https://github.com/librefonts/bentham (`.sfd`), latest at commit `a89643ad524f785a73f5326e6ee901fb042fa765`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/bhavuka/METADATA.pb
+++ b/ofl/bhavuka/METADATA.pb
@@ -18,6 +18,6 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/Bhavuka"
-  commit: "9a79127fc31dda5447e875d77c8bdb0aab77cc98"
+  commit: "5a9c2de51b99f4a5735c1dba6a883a2d9be4caab"
   config_yaml: "sources/config.yaml"
 }

--- a/ofl/buda/METADATA.pb
+++ b/ofl/buda/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2010-12-20"
 source {
-  repository_url: "https://github.com/librefonts/buda"
-  commit: "c632d6ba92f1c89f40f704c2cd873d5a9ede22a6"
+  repository_url: "https://github.com/googlefonts/buda"
+  commit: "c53669f67b2d293b48e43a1b394ef39ff08200de"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Buda-Light.ttf"
+    dest_file: "Buda-Light.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/buda/upstream_info.md
+++ b/ofl/buda/upstream_info.md
@@ -1,45 +1,26 @@
 # Buda
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: Adele Antignac
-**METADATA.pb path**: `ofl/buda/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/buda |
-| Commit | `c632d6ba92f1c89f40f704c2cd873d5a9ede22a6` |
-| Config YAML | N/A (SFD-only sources) |
-| Branch | `master` |
+Google Fonts shipped Buda (Light) built from FontForge SFD sources at https://github.com/librefonts/buda. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/buda` was identified from the librefonts organization on GitHub, which hosts many early Google Fonts source repositories. The upstream repo is cached at `upstream_repos/fontc_crater_cache/librefonts/buda/` and contains the SFD source files and TTX dumps for the Buda font. The URL was added to the tracking data and a pending source block exists on branch `sources_info_2026-02-25` (commit `9a14639f3`) but has not yet been merged to the main branch of google/fonts.
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/buda, building the fonts with gftools-builder3 + fontc.
+- An explicit OS/2 WeightClass override (300) was added (usWeightClass Light).
+- The build was verified against the shipped binaries.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The upstream repository has only a single commit: `c632d6ba92f1c89f40f704c2cd873d5a9ede22a6` (message: "update .travis.yml"). This is both the initial and only commit in the repository, making it the only possible reference. The font binary in google/fonts was last updated in PR #868 ("hotfix-buda: v1.003 added", 2017-08-07) by Marc Foley, which predates the source block tracking effort. Since the upstream repo has only one commit, the hash is unambiguously correct.
-
-## How Config YAML Was Resolved
-
-There is no config.yaml in the upstream repository. The only source file is `src/Buda-Light-TTF.sfd`, which is a FontForge SFD format file. SFD files are not compatible with the gftools-builder pipeline, so no config.yaml can be created for this family. No override config.yaml exists in the google/fonts family directory either.
+The source now lives at https://github.com/googlefonts/buda (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
 ## Verification
 
-- Commit exists in upstream repo: Yes (it is the only commit)
-- Commit date: Not available (single commit, likely very old)
-- Commit message: "update .travis.yml"
-- Source files at commit: `src/Buda-Light-TTF.sfd` (FontForge SFD format)
-- Font binary in google/fonts last updated: 2017-08-07 (PR #868)
-- Original addition to Google Fonts: 2010-12-20
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths.
 
-## Confidence
+## Original repository (dormant)
 
-**High**: The repository URL and commit hash are straightforward to verify. The upstream repo has only one commit, so the hash is unambiguous. The font uses SFD sources which cannot be built with gftools-builder, making this family permanently `missing_config` in the modern build system.
-
-## Open Questions
-
-1. The source block has been prepared on branch `sources_info_2026-02-25` but has not yet been merged into the main google/fonts repository. Once merged, METADATA.pb will document the upstream source.
-2. Since the font uses SFD sources only, it would need to be converted to a modern source format (UFO or Glyphs) before a config.yaml could be created. This is unlikely to happen unless the font receives a major redesign/update.
+The original FontForge sources are at https://github.com/librefonts/buda (`.sfd`), latest at commit `c632d6ba92f1c89f40f704c2cd873d5a9ede22a6`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/cantarell/METADATA.pb
+++ b/ofl/cantarell/METADATA.pb
@@ -43,6 +43,28 @@ subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 source {
-  repository_url: "https://github.com/davelab6/cantarell"
-  commit: "52d3363878871c868eaeb64c75a701c1193750af"
+  repository_url: "https://github.com/googlefonts/cantarell"
+  commit: "1684004f92b47dbaa3ee7db870091d4d66c5dd8a"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Cantarell-Bold.ttf"
+    dest_file: "Cantarell-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Cantarell-BoldItalic.ttf"
+    dest_file: "Cantarell-BoldItalic.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Cantarell-Italic.ttf"
+    dest_file: "Cantarell-Italic.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Cantarell-Regular.ttf"
+    dest_file: "Cantarell-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/cantarell/upstream_info.md
+++ b/ofl/cantarell/upstream_info.md
@@ -1,68 +1,28 @@
-# Cantarell - Investigation Report
+# Cantarell
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Cantarell |
-| Designer | Dave Crossland |
-| License | OFL |
-| Date Added | 2010-05-10 |
-| Repository URL | https://github.com/davelab6/cantarell |
-| Commit Hash | 52d3363878871c868eaeb64c75a701c1193750af |
-| Branch | master |
-| Config YAML | Override in google/fonts |
-| Status | complete |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Cantarell (Regular, Bold, Italic and BoldItalic) built from FontForge SFD sources at https://github.com/davelab6/cantarell. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/davelab6/cantarell` was added in commit f7455d788 ("Populate source.repository_url") which was a batch operation populating source blocks for many families. The davelab6/cantarell repo is the original upstream maintained by Dave Crossland himself, the designer.
+## Actions taken
 
-Note: There is also a GNOME version of Cantarell at `https://github.com/GNOME/cantarell-fonts` (read-only mirror of https://gitlab.gnome.org/GNOME/cantarell-fonts), which is a separate, much more evolved version of the font. The Google Fonts version uses the original Dave Crossland 2009 release, not the GNOME version.
+- The canonical FontForge SFD sources were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/cantarell, building the fonts with gftools-builder3 + fontc.
+- The vertical metrics were set to the shipped values and the font-level Use Typo Metrics flag was added (babelfont does not propagate the SFD flag).
+- uni0302 was forced to the Letter category so it stays a spacing glyph (as shipped) rather than being zeroed as a combining mark.
+- An OS/2 WeightClass override (700) was added to Bold and BoldItalic; the BoldItalic master was named so fontc style-links it.
+- The build was verified against the shipped binaries.
 
-## How Commit Determined
+## Final state
 
-The commit `52d3363878871c868eaeb64c75a701c1193750af` is the HEAD (and latest) commit of the davelab6/cantarell repository, dated 2013-12-02. This commit ("Add original copyright and OFL.txt") is one of only two commits in the repo:
-
-1. `7e7b962` (2013-12-02) - "Import original Dave Crossland release from 2009" - added 5 SFD source files
-2. `52d3363` (2013-12-02) - "Add original copyright and OFL.txt" - added license file
-
-The commit hash was added in commit ad48b604a ("sources info for Cantarell: Version 1.004 (PR #5213)") on 2025-11-19 by Felipe Sanches. This same commit also added the override config.yaml file to google/fonts.
-
-## Config YAML Status
-
-An override `config.yaml` exists in the google/fonts directory at `ofl/cantarell/config.yaml` with the following content:
-
-```yaml
-buildVariable: false
-sources:
-  - src/Cantarell-Regular.sfd
-  - src/Cantarell-Regular-Spiro.sfd
-  - src/Cantarell-Oblique.sfd
-  - src/Cantarell-BoldOblique.sfd
-  - src/Cantarell-Bold.sfd
-```
-
-This config references all 5 SFD source files from the upstream repository. Since the override config exists in google/fonts, the `config_yaml` field is correctly omitted from the METADATA.pb source block.
-
-No `config.yaml` exists in the upstream repository itself.
+The source now lives at https://github.com/googlefonts/cantarell (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional parity with the shipped binaries.
 
 ## Verification
 
-- **Commit hash verified**: The hash `52d3363` exists in the davelab6/cantarell repository and is HEAD of master. CONFIRMED.
-- **Repository accessible**: davelab6/cantarell is a valid GitHub repository. CONFIRMED.
-- **Source files**: 5 SFD files in `src/` directory matching the override config.yaml.
-- **Override config**: Present in google/fonts at `ofl/cantarell/config.yaml`. CONFIRMED.
-- **Font history**: The font has been through multiple hotfixes in google/fonts:
-  - PR #5010 (e29d904ec) - Name ID13 and 14 hotfix, version bumped to 1.002
-  - PR #5213 (bef4d502a) - Version 1.004, extensive hotfixes (filenames, name tables, vertical metrics, weightClass)
-  - These were manual hotfixes, not rebuilds from the upstream SFD sources.
+cmap, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS features and advances match the shipped binaries. The only difference from the shipped binaries is the advance width of the auto-generated .notdef box (748 vs 1024); the SFDs contain no .notdef glyph to control it, and it is never used in real text.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** - The repository URL, commit hash, and override config.yaml are all correct. The davelab6/cantarell repo contains the original 2009 sources that were used for the initial Google Fonts onboarding. The font has since been hotfixed multiple times in google/fonts without rebuilding from the upstream sources.
-
-## Open Questions
-
-- The current binary fonts in google/fonts have been extensively modified via hotfixes and may not match what would be produced by building from the SFD sources. A rebuild from the upstream sources would likely produce different output than the current binaries.
-- The GNOME Cantarell project (cantarell-fonts) is a significantly different and more advanced version of this typeface, but is tracked separately.
+The original FontForge sources are at https://github.com/davelab6/cantarell (`.sfd`), latest at commit `52d3363878871c868eaeb64c75a701c1193750af`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/carme/METADATA.pb
+++ b/ofl/carme/METADATA.pb
@@ -15,6 +15,16 @@ fonts {
 subsets: "menu"
 subsets: "latin"
 source {
-  repository_url: "https://github.com/librefonts/carme"
-  commit: "823391960931cedd0b9cb7caf0fcae71c4bd59ba"
+  repository_url: "https://github.com/googlefonts/carme"
+  commit: "bddcc27d905baa14d9736bb0483ab20b5acf5434"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Carme-Regular.ttf"
+    dest_file: "Carme-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/carme/upstream_info.md
+++ b/ofl/carme/upstream_info.md
@@ -1,56 +1,25 @@
-# Investigation: Carme
+# Carme
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Carme |
-| Designer | Ruben Prol |
-| License | OFL |
-| Date Added | 2011-07-27 |
-| Repository URL | https://github.com/librefonts/carme |
-| Commit Hash | `823391960931cedd0b9cb7caf0fcae71c4bd59ba` |
-| Branch | (not specified) |
-| Config YAML | None in upstream |
-| Override Config | Yes (in google/fonts) |
-| Status | complete |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Carme (Regular) built from FontForge SFD sources at https://github.com/librefonts/carme. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/carme` was added by Simon Cozens in commit `c8f729cbd` ("Add more upstreams (c,d)") on 2024-01-14. This is a librefonts mirror repository containing the font sources.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/carme, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-The commit hash `823391960931cedd0b9cb7caf0fcae71c4bd59ba` was added in a later commit `655a112a5` by Felipe Sanches on 2025-12-11, referencing google/fonts original commit `90abd17b4f97671435798b6147b698aa9087612f` (the "Initial commit" of the google/fonts repository).
+## Final state
 
-This commit is the HEAD (latest) commit of the upstream repository, with the message "update .travis.yml". The repository has 12 commits total, starting from "Move carme font files to separate repository" up through various Travis CI configuration updates.
-
-Since the font was in the initial google/fonts commit (2014, predating the librefonts repo migration), the HEAD commit is a reasonable reference as the librefonts repo represents the full history of the font project.
+The source now lives at https://github.com/googlefonts/carme (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
 ## Verification
 
-- **Commit exists in upstream repo**: Yes. `8233919` is the HEAD of the master branch.
-- **Repository accessible**: Yes, cached at `upstream_repos/fontc_crater_cache/librefonts/carme/`.
-- **Source files**: The repo contains `src/Carme-Regular-TTF.sfd` (FontForge SFD format) and various TTX decomposed files.
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths.
 
-## Config YAML Status
+## Original repository (dormant)
 
-**Override config.yaml exists in google/fonts.** The file `google/fonts/ofl/carme/config.yaml` contains:
-
-```yaml
-buildVariable: false
-sources:
-  - src/Carme-Regular-TTF.sfd
-```
-
-This override was added in commit `655a112a5` on 2025-12-11. There is no config.yaml in the upstream repository itself. The override points to the SFD file in the upstream repo, which is the only buildable source.
-
-Per project policy, when an override config.yaml exists in the google/fonts family directory, the `config_yaml` field can be omitted from the METADATA.pb source block.
-
-## Confidence Level
-
-**HIGH** -- The repository URL is a well-known librefonts mirror. The commit hash points to the latest commit (HEAD), which is appropriate since the font was part of the initial google/fonts commit before the librefonts repos existed. The override config.yaml correctly references the SFD source file.
-
-## Open Questions
-
-- None. This family is complete with the override config.yaml providing build configuration.
+The original FontForge sources are at https://github.com/librefonts/carme (`.sfd`), latest at commit `823391960931cedd0b9cb7caf0fcae71c4bd59ba`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/caudex/METADATA.pb
+++ b/ofl/caudex/METADATA.pb
@@ -4,8 +4,30 @@ license: "OFL"
 category: "SERIF"
 date_added: "2011-05-18"
 source {
-  repository_url: "https://github.com/librefonts/caudex"
-  commit: "901fb15160f96cb5a2b91e48a6d89d9c18c6f6d5"
+  repository_url: "https://github.com/googlefonts/caudex"
+  commit: "2cd095f7ea63c324e8a5f0135acb6a330f2842f8"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Caudex-Bold.ttf"
+    dest_file: "Caudex-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Caudex-BoldItalic.ttf"
+    dest_file: "Caudex-BoldItalic.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Caudex-Italic.ttf"
+    dest_file: "Caudex-Italic.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Caudex-Regular.ttf"
+    dest_file: "Caudex-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/caudex/upstream_info.md
+++ b/ofl/caudex/upstream_info.md
@@ -1,52 +1,27 @@
-# Investigation Report: Caudex
+# Caudex
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| **Family Name** | Caudex |
-| **Designer** | Nidud (Hjort Nidudsson) |
-| **License** | OFL |
-| **Date Added** | 2011-05-18 |
-| **Repository URL** | https://github.com/librefonts/caudex |
-| **Commit Hash** | `901fb15160f96cb5a2b91e48a6d89d9c18c6f6d5` |
-| **Branch** | master |
-| **Config YAML** | N/A |
-| **Status** | missing_config (SFD-only sources) |
+## Initial state
 
-## How URL Was Found
+Google Fonts shipped Caudex (Regular, Bold, Italic and BoldItalic) built from FontForge SFD sources at https://github.com/librefonts/caudex. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/caudex` is a well-known librefonts archive repository. The cached clone at `upstream_repos/fontc_crater_cache/librefonts/caudex/` confirms the remote URL matches. The repo contains TTX decompositions and SFD sources from the original font.
+## Actions taken
 
-## How Commit Was Determined
+- The canonical FontForge SFD sources were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/caudex, building the fonts with gftools-builder3 + fontc.
+- Two duplicate glyphs (Ldot/ldot, defined twice in the SFDs, canonical + a PUA copy) were renamed Ldot.1/ldot.1, matching the canonical Google Fonts pipeline; this also avoids a fontc scheduler hang on duplicate glyph names.
+- An OS/2 WeightClass override (700) was added to Bold and BoldItalic.
+- The build was verified against the shipped binaries.
 
-The upstream repository has only a single commit:
-- `901fb15160f96cb5a2b91e48a6d89d9c18c6f6d5` - "update .travis.yml"
+## Final state
 
-Since there is only one commit in the entire repository, this is the only possible commit to reference. The librefonts archive was created as a snapshot of existing fonts, so this single commit represents the complete state of the project.
-
-## Config YAML Status
-
-**No config.yaml exists and none is possible.** The upstream repo contains only SFD (FontForge Spline Font Database) source files:
-- `src/Caudex-Regular.sfd`
-- `src/Caudex-Italic.sfd`
-- `src/Caudex-Bold.sfd`
-- `src/Caudex-BoldItalic.sfd`
-
-SFD is a FontForge-native format that is not compatible with gftools-builder. Building from these sources would require FontForge, not the standard Google Fonts build toolchain.
+The source now lives at https://github.com/googlefonts/caudex (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional parity with the shipped binaries.
 
 ## Verification
 
-- **Repository accessible**: Yes, cached at `upstream_repos/fontc_crater_cache/librefonts/caudex/`
-- **Commit exists**: Yes, it is the only commit in the repo
-- **Font file history in google/fonts**: The TTF files were part of the initial commit (`90abd17b4`) and were never updated (the only other touch was the large deploy restructure `76adaf1d2` which reorganized the repo but did not change font binaries)
-- **No override config.yaml** exists in `google/fonts/ofl/caudex/`
-- **METADATA.pb** does not have a source block
+cmap, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS features and advances match the shipped binaries. The build classifies the Latin combining marks in GDEF, which the older ufo2ft-built shipped binary left unclassified; Caudex has no mark-positioning GPOS feature, so this is inert and the build is simply more correct.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** - The repository URL and commit are unambiguous. Single commit repo, SFD-only sources. The status of "missing_config" is correct but expected since SFD sources cannot use gftools-builder.
-
-## Open Questions
-
-None. This is a legacy font with SFD-only sources. A config.yaml would only be possible if the font were to be converted to a gftools-builder-compatible format (e.g., .glyphs or .ufo).
+The original FontForge sources are at https://github.com/librefonts/caudex (`.sfd`), latest at commit `901fb15160f96cb5a2b91e48a6d89d9c18c6f6d5`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/chathura/METADATA.pb
+++ b/ofl/chathura/METADATA.pb
@@ -4,8 +4,34 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2017-05-09"
 source {
-  repository_url: "https://github.com/appajid/Chathura"
-  commit: "f6944e361db05f2cb3a33356e54615f4cf754de8"
+  repository_url: "https://github.com/googlefonts/Chathura"
+  commit: "e480434f75f149a18073913a0c5f041b0c2829c3"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Chathura-Bold.ttf"
+    dest_file: "Chathura-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Chathura-ExtraBold.ttf"
+    dest_file: "Chathura-ExtraBold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Chathura-Light.ttf"
+    dest_file: "Chathura-Light.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Chathura-Regular.ttf"
+    dest_file: "Chathura-Regular.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Chathura-Thin.ttf"
+    dest_file: "Chathura-Thin.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/chathura/upstream_info.md
+++ b/ofl/chathura/upstream_info.md
@@ -1,51 +1,28 @@
-# Investigation: Chathura
+# Chathura
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Chathura |
-| Designer | Appaji Ambarisha Darbha |
-| License | OFL |
-| Date Added | 2017-05-09 |
-| Repository URL | https://github.com/appajid/Chathura |
-| Commit | `f6944e361db05f2cb3a33356e54615f4cf754de8` |
-| Branch | master |
-| Config YAML | None (not applicable) |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Chathura (Thin, Light, Regular, Bold and ExtraBold) built from FontForge SFD sources at https://github.com/appajid/Chathura. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/appajid/Chathura` was added to the METADATA.pb source block by commit `9a14639f3` ("Add source blocks to 602 more METADATA.pb files"). The URL matches the repository where the font source files are hosted.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD sources were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/Chathura, building the fonts with gftools-builder3 + fontc.
+- One dead, shadowed ligature substitution was removed per weight (identical input to a preceding rule; fea-rs rejects it where FontForge silently dropped it).
+- The vertical metrics were set to the shipped values, the master name was set so Bold is style-linked, and the below-base form uni0C30_uni0C4D.blwf was given subCategory = Nonspacing so its GDEF class matches the shipped binary.
+- An OS/2 WeightClass override was added to the four non-Regular weights (250/300/700/800).
+- The build was verified against the shipped binaries.
 
-The commit `f6944e361db05f2cb3a33356e54615f4cf754de8` is the only commit (HEAD) in the upstream repository, dated 2016-05-31. It is a "Merge pull request #5 from davelab6/davelab6-ttf-fix".
+## Final state
 
-The font was added to google/fonts via PR #944 ("hotfix-chathura: v1.002 added") by Marc Foley (m4rc1e) on 2017-05-11. Since the upstream repo has only one commit (the HEAD), and it predates the google/fonts onboarding by about a year, this commit is unambiguously the correct reference.
-
-## Config YAML Status
-
-**Not applicable.** The upstream repository contains only SFD (FontForge) source files and pre-built TTF binaries. There are no `.glyphs`, `.ufo`, or `.designspace` files that would be compatible with gftools-builder. The repository structure:
-
-- `Chathura-Bold.sfd`, `Chathura-ExtraBold.sfd`, `Chathura-Light.sfd`, `Chathura-Regular.sfd`, `Chathura-Thin.sfd`
-- Pre-built TTF files for all 5 weights
-- No `config.yaml` in the upstream repo
-- No override `config.yaml` in the google/fonts family directory
-
-Since SFD sources cannot be used with gftools-builder, a config.yaml is not applicable for this family.
+The source now lives at https://github.com/googlefonts/Chathura (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
 ## Verification
 
-- **Repository URL**: Verified -- the upstream repo is cached at `upstream_repos/fontc_crater_cache/appajid/Chathura`.
-- **Commit**: Verified as HEAD (and only commit) of the upstream repo. Predates the google/fonts onboarding.
-- **Source type**: SFD-only sources -- not compatible with gftools-builder.
-- **No config.yaml**: Correctly absent given the source format.
+Identical to the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths.
 
-## Confidence Level
+## Original repository (dormant)
 
-**Very High** -- The repository has only one commit, making the commit reference unambiguous. The source format (SFD) is well-documented.
-
-## Open Questions
-
-None. The status is correctly `missing_config` because the SFD source format is not compatible with gftools-builder. No action needed unless the font is eventually migrated to a modern source format.
+The original FontForge sources are at https://github.com/appajid/Chathura (`.sfd`), latest at commit `f6944e361db05f2cb3a33356e54615f4cf754de8`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/creepster/METADATA.pb
+++ b/ofl/creepster/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-12-19"
 source {
-  repository_url: "https://github.com/librefonts/creepster"
-  commit: "f6eec0d741fd8ecba905f403d77c073f2e8be7f6"
+  repository_url: "https://github.com/googlefonts/creepster"
+  commit: "1c79da6f4d0cc0835ba16d20aba5c113e6245e7e"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Creepster-Regular.ttf"
+    dest_file: "Creepster-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/creepster/upstream_info.md
+++ b/ofl/creepster/upstream_info.md
@@ -1,50 +1,25 @@
 # Creepster
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: Sideshow (Font Diner)
-**METADATA.pb path**: `ofl/creepster/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/creepster |
-| Commit | `f6eec0d741fd8ecba905f403d77c073f2e8be7f6` |
-| Config YAML | N/A (SFD-only sources) |
-| Branch | master |
+Google Fonts shipped Creepster (Regular) built from FontForge SFD sources at https://github.com/librefonts/creepster. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/creepster` is from the `librefonts` GitHub organization, which archives Google Fonts sources migrated from earlier hosting. The URL was added to METADATA.pb in the pending PR branch `felipesanches/sources_info_2026-02-25` (commit `9a14639f3`, "Add source blocks to 602 more METADATA.pb files"). The main branch of google/fonts does not yet have a source block for this family.
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/creepster, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The commit hash `f6eec0d741fd8ecba905f403d77c073f2e8be7f6` is the only commit in the upstream repository ("update .travis.yml", 2014-10-17). Since this is a single-commit repo, it is trivially the correct and only possible reference. The font was first added to Google Fonts on 2011-12-19 (per `date_added` in METADATA.pb) and the TTF file has never been modified in google/fonts since the initial commit `90abd17b4` (2015-03-07, which imported the existing catalog).
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository or in the google/fonts family directory. The upstream repo contains only:
-- `src/Creepster-Regular-TTF.sfd` (FontForge SFD format)
-
-SFD files are not compatible with gftools-builder, so a config.yaml cannot be created without converting the sources to a modern format.
+The source now lives at https://github.com/googlefonts/creepster (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional parity with the shipped binaries.
 
 ## Verification
 
-- Repository URL accessible: Yes
-- Commit exists in upstream repo: Yes (only commit / HEAD)
-- Commit date: 2014-10-17 13:33:48 +0300
-- Commit message: "update .travis.yml"
-- Source block on main: No (pending PR branch only)
-- Source files at commit: SFD file only (`src/Creepster-Regular-TTF.sfd`)
-- Override config.yaml: Not present
+cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle and advance widths are identical to the shipped binary. The 1488 kerning pairs are preserved but modernized from the shipped legacy `kern` table to a GPOS `kern` feature (the current Google Fonts mechanism); neither version has any other OpenType layout tables.
 
-## Confidence
+## Original repository (dormant)
 
-**High**: The librefonts organization is a well-known archive of Google Fonts sources. The repo has only one commit, making the hash unambiguous. The font binary has never been updated in google/fonts since the initial catalog import.
-
-## Open Questions
-
-1. The source block (repository_url and commit hash) has not yet been merged to google/fonts main -- it is on the pending branch `felipesanches/sources_info_2026-02-25`.
-2. No config.yaml can be created from SFD sources without source conversion. This family will remain in `missing_config` status unless the sources are modernized.
-3. The copyright mentions "Font Diner, Inc DBA Sideshow" -- the designer credit uses "Sideshow" as the key in METADATA.pb.
+The original FontForge sources are at https://github.com/librefonts/creepster (`.sfd`), latest at commit `f6eec0d741fd8ecba905f403d77c073f2e8be7f6`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/dorsa/METADATA.pb
+++ b/ofl/dorsa/METADATA.pb
@@ -17,6 +17,16 @@ subsets: "latin"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/dorsa"
-  commit: "90d5bffc5b005be8d3f7728ccb9aae3deaae1c23"
+  repository_url: "https://github.com/googlefonts/dorsa"
+  commit: "3d21216a5f3d62b466464dd6c7fbcb945ab67144"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Dorsa-Regular.ttf"
+    dest_file: "Dorsa-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/dorsa/upstream_info.md
+++ b/ofl/dorsa/upstream_info.md
@@ -1,42 +1,25 @@
 # Dorsa
 
-**Date investigated**: 2026-02-27
-**Status**: missing_config
-**Designer**: Santiago Orozco
-**METADATA.pb path**: `ofl/dorsa/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/dorsa |
-| Commit | `90d5bffc5b005be8d3f7728ccb9aae3deaae1c23` |
-| Config YAML | -- |
-| Branch | master |
+Google Fonts shipped Dorsa (Regular) built from FontForge SFD sources at https://github.com/librefonts/dorsa. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The upstream repository is located at https://github.com/librefonts/dorsa (HTTP 200 verified). This was found by checking the existing clone at `upstream_repos/fontc_crater_cache/librefonts/dorsa`, whose git remote points to this URL. The librefonts GitHub organization was used to host source files for many early Google Fonts families. The METADATA.pb currently has no `source {}` block or `repository_url` field.
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/dorsa, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The upstream repository contains exactly one commit: `90d5bffc5b005be8d3f7728ccb9aae3deaae1c23` (2014-10-17, by hash3g, message: "update .travis.yml"). This is the initial and only commit in the repository, which imported the SFD source, TTX decomposition files, METADATA.json, DESCRIPTION, OFL license, and a Travis CI configuration. Since there is only one commit, it is trivially the correct reference point for the complete state of the upstream source.
-
-Note that the font was originally added to Google Fonts on 2011-08-31 (per `dateAdded` in METADATA.pb), well before this upstream repo was created in October 2014. The SFD file's internal timestamps show creation on 2011-05-19 and last modification on 2011-09-04. The librefonts repo was created as a retroactive archive of the font sources, not as a development repository.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository, and no override `config.yaml` exists in the `google/fonts/ofl/dorsa/` directory. The only source file is an SFD (FontForge Spline Font Database) file: `src/Dorsa-Regular-TTF.sfd`. SFD files are not compatible with gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` sources. Therefore, no config.yaml can be meaningfully created for this family without first converting the sources to a compatible format.
-
-The Travis CI configuration (`.travis.yml`) shows the font was built using `fontbakery-build.py`, an older build pipeline that predates gftools-builder.
+The source now lives at https://github.com/googlefonts/dorsa (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
 ## Verification
 
-- Commit exists in upstream repo: Yes
-- Commit date: 2014-10-17 13:35:02 +0300
-- Commit message: "update .travis.yml"
-- Source files at commit: `src/Dorsa-Regular-TTF.sfd`, `src/METADATA_comments.txt`, `src/VERSIONS.txt`, plus TTX decomposition files, DESCRIPTION.en_us.html, METADATA.json, OFL.txt, .travis.yml
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths.
 
-## Confidence
+## Original repository (dormant)
 
-**HIGH**: The upstream repository at librefonts/dorsa is the canonical source archive for this font. It has only a single commit containing the complete SFD source, making commit identification unambiguous. The font copyright matches between the SFD file, METADATA.pb, and METADATA.json (Santiago Orozco, 2011). The repository URL is verified accessible. The only limitation is the lack of gftools-builder-compatible sources (SFD only), which means no config.yaml can be provided.
+The original FontForge sources are at https://github.com/librefonts/dorsa (`.sfd`), latest at commit `90d5bffc5b005be8d3f7728ccb9aae3deaae1c23`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/eater/METADATA.pb
+++ b/ofl/eater/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 stroke: "SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/eater"
-  commit: "91120e636b79d400473167dae30ff31a7c03b813"
+  repository_url: "https://github.com/googlefonts/eater"
+  commit: "6c5ace2f3226138bc19b92312a0a82ff6cf6861f"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Eater-Regular.ttf"
+    dest_file: "Eater-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/eater/upstream_info.md
+++ b/ofl/eater/upstream_info.md
@@ -1,53 +1,25 @@
-# Investigation Report: Eater
+# Eater
 
-- **Date investigated**: 2026-02-27
-- **Status**: missing_config
-- **Designer**: Vernon Adams (Typomondo)
-- **METADATA.pb path**: ofl/eater/METADATA.pb
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field           | Value |
-|-----------------|-------|
-| repository_url  | https://github.com/librefonts/eater |
-| commit          | 91120e636b79d400473167dae30ff31a7c03b813 |
-| config_yaml     | N/A (SFD-only sources) |
+Google Fonts shipped Eater (Regular) built from FontForge SFD sources at https://github.com/librefonts/eater. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How URL Was Found
+## Actions taken
 
-The METADATA.pb file does not contain a `source` block or `repository_url`. The upstream repository was identified from the existing local clone at `upstream_repos/fontc_crater_cache/librefonts/eater`, whose remote points to `https://github.com/librefonts/eater`. The URL was verified accessible (HTTP 200).
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/eater, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-This is a librefonts-organization repo, which is part of the collection of font sources migrated from the old Google Font Directory. The copyright in OFL.txt and METADATA.pb attributes the font to "Vernon Adams DBA Typomondo (vern@newtypography.co.uk)".
+## Final state
 
-## How Commit Hash Was Identified
-
-The upstream repository contains exactly **one commit**:
-
-- `91120e6` (2014-10-17) "update .travis.yml" by hash3g
-
-Since there is only a single commit in the entire repository, there is no ambiguity about which commit to reference. This commit contains the complete initial import: SFD source files, TTX decompositions of the binary font, METADATA.json, OFL.txt, DESCRIPTION.en_us.html, and the Travis CI configuration.
-
-The font was added to google/fonts in commit `90abd17b4` (2015-03-07, "Initial commit" by Dave Crossland), with a binary size of 83,928 bytes. The font's `date_added` in METADATA.pb is 2011-12-19, indicating the font was originally part of the Google Font Directory before the google/fonts repository was created. The librefonts repo was created later (2014-10-17) as a source archive.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository or in the google/fonts family directory.
-
-The upstream repository contains only FontForge SFD source files:
-- `src/Eater-Regular.sfd` (PostScript-flavored SFD)
-- `src/Eater-Regular-TTF.sfd` (TrueType-flavored SFD)
-
-SFD files are not compatible with gftools-builder, which requires .glyphs, .ufo, or .designspace sources. A config.yaml override cannot be created without converting the sources to a supported format first. The font would need to be migrated to a modern source format before a config.yaml can be provided.
+The source now lives at https://github.com/googlefonts/eater (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
 ## Verification
 
-- **Repository URL**: Verified accessible (HTTP 200)
-- **Repository is clean**: Confirmed (no local modifications, up to date with origin)
-- **Commit count**: 1 (no ambiguity)
-- **Source format**: SFD (FontForge) -- not compatible with gftools-builder
-- **Binary in google/fonts**: Eater-Regular.ttf (83,928 bytes), unchanged since initial commit (2015-03-07)
-- **No config.yaml**: Neither in upstream nor in google/fonts family directory
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths.
 
-## Confidence
+## Original repository (dormant)
 
-**HIGH** -- The repository URL is verified and the commit hash is unambiguous (single commit in repo). The "missing_config" status is due to SFD-only sources that are incompatible with gftools-builder; no override config.yaml can be created without source format conversion.
+The original FontForge sources are at https://github.com/librefonts/eater (`.sfd`), latest at commit `91120e636b79d400473167dae30ff31a7c03b813`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/geo/METADATA.pb
+++ b/ofl/geo/METADATA.pb
@@ -26,6 +26,20 @@ subsets: "latin"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/geo"
-  commit: "0d2a51963d3c6e52d7b8edc50a5d7b457bb1a663"
+  repository_url: "https://github.com/googlefonts/geo"
+  commit: "95c7f776abbeab9ccbb97d91ee68b1dfb72885f5"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Geo-Oblique.ttf"
+    dest_file: "Geo-Oblique.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Geo-Regular.ttf"
+    dest_file: "Geo-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/geo/upstream_info.md
+++ b/ofl/geo/upstream_info.md
@@ -1,66 +1,26 @@
-# Investigation Report: Geo
+# Geo
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Geo is a geometric sans-serif display typeface designed by Ben Weiner, added to Google Fonts on 2010-11-30. The font was part of the initial commit (90abd17b) to the google/fonts repository. The upstream repository is at `https://github.com/librefonts/geo` and contains only SFD (FontForge) source files -- no `.glyphs`, `.ufo`, or `.designspace` files, and no `config.yaml`. Since SFD sources are not compatible with gftools-builder, no config.yaml can be provided.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Geo (Regular and Oblique) built from FontForge SFD sources at https://github.com/librefonts/geo. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field              | Value                                                    |
-|--------------------|----------------------------------------------------------|
-| Family Name        | Geo                                                      |
-| Designer           | Ben Weiner                                               |
-| Date Added         | 2010-11-30                                               |
-| Repository URL     | https://github.com/librefonts/geo                        |
-| Commit Hash        | 0d2a51963d3c6e52d7b8edc50a5d7b457bb1a663 (only commit)  |
-| Config YAML        | None (SFD-only sources)                                  |
-| Source Files       | src/Geo-Regular-TTF.sfd, src/Geo-Oblique-TTF.sfd        |
-| Status             | no_config_possible                                       |
-| Confidence         | HIGH                                                     |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD sources were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/geo, building the fonts with gftools-builder3 + fontc.
+- An explicit OS/2 WeightClass override (500) was added to both styles (usWeightClass Medium).
+- The build was verified against the shipped binaries.
 
-### METADATA.pb Analysis
+## Final state
 
-The current METADATA.pb has no `source { }` block at all. The font was added in the initial commit of the google/fonts repository (90abd17b, dated 2015-03-07 in git, but `date_added` shows 2010-11-30). No repository_url, commit hash, or config_yaml are recorded.
+The source now lives at https://github.com/googlefonts/geo (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
-### Upstream Repository
+## Verification
 
-The upstream repository at `https://github.com/librefonts/geo` is cached at `upstream_repos/fontc_crater_cache/librefonts/geo/`. It has a single commit:
+Identical to the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths.
 
-- `0d2a519` (2014-10-17): "update .travis.yml"
+## Original repository (dormant)
 
-This is a shallow/squashed history. The repo contains:
-- **Source files**: `src/Geo-Regular-TTF.sfd` and `src/Geo-Oblique-TTF.sfd` (FontForge SFD format)
-- **TTX decompositions**: Multiple `.ttx` files for both Regular and Oblique
-- **No config.yaml** anywhere in the repo
-- **No `.glyphs`, `.ufo`, or `.designspace` files**
-
-Since the repo has only one commit, that commit (0d2a519) is the only valid reference. The font files in google/fonts have never been updated since the initial commit.
-
-### Build Configuration
-
-The upstream sources are in SFD (FontForge) format only. SFD files are not compatible with gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` sources. Therefore, no config.yaml can be created -- neither as an upstream file nor as an override.
-
-### Google Fonts History
-
-The Geo font files (`Geo-Regular.ttf`, `Geo-Oblique.ttf`) have only been touched in the initial commit (90abd17b). No subsequent updates have been made to the binary fonts.
-
-## Conclusion
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/geo"
-  commit: "0d2a51963d3c6e52d7b8edc50a5d7b457bb1a663"
-  files {
-    source_file: "OFL.txt"
-    dest_file: "OFL.txt"
-  }
-}
-```
-
-### Status: no_config_possible
-
-The upstream repo only has SFD sources, which are not compatible with gftools-builder. A `config_yaml` field cannot be set. The source block can still document the repository URL and commit for provenance tracking.
+The original FontForge sources are at https://github.com/librefonts/geo (`.sfd`), latest at commit `0d2a51963d3c6e52d7b8edc50a5d7b457bb1a663`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/glegoo/METADATA.pb
+++ b/ofl/glegoo/METADATA.pb
@@ -26,7 +26,21 @@ subsets: "devanagari"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/etunni/glegoo"
-  commit: "a6b0a10abfaf1b88feb4a9f9eb731beefbb4bbb8"
+  repository_url: "https://github.com/googlefonts/glegoo"
+  commit: "f33250e4771fc7535fbbe847c4d9787396dff0a9"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Glegoo-Bold.ttf"
+    dest_file: "Glegoo-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Glegoo-Regular.ttf"
+    dest_file: "Glegoo-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SLAB_SERIF"

--- a/ofl/glegoo/upstream_info.md
+++ b/ofl/glegoo/upstream_info.md
@@ -1,93 +1,28 @@
-# Investigation Report: Glegoo
+# Glegoo
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Glegoo is a slab serif typeface designed by Eduardo Tunni, featuring Regular and Bold weights with Latin and Devanagari script support. The upstream repository at `https://github.com/etunni/glegoo` contains FontForge SFD source files. The METADATA.pb already has a source block with repository_url and commit hash, and an override config.yaml exists in the google/fonts family directory. However, the override config.yaml only references `Glegoo-Regular.sfd` and omits `Glegoo-Bold.sfd`, which means it cannot produce the full family.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Glegoo (Regular and Bold) built from FontForge SFD sources at https://github.com/etunni/glegoo. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field              | Value |
-|--------------------|-------|
-| Family Name        | Glegoo |
-| Designer           | Eduardo Tunni |
-| Repository URL     | https://github.com/etunni/glegoo |
-| Commit Hash        | a6b0a10abfaf1b88feb4a9f9eb731beefbb4bbb8 |
-| Config YAML        | Override config.yaml in google/fonts (needs correction) |
-| Source Type        | FontForge SFD (.sfd) |
-| Weights            | Regular (400), Bold (700) |
-| Status             | needs_correction |
-| Confidence         | HIGH |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD sources were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/glegoo, building the fonts with gftools-builder3 + fontc.
+- Devanagari mark positioning: babelfont names the below/above anchors generically (DVAnchor0/DVAnchor3), which fontc cannot split into blwm/abvm; the below-base anchors were renamed to bottom so fontc routes below-base marks to blwm (12/12, matching shipped).
+- Two dead, shadowed i-matra ligature rules were removed.
+- The vertical metrics were set to the shipped values, the Bold master name + an OS/2 WeightClass override (700) were added, and the spacing conjuncts were kept out of the mark category so their advances and mark coverage match shipped.
+- The build was verified against the shipped binaries.
 
-### METADATA.pb Analysis
+## Final state
 
-The current METADATA.pb contains a source block added by Simon Cozens (commit 474a446c0, 2024-01-14) with the repository_url, later enriched by Felipe Sanches (commit f7b6a76a3, 2025-10-30) with the commit hash `a6b0a10abfaf1b88feb4a9f9eb731beefbb4bbb8`. No `config_yaml` field is set in the source block, which is correct since there is a local override config.yaml.
+The source now lives at https://github.com/googlefonts/glegoo (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional parity with the shipped binaries.
 
-### Upstream Repository
+## Verification
 
-- **URL**: https://github.com/etunni/glegoo
-- **Cached at**: upstream_repos/fontc_crater_cache/etunni/glegoo
-- **Remote verified**: Yes, remote origin matches the METADATA.pb repository_url
+cmap, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB features, abvm/blwm mark coverage (40/12) and advance widths all match the shipped binaries. The only difference is a redundant generic `mark` GPOS feature that fontc registers alongside abvm/blwm; it is inert for Devanagari (HarfBuzz applies the Indic abvm/blwm features, not the default mark).
 
-The repository contains:
-- `Glegoo-Regular.sfd` - FontForge source for Regular weight (v2.0.1)
-- `Glegoo-Bold.sfd` - FontForge source for Bold weight (v2.0.1)
-- `Glegoo-Regular.ttf` - Pre-compiled Regular binary
-- `Glegoo-Bold.ttf` - Pre-compiled Bold binary
-- `OFL.txt`, `FONTLOG.txt` - License and font log
-- No config.yaml in the upstream repo
-- No .glyphs, .ufo, or .designspace files
+## Original repository (dormant)
 
-### Commit Hash Verification
-
-The referenced commit `a6b0a10` (2014-08-27, "Update files and image") is the HEAD of the repository's master branch. It only modified documentation files (PDF sample and InDesign template), not the font sources.
-
-The SFD source files were last updated in commit `99fd234` (2014-08-12, "New ttf's with auto hinting version 1.1"). The commit `a6b0a10` is acceptable as the reference since it is the latest commit in the repo and the SFD files at that commit are identical to those at `99fd234`.
-
-The TTF files in google/fonts do not match the pre-compiled TTFs in the upstream repo (different md5 checksums), indicating the fonts in google/fonts were rebuilt from the SFD sources during onboarding rather than copied directly.
-
-### Google Fonts History
-
-- **Initial commit** (90abd17b4, 2015-03-07): Font files were added in the initial commit of the google/fonts repository.
-- **No TTF updates**: The TTF files have never been updated since the initial commit.
-
-### Override config.yaml Issue
-
-The current override config.yaml in `ofl/glegoo/config.yaml` contains:
-
-```yaml
-buildVariable: false
-sources:
-  - Glegoo-Regular.sfd
-```
-
-This only references the Regular weight. The Bold weight (`Glegoo-Bold.sfd`) is a separate SFD file in the upstream repo and should also be listed. Without it, gftools-builder would only produce the Regular weight, not the full family.
-
-## Conclusion
-
-The source block in METADATA.pb is correct (repository_url and commit hash are both valid). However, the override config.yaml needs correction to include both SFD sources. Note that SFD is not a modern gftools-builder source format, so building from these sources may not be fully supported by the current toolchain.
-
-### Recommended METADATA.pb Source Block
-
-The existing source block is correct and does not need changes:
-
-```
-source {
-  repository_url: "https://github.com/etunni/glegoo"
-  commit: "a6b0a10abfaf1b88feb4a9f9eb731beefbb4bbb8"
-}
-```
-
-### Recommended Override config.yaml Correction
-
-```yaml
-buildVariable: false
-sources:
-  - Glegoo-Regular.sfd
-  - Glegoo-Bold.sfd
-```
-
-### Status: needs_correction
-
-The METADATA.pb source block is complete, but the override config.yaml should be corrected to include both the Regular and Bold SFD sources.
+The original FontForge sources are at https://github.com/etunni/glegoo (`.sfd`), latest at commit `a6b0a10abfaf1b88feb4a9f9eb731beefbb4bbb8`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/headlandone/METADATA.pb
+++ b/ofl/headlandone/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/headlandone"
-  commit: "c5193604253d9cf325e43b44e88045a503b53cbf"
+  repository_url: "https://github.com/googlefonts/headlandone"
+  commit: "fe8d141e82ed1697ae76dcea8c524acb2eef0490"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/HeadlandOne-Regular.ttf"
+    dest_file: "HeadlandOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/headlandone/upstream_info.md
+++ b/ofl/headlandone/upstream_info.md
@@ -1,83 +1,27 @@
-# Investigation Report: Headland One
+# HeadlandOne
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Headland One is a serif typeface designed by Gary Lonergan and mastered by Eben Sorkin (Sorkin Type Co), added to Google Fonts on 2012-05-09 via the initial commit of the repository. It has no source block in METADATA.pb. An upstream repository exists at `https://github.com/librefonts/headlandone`, but it contains only SFD source files (FontForge format) and TTX dumps -- no gftools-builder compatible sources (.glyphs, .ufo, or .designspace). No config.yaml is possible for this family.
+## Initial state
 
-## Key Findings
+Google Fonts shipped HeadlandOne (Regular) built from FontForge SFD sources at https://github.com/librefonts/headlandone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field              | Value                                                                 |
-|--------------------|-----------------------------------------------------------------------|
-| Family Name        | Headland One                                                          |
-| Designer           | Gary Lonergan                                                         |
-| Repository URL     | https://github.com/librefonts/headlandone                             |
-| Commit Hash        | c5193604253d9cf325e43b44e88045a503b53cbf                              |
-| Config YAML        | None (SFD-only sources)                                               |
-| Status             | no_config_possible                                                    |
-| Confidence         | HIGH                                                                  |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/headlandone, building the fonts with gftools-builder3 + fontc.
+- The vertical metrics were set to the shipped OS/2 and hhea values (babelfont's offset-mode resolution left them a few units off).
+- The spacing glyph commaaccent was forced to the Letter category so fontc does not classify it as a combining mark.
+- The build was verified against the shipped binaries.
 
-### METADATA.pb Analysis
+## Final state
 
-The current METADATA.pb has no source block at all. It contains only:
-- Family name, designer ("Gary Lonergan"), license (OFL)
-- Category: SERIF
-- Date added: 2012-05-09
-- One font weight: HeadlandOne-Regular.ttf (400 normal)
-- Subsets: menu, latin, latin-ext
+The source now lives at https://github.com/googlefonts/headlandone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
-No `repository_url`, `commit`, or `config_yaml` fields.
+## Verification
 
-### Google Fonts Git History
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths.
 
-The font was part of the massive initial commit of the google/fonts repository:
+## Original repository (dormant)
 
-1. **90abd17b4** - `Initial commit` -- Mar 7, 2015 (by Dave Crossland) -- this is when the git repo was created; the font was already in the Google Fonts catalog since 2012-05-09.
-2. **76adaf1d2** - `deploy: c7e274018...` -- this commit DELETED the Headland One files (likely a transient state in repo reorganization).
-
-The binary TTF file has only been touched by these two commits. There are no PR references or update commits.
-
-### Upstream Repository
-
-The upstream repo at `https://github.com/librefonts/headlandone` is cached at `fontc_crater_cache/librefonts/headlandone`.
-
-The repo has a single commit:
-- **c519360** - `update .travis.yml` -- Oct 17, 2014
-
-This is a typical `librefonts` mirror repo that contains:
-- TTX table dumps of the font files
-- SFD source files (`src/HeadlandOne-Regular-TTF.sfd` and `src/HeadlandOne-Regular-OTF.sfd`)
-- FONTLOG.txt, DESCRIPTION.en_us.html, OFL.txt, METADATA.json
-
-### Source Files
-
-The only source files in the repo are:
-- `src/HeadlandOne-Regular-TTF.sfd` -- FontForge SFD for TrueType version
-- `src/HeadlandOne-Regular-OTF.sfd` -- FontForge SFD for OpenType/CFF version
-
-These are SFD (FontForge) format files. The FONTLOG.txt mentions the original source was created in FontLab VBF format. No `.glyphs`, `.ufo`, or `.designspace` files exist. These SFD sources are not compatible with gftools-builder, so no config.yaml can be created.
-
-### Font Copyright and Origin
-
-From the FONTLOG.txt and binary metadata:
-- Designed by Gary Lonergan (garylonergan@hotmail.com)
-- Mastered by Eben Sorkin (sorkineben@gmail.com, Sorkin Type Co)
-- Copyright: "Copyright (c) 2011, Sorkin Type Co (www.sorkintype.com)"
-- Version 1.002 (April 2011)
-- The DESCRIPTION.en_us.html references Google Code as the source repository (historical -- Google Code was shut down)
-
-No override config.yaml exists in the google/fonts directory.
-
-## Conclusion
-
-The family has an identifiable upstream repo at `librefonts/headlandone` with only one commit. The sources are SFD-only (FontForge format), which are not compatible with gftools-builder. A source block can be added with the repository URL and commit hash, but no config.yaml is possible.
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/headlandone"
-  commit: "c5193604253d9cf325e43b44e88045a503b53cbf"
-}
-```
+The original FontForge sources are at https://github.com/librefonts/headlandone (`.sfd`), latest at commit `c5193604253d9cf325e43b44e88045a503b53cbf`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/ranga/METADATA.pb
+++ b/ofl/ranga/METADATA.pb
@@ -29,6 +29,20 @@ primary_script: "Deva"
 classifications: "DISPLAY"
 classifications: "HANDWRITING"
 source {
-  repository_url: "https://github.com/antonxheight/Ranga"
-  commit: "15fadcc52c43bfbe15915c530b2409f8bcf244e4"
+  repository_url: "https://github.com/googlefonts/Ranga"
+  commit: "47116eb916be5a95fbf6ba6f3795badbc15a2265"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Ranga-Bold.ttf"
+    dest_file: "Ranga-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Ranga-Regular.ttf"
+    dest_file: "Ranga-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/ranga/upstream_info.md
+++ b/ofl/ranga/upstream_info.md
@@ -1,18 +1,28 @@
-# Ranga — Source Repository Investigation
+# Ranga
 
-**Model**: Claude Opus 4.6
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Repository
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository | [antonxheight/Ranga](https://github.com/antonxheight/Ranga) |
-| Commit | `15fadcc52c43bfbe15915c530b2409f8bcf244e4` |
-| Binary Date | 2017-05-09 |
-| Source Types | .sfd |
-| Buildable | No |
-| Confidence | High (canonical designer repo) |
+Google Fonts shipped Ranga (Regular and Bold) built from FontForge SFD sources at https://github.com/antonxheight/Ranga. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Notes
+## Actions taken
 
-Source repository for ranga. Commit determined by date correlation with the last binary modification in google/fonts (2017-05-09).
+- The canonical FontForge SFD sources were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/Ranga, building the fonts with gftools-builder3 + fontc.
+- Source FEA fixes: a dangling glyph reference (shadeva_viramadeva_alt, a typo for the existing shadeva_viramadeva.alt) was corrected, and two dead, shadowed ligature rules were removed.
+- Devanagari mark positioning: the below-base anchors (named DVAnchor0 by babelfont) were renamed to bottom so fontc routes below-base marks to blwm (12/12).
+- The vertical metrics were set to the shipped values, the Bold master name + an OS/2 WeightClass override (700) were added, and the spacing conjuncts were kept out of the mark category so their advances and mark coverage match shipped.
+- The build was verified against the shipped binaries.
+
+## Final state
+
+The source now lives at https://github.com/googlefonts/Ranga (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional parity with the shipped binaries.
+
+## Verification
+
+cmap, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB features, abvm/blwm mark coverage (37/12) and advance widths all match the shipped binaries. The only difference is a redundant generic `mark` GPOS feature that fontc registers alongside abvm/blwm; it is inert for Devanagari (HarfBuzz applies the Indic abvm/blwm features, not the default mark).
+
+## Original repository (dormant)
+
+The original FontForge sources are at https://github.com/antonxheight/Ranga (`.sfd`), latest at commit `15fadcc52c...`. Preserved for provenance; the new `.glyphs` source supersedes it for building.


### PR DESCRIPTION
## Summary

This PR points 15 Google Fonts families at new upstream source repositories under the `googlefonts` org. Each of these families shipped from FontForge `.sfd` sources with no Glyphs source and nothing that builds with the current Google Fonts Rust pipeline (fontc). The `.sfd` sources were converted to Glyphs (`.glyphs`) with babelfont-rs and set up as standard Unified Font Repositories that build with gftools-builder3 + fontc. This PR updates each family's METADATA.pb `source { }` block (repository, commit, files, config) and rewrites its `upstream_info.md`.

There is one commit per family.

## Families

| Family | Styles | Source repository | Parity |
|--------|--------|-------------------|--------|
| Antic | Regular | [googlefonts/antic](https://github.com/googlefonts/antic) | strict |
| Dorsa | Regular | [googlefonts/dorsa](https://github.com/googlefonts/dorsa) | strict |
| Eater | Regular | [googlefonts/eater](https://github.com/googlefonts/eater) | strict |
| Allan | Regular, Bold | [googlefonts/allan](https://github.com/googlefonts/allan) | strict |
| Buda | Light | [googlefonts/buda](https://github.com/googlefonts/buda) | strict |
| Geo | Regular, Oblique | [googlefonts/geo](https://github.com/googlefonts/geo) | strict |
| Headland One | Regular | [googlefonts/headlandone](https://github.com/googlefonts/headlandone) | strict |
| Caudex | Regular, Bold, Italic, BoldItalic | [googlefonts/caudex](https://github.com/googlefonts/caudex) | functional |
| Chathura | Thin, Light, Regular, Bold, ExtraBold | [googlefonts/Chathura](https://github.com/googlefonts/Chathura) | strict |
| Cantarell | Regular, Bold, Italic, BoldItalic | [googlefonts/cantarell](https://github.com/googlefonts/cantarell) | functional |
| Bentham | Regular | [googlefonts/bentham](https://github.com/googlefonts/bentham) | strict |
| Carme | Regular | [googlefonts/carme](https://github.com/googlefonts/carme) | strict |
| Creepster | Regular | [googlefonts/creepster](https://github.com/googlefonts/creepster) | functional |
| Glegoo | Regular, Bold | [googlefonts/glegoo](https://github.com/googlefonts/glegoo) | functional |
| Ranga | Regular, Bold | [googlefonts/Ranga](https://github.com/googlefonts/Ranga) | functional |

## What each commit does

- **METADATA.pb**: the `source { }` block now points at `googlefonts/<family>` at the merged commit, with `config_yaml: sources/config.yaml` and `branch: master`. The previously-recorded FontForge mirror is preserved in each `upstream_info.md`.
- **upstream_info.md**: rewritten as a lean record of the modernization (initial state, actions taken, verification). The repository, commit and config live only in METADATA.pb and are deliberately not duplicated in a table here, so the two cannot drift.

## Verification

Every family was built with gftools-builder3 + fontc and compared against the shipped binaries. 10 reach strict functional equivalence (identical cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths).

5 reach functional parity, with the single difference documented in the family's `upstream_info.md`:
- **caudex**: the build classifies the Latin combining marks in GDEF, which the older ufo2ft-built shipped binary left unclassified; Caudex has no mark-positioning GPOS feature, so this is inert and the build is simply more correct.
- **cantarell**: the only difference is the advance width of the auto-generated `.notdef` box (the SFDs contain no `.notdef` to control it; it is never used in real text).
- **glegoo** and **ranga** (Devanagari): a redundant generic `mark` GPOS feature that fontc registers alongside `abvm`/`blwm`; it is inert for Devanagari, where HarfBuzz applies the Indic `abvm`/`blwm` features rather than the default `mark`.
- **creepster**: the kerning is fully preserved but modernized from the shipped legacy `kern` table to a GPOS `kern` feature (the current Google Fonts mechanism).

## Notes

- The source repositories build in CI with gftools-builder3 + fontc (the same pipeline used for verification here).
- Some source fixes recorded in the reports (an OS/2 WeightClass override, Devanagari anchor renaming, etc.) are small workarounds for current tooling gaps and can be removed once the corresponding fontc/babelfont fixes land.