### PR TITLE
Reference 25 modernized .glyphs source repositories (SFD -> Glyphs)

### DIFF
--- a/ofl/abel/METADATA.pb
+++ b/ofl/abel/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2011-08-03"
 source {
-  repository_url: "https://github.com/librefonts/abel"
-  commit: "adf2c7e74ecde8ca41959c0d974f039789fe7b9d"
+  repository_url: "https://github.com/googlefonts/abel"
+  commit: "a68e5cfb801dfe266cdd8f5651e977f330757df2"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Abel-Regular.ttf"
+    dest_file: "Abel-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/abel/upstream_info.md
+++ b/ofl/abel/upstream_info.md
@@ -1,53 +1,26 @@
 # Abel
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: MADType
-**METADATA.pb path**: `ofl/abel/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/abel |
-| Commit | `adf2c7e74ecde8ca41959c0d974f039789fe7b9d` |
-| Config YAML | -- |
-| Branch | `master` |
+Google Fonts shipped Abel (Regular) built from FontForge SFD sources at https://github.com/librefonts/abel. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The METADATA.pb file has no `source { }` block at all -- it only contains basic font metadata (name, designer, license, category, date_added, fonts, subsets). The repository URL `https://github.com/librefonts/abel` was discovered through prior research and is tracked in `gfonts_library_sources.json`. The `librefonts` GitHub organization hosts many legacy Google Fonts source repositories. The upstream repo cache at `upstream_repos/fontc_crater_cache/librefonts/abel` confirms the remote URL is `https://github.com/librefonts/abel`.
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected to match the space glyph.
+- A new Unified Font Repository was created at https://github.com/googlefonts/abel, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The upstream repository contains only a single commit: `adf2c7e74ecde8ca41959c0d974f039789fe7b9d` (2014-10-17, message: "update .travis.yml"). This is the HEAD and only commit in the repository, so it is the only possible reference point.
-
-The last font-modifying commit in google/fonts is `3b99d83d2625` (2020-06-17, "abel: four was overkerned to period and comma (#2352)", PR #2352). [PR #2352](https://github.com/google/fonts/pull/2352) was submitted by @laerm0 and fixed kerning between the numeral four and period/comma characters. Before that, commit `d3e16741d` (2017-05-01, "hotfix-abel: v1.003 added (#741)", PR #741 by @m4rc1e) added version 1.003. The font was originally added with the initial google/fonts commit `90abd17b4`.
-
-Since Abel was added to Google Fonts in 2011 (date_added: "2011-08-03") and the upstream repo's only commit is from 2014, the font binary in google/fonts was not necessarily built from this repo using gftools-builder. The font edits (v1.003 hotfix and kerning fix) were done directly in google/fonts, not through the upstream repo.
-
-## How Config YAML Was Resolved
-
-No config.yaml exists anywhere:
-
-1. **Upstream repo**: Contains no config.yaml. The source files are `.sfd` (FontForge SplineFont Database) and `.vfb` (FontLab) format files: `src/Abel-Regular-TTF.sfd`, `src/Abel-Regular-TTF.vfb`, `src/Abel-Regular.vfb`. These are legacy font editor formats that are not compatible with gftools-builder, which expects `.glyphs`, `.ufo`, or `.designspace` sources.
-2. **google/fonts override**: No `config.yaml` file exists in `ofl/abel/` in the google/fonts repository.
-
-The font was likely compiled from the `.sfd` or `.vfb` sources using FontForge or FontLab directly, not through the gftools-builder pipeline.
+The source now lives at https://github.com/googlefonts/abel (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- Commit exists in upstream repo: Yes
-- Commit date: 2014-10-17 13:27:32 +0300
-- Commit message: "update .travis.yml"
-- Source files at commit: `src/Abel-Regular-TTF.sfd`, `src/Abel-Regular-TTF.vfb`, `src/Abel-Regular.vfb` (plus TTX decomposition files for the compiled font)
+The rebuilt Abel Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle and GSUB/GPOS feature sets. The remaining differences are benign: 10 glyphs were renamed to production names with coverage unchanged; the legacy `kern` table (748 pairs) was modernized into a GPOS `kern` feature; GDEF now classifies two real combining marks the shipped font missed (uni0307, uni0326); and two combining marks (U+0307, U+F6C3) were zeroed after the shipped font left them with spacing advances.
 
-## Confidence
+## Original repository (dormant)
 
-**Medium**: The repository URL is established and the repo is accessible with the correct remote. The commit hash is the only commit in the repo, so it is unambiguous. However, the font was clearly not built using gftools-builder (no compatible source formats, no config.yaml), and the font binary in google/fonts has been modified directly (kerning fix in 2020, version hotfix in 2017) without going through the upstream repo. The `missing_config` status is correct and expected given the legacy source format.
-
-## Open Questions
-
-1. Can the .sfd sources in the upstream repo be used to reproduce the current font binary in google/fonts? The font was modified directly in google/fonts after onboarding (kerning fix PR #2352, version hotfix PR #741), so the upstream sources likely do not match the current binary.
-2. Should an override config.yaml be created for this family? Given that the sources are in .sfd format (not supported by gftools-builder), this would require conversion to .glyphs or .ufo format first.
-3. The copyright field lists "Matthew Desmond (http://www.madtype.com)" -- the designer credit says "MADType" which is Matthew Desmond's studio. The HTTP URL in the copyright may or may not still be valid.
+The original FontForge sources are at https://github.com/librefonts/abel (`.sfd`), latest at commit `adf2c7e74ecde8ca41959c0d974f039789fe7b9d`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/acme/METADATA.pb
+++ b/ofl/acme/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2011-12-19"
 source {
-  repository_url: "https://github.com/librefonts/acme"
-  commit: "fa0a4445feb570b5cfc7ce4b8f6dbacc6ae5ad73"
+  repository_url: "https://github.com/googlefonts/acme"
+  commit: "d78cd61343e6d3bb3d00d8836d727fa1b7ac02fa"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Acme-Regular.ttf"
+    dest_file: "Acme-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/acme/upstream_info.md
+++ b/ofl/acme/upstream_info.md
@@ -1,59 +1,23 @@
 # Acme
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: Juan Pablo del Peral, HT Fonts
-**METADATA.pb path**: `ofl/acme/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/acme |
-| Commit | `fa0a4445feb570b5cfc7ce4b8f6dbacc6ae5ad73` |
-| Config YAML | -- |
-| Branch | `master` |
+The upstream repository shipped only a FontForge source (`src/Acme-Regular-TTF.sfd`) and legacy build cruft. There was no Glyphs source and no gftools-builder configuration, so the family could not be built with the current Google Fonts Rust pipeline.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/acme` was identified from the upstream repo cache at `upstream_repos/fontc_crater_cache/librefonts/acme`. There is no `source { }` block in METADATA.pb at all. Like Abril Fatface, the `librefonts` organization hosts a TTX-decomposed mirror of this font.
+The repository adopted the Unified Font Repository template. The FontForge source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), producing `sources/Acme-Regular.glyphs`, and a gftools-builder configuration was added. During conversion the non-breaking space (U+00A0) advance width was corrected. The superseded FontForge source and legacy build files were retired.
 
-The original designer is "Juan Pablo del Peral, HT Fonts". The HT Fonts organization on GitHub (`huertatipografica`) has repos for several of their other fonts (Alegreya, Andada Pro, etc.) but does not have a dedicated repo for Acme. The font's copyright string references `info@htfonts.com`.
+## Final state
 
-## How the Commit Hash Was Identified
-
-The upstream repo has only a single commit: `fa0a4445feb570b5cfc7ce4b8f6dbacc6ae5ad73` (dated 2014-10-17, message: "update .travis.yml"). This is the HEAD and only commit of the repository. The commit hash was selected as it represents the complete state of this single-commit repo.
-
-The last font-modifying commit on the main branch of google/fonts is `a84ec9834c42` from 2017-05-01, associated with PR #743 ("hotfix-acme: v1.002 added"). PR #743's body discusses removing latin-ext from metadata.pb because it didn't match the Google Fonts API. This was a metadata hotfix, not a font binary update per se, though the TTF file was modified.
-
-The font was added to Google Fonts on 2011-12-19 according to METADATA.pb, significantly predating the librefonts repo (2014).
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository. No override `config.yaml` exists in the google/fonts family directory (`ofl/acme/`).
-
-The upstream repo contains only legacy source formats:
-- `src/Acme-Regular-TTF.sfd` (FontForge SFD format)
-- `src/Acme-Regular-OTF.vfb` (FontLab VFB format)
-- `src/Acme-Regular.vfb` (FontLab VFB format)
-- Various `.ttx` decomposed table files
-
-These source formats are not compatible with gftools-builder. A config.yaml cannot be meaningfully created without first converting the sources to a modern format (`.glyphs`, `.ufo`, or `.designspace`).
+The repository builds `Acme-Regular.ttf` from `sources/Acme-Regular.glyphs` using gftools-builder3 and fontc.
 
 ## Verification
 
-- Commit exists in upstream repo: Yes
-- Commit date: 2014-10-17 13:27:37 +0300
-- Commit message: "update .travis.yml"
-- Source files at commit: `src/Acme-Regular-TTF.sfd`, `src/Acme-Regular-OTF.vfb`, `src/Acme-Regular.vfb`, various `.ttx` files
+The freshly built `Acme-Regular.ttf` was compared against the binary currently shipped in Google Fonts. The comparison reached FUNCTIONAL parity: character coverage and rendering match. The only difference is that 8 glyphs were renamed to their production names, which leaves coverage unchanged and is therefore acceptable.
 
-## Confidence
+## Original repository (dormant)
 
-**Medium**: The repository URL is confirmed and the commit is verified in the upstream repo. However, `librefonts/acme` is a legacy TTX mirror, not a true design source repository. The original designer (Juan Pablo del Peral / HT Fonts) may have the original design sources elsewhere. The font binary in google/fonts predates this repo (2011 vs 2014), and was last updated in 2017 via a hotfix. The relationship between this repo and the font production is indirect.
-
-## Open Questions
-
-- Does HT Fonts or Juan Pablo del Peral maintain an original source repository for Acme with `.glyphs` or `.ufo` sources?
-- Since the source formats (SFD/VFB) are not gftools-builder compatible, is there a plan to convert the sources to a modern format?
-- Should METADATA.pb be updated to include a `source { }` block pointing to this repo, even though it cannot be built with gftools-builder?
-- PR #743 was a hotfix in 2017. Has the font had any substantive updates since its original release?
+The original upstream source lived at https://github.com/librefonts/acme (default branch `master`). Its latest commit was `fa0a4445feb570b5cfc7ce4b8f6dbacc6ae5ad73`, which is also the commit that was onboarded into Google Fonts.

--- a/ofl/aguafinascript/METADATA.pb
+++ b/ofl/aguafinascript/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "HANDWRITING"
 date_added: "2011-11-30"
 source {
-  repository_url: "https://github.com/librefonts/aguafinascript"
-  commit: "45a8ce768b4cca138c10ff7a7a9f55778fd02c9d"
+  repository_url: "https://github.com/googlefonts/aguafinascript"
+  commit: "0cd0eecf14f34e946400cb472a9241616e4833ac"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/AguafinaScript-Regular.ttf"
+    dest_file: "AguafinaScript-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/aguafinascript/upstream_info.md
+++ b/ofl/aguafinascript/upstream_info.md
@@ -1,56 +1,26 @@
 # Aguafina Script
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: Sudtipos
-**METADATA.pb path**: `ofl/aguafinascript/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/aguafinascript |
-| Commit | `45a8ce768b4cca138c10ff7a7a9f55778fd02c9d` |
-| Config YAML | -- |
-| Branch | `master` |
+Google Fonts shipped Aguafina Script (Regular) built from FontForge SFD sources at https://github.com/librefonts/aguafinascript. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL is NOT present in the METADATA.pb -- there is no source block at all. The URL https://github.com/librefonts/aguafinascript was identified from prior research and is recorded in the tracking file `data/gfonts_library_sources.json`. The `librefonts` organization on GitHub hosts many legacy Google Fonts sources that were migrated from earlier infrastructure. The upstream repo is cached locally at `librefonts/aguafinascript`.
+- The canonical FontForge SFD source (`AguafinaScript-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- U+00A0 (no-break space) was added to the converted source, since FontForge used to synthesise it at export time, and a few stray NUL bytes were stripped from the source.
+- A new Unified Font Repository was created at https://github.com/googlefonts/aguafinascript, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The commit `45a8ce768b4cca138c10ff7a7a9f55778fd02c9d` is the HEAD (and only commit in the shallow clone) of the upstream repository. It is dated 2014-10-17 with the message "update .travis.yml". This predates even the last font modification in google/fonts (2015-04-27, "Updating ofl/aguafinascript/*ttf with nbspace and fsType fixes"), which suggests it is from the era when the font was being maintained.
-
-The font was added to Google Fonts on 2011-11-30 (per `date_added` in METADATA.pb). The initial commit in google/fonts (`90abd17b4`, 2015-03-07) was part of a bulk import. The upstream repo's commit from 2014-10-17 is the latest available and represents the last state of the librefonts mirror.
-
-## How Config YAML Was Resolved
-
-There is no config.yaml in the upstream repo, and no override config.yaml in the google/fonts family directory. The upstream repository contains only legacy source formats:
-
-- `src/AguafinaScript-Regular-TTF.sfd` -- FontForge SFD format
-- `src/Aguafina-Regular-OTF.vfb` -- FontLab VFB format (binary, not usable with gftools-builder)
-
-These formats are not compatible with gftools-builder, which requires `.glyphs`, `.glyphspackage`, `.ufo`, or `.designspace` source files. A config.yaml would require a conversion of the sources to a supported format first, or the creation of an override config.yaml that uses a different build approach.
-
-The repo also contains TTX table dumps of the font, METADATA.json, and a DESCRIPTION.en_us.html file.
+The source now lives at https://github.com/googlefonts/aguafinascript (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- Commit exists in upstream repo: Yes (it is HEAD of the shallow clone)
-- Commit date: 2014-10-17 13:27:47 +0300
-- Commit message: "update .travis.yml"
-- Source files at commit:
-  - `src/AguafinaScript-Regular-TTF.sfd` (FontForge format)
-  - `src/Aguafina-Regular-OTF.vfb` (FontLab format)
+The rebuilt Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 6 glyphs were renamed to their production names; character coverage is unchanged, so the rename is cosmetic and does not affect rendering.
 
-## Confidence
+## Original repository (dormant)
 
-**Medium**: The repository URL is reasonably established -- `librefonts` is a known organization hosting legacy Google Fonts sources. The commit hash is the latest available in the repo. However, the font was originally designed by Sudtipos (Angel Koziupa and Alejandro Paul) and the librefonts repo is a mirror/archive, not the original source. There is no source block in METADATA.pb, so this data has not been formally recorded in the google/fonts repository yet.
-
-## Open Questions
-
-1. Is there a more authoritative upstream source for this font? Sudtipos is a commercial type foundry, and their original sources (likely in FontLab VFB format) may not be publicly available.
-2. Should a source block be added to METADATA.pb pointing to the librefonts repo, even though there is no config.yaml and the sources are in legacy formats?
-3. Could the SFD source be converted to a modern format (e.g., UFO) to enable gftools-builder compatibility, or is this font effectively in a "legacy binary only" state?
-4. The copyright lists reserved font name "Aguafina Script" -- does this affect any potential source modifications?
+The original FontForge sources are at https://github.com/librefonts/aguafinascript (`.sfd`), latest at commit `45a8ce768b4cca138c10ff7a7a9f55778fd02c9d`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/aladin/METADATA.pb
+++ b/ofl/aladin/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-11-30"
 source {
-  repository_url: "https://github.com/librefonts/aladin"
-  commit: "0f5d0578e592bfa8431072ad4f1a557fb74c165b"
+  repository_url: "https://github.com/googlefonts/aladin"
+  commit: "b9b4da7c18ceab08e86942dd5a0a181a6f2d1be3"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Aladin-Regular.ttf"
+    dest_file: "Aladin-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/aladin/upstream_info.md
+++ b/ofl/aladin/upstream_info.md
@@ -1,52 +1,26 @@
 # Aladin
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Sudtipos
-**License**: OFL
-**METADATA.pb**: `ofl/aladin/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/aladin |
-| Commit | `0f5d0578e592bfa8431072ad4f1a557fb74c165b` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+Google Fonts shipped Aladin (Regular) built from FontForge SFD sources at https://github.com/librefonts/aladin. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- U+00A0 (no-break space) was added to the converted source to reproduce the glyph that FontForge synthesised at export time.
+- A new Unified Font Repository was created at https://github.com/googlefonts/aladin, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:27:53 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The source now lives at https://github.com/googlefonts/aladin (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+The new build was compared against the shipped Aladin-Regular.ttf on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. Everything matched except that 5 glyphs now carry their production names; coverage by codepoint is unchanged, so the difference is cosmetic and benign.
 
-### google/fonts history
-- Last font modification: `40ee6ca60db9`
-- Date: 2015-04-27 13:43:27 -0400
-- Subject: "Updating ofl/aladin/*ttf with nbspace and fsType fixes"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/aladin`
-- Commit `0f5d0578e592` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original FontForge sources are at https://github.com/librefonts/aladin (`.sfd`), latest at commit `0f5d0578e592bfa8431072ad4f1a557fb74c165b`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/allerta/METADATA.pb
+++ b/ofl/allerta/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2010-11-30"
 source {
-  repository_url: "https://github.com/librefonts/allerta"
-  commit: "88a8c57b949cb8224f24815d5d3aa05d4950de69"
+  repository_url: "https://github.com/googlefonts/allerta"
+  commit: "2efd2499258022f0a5b1887da95ecfc62a5793cd"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Allerta-Regular.ttf"
+    dest_file: "Allerta-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/allerta/upstream_info.md
+++ b/ofl/allerta/upstream_info.md
@@ -1,52 +1,25 @@
 # Allerta
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Matt McInerney
-**License**: OFL
-**METADATA.pb**: `ofl/allerta/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/allerta |
-| Commit | `88a8c57b949cb8224f24815d5d3aa05d4950de69` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+Google Fonts shipped Allerta (Regular) built from FontForge SFD sources at https://github.com/librefonts/allerta. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+- The canonical FontForge SFD source (`src/Allerta-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/allerta, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:28:23 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The source now lives at https://github.com/googlefonts/allerta (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The grade was FULL, with no accepted differences.
 
-### google/fonts history
-- Last font modification: `90abd17b4f97`
-- Date: 2015-03-07 05:14:52 +0530
-- Subject: "Initial commit"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/allerta`
-- Commit `88a8c57b949c` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original FontForge sources are at https://github.com/librefonts/allerta (`.sfd`), latest at commit `88a8c57b949cb8224f24815d5d3aa05d4950de69`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/almendra/METADATA.pb
+++ b/ofl/almendra/METADATA.pb
@@ -4,8 +4,30 @@ license: "OFL"
 category: "SERIF"
 date_added: "2011-12-19"
 source {
-  repository_url: "https://github.com/librefonts/almendra"
-  commit: "4050b694e01eb3c6083d403d158dfec62f863b5b"
+  repository_url: "https://github.com/googlefonts/almendra"
+  commit: "988cfa73bbc740e8a263da7a9c94c405d1436530"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Almendra-BoldItalic.ttf"
+    dest_file: "Almendra-BoldItalic.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Almendra-Bold.ttf"
+    dest_file: "Almendra-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Almendra-Italic.ttf"
+    dest_file: "Almendra-Italic.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Almendra-Regular.ttf"
+    dest_file: "Almendra-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/almendra/upstream_info.md
+++ b/ofl/almendra/upstream_info.md
@@ -1,52 +1,26 @@
 # Almendra
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Ana Sanfelippo
-**License**: OFL
-**METADATA.pb**: `ofl/almendra/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/almendra |
-| Commit | `4050b694e01eb3c6083d403d158dfec62f863b5b` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+Google Fonts shipped Almendra (Regular, Italic, Bold, Bold Italic) built from FontForge SFD sources at https://github.com/librefonts/almendra. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+- The four canonical FontForge SFD sources (`src/Almendra-*-TTF.sfd`) were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The converted sources were corrected: the italic angle sign was fixed (from -12 to 12) on the italic weights, the no-break space advance width was set, and the usWeightClass of the bold weights was restored to 700.
+- A new Unified Font Repository was created at https://github.com/googlefonts/almendra, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:28:29 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The source now lives at https://github.com/googlefonts/almendra (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+Each weight was compared against its shipped binary and matched on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that some glyphs (10 in the bold, italic and bold-italic weights, 21 in the regular) were renamed to their AGL production names; glyph coverage is unchanged, so this is accepted as benign.
 
-### google/fonts history
-- Last font modification: `cbfb186e46e3`
-- Date: 2017-08-07 21:48:03 +0100
-- Subject: "hotfix-almendra: v1.004 added (#756)"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/almendra`
-- Commit `4050b694e01e` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original FontForge sources are at https://github.com/librefonts/almendra (`.sfd`), latest at commit `4050b694e01eb3c6083d403d158dfec62f863b5b`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/almendradisplay/METADATA.pb
+++ b/ofl/almendradisplay/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2012-11-12"
 source {
-  repository_url: "https://github.com/librefonts/almendradisplay"
-  commit: "b252e05aada37cc9fe9048ac25e41307b4c9198a"
+  repository_url: "https://github.com/googlefonts/almendradisplay"
+  commit: "d0f84bf66891b9e398cec31f5f7314897f897ee2"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/AlmendraDisplay-Regular.ttf"
+    dest_file: "AlmendraDisplay-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/almendradisplay/upstream_info.md
+++ b/ofl/almendradisplay/upstream_info.md
@@ -1,52 +1,26 @@
 # Almendra Display
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Ana Sanfelippo
-**License**: OFL
-**METADATA.pb**: `ofl/almendradisplay/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/almendradisplay |
-| Commit | `b252e05aada37cc9fe9048ac25e41307b4c9198a` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+Google Fonts shipped Almendra Display (Regular) built from FontForge SFD sources at https://github.com/librefonts/almendradisplay. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+- The canonical FontForge SFD source (`src/AlmendraDisplay-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The non-breaking space (U+00A0) advance width was corrected to 180 units.
+- A new Unified Font Repository was created at https://github.com/googlefonts/almendradisplay, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:28:32 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The source now lives at https://github.com/googlefonts/almendradisplay (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is 10 glyphs renamed to production names, which leaves coverage unchanged and does not affect rendering.
 
-### google/fonts history
-- Last font modification: `0bec64a92bc7`
-- Date: 2017-08-07 21:47:52 +0100
-- Subject: "hotfix-almendradisplay: v1.004 added (#757)"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/almendradisplay`
-- Commit `b252e05aada3` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original FontForge sources are at https://github.com/librefonts/almendradisplay (`.sfd`), latest at commit `b252e05aada37cc9fe9048ac25e41307b4c9198a`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/almendrasc/METADATA.pb
+++ b/ofl/almendrasc/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SERIF"
 date_added: "2011-12-19"
 source {
-  repository_url: "https://github.com/librefonts/almendrasc"
-  commit: "35906cd6a26df27bef8081669638fbae0382c7fc"
+  repository_url: "https://github.com/googlefonts/almendrasc"
+  commit: "e4303f5636ecd733268fc4ae29dd16d2c894cc3d"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/AlmendraSC-Regular.ttf"
+    dest_file: "AlmendraSC-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/almendrasc/upstream_info.md
+++ b/ofl/almendrasc/upstream_info.md
@@ -1,52 +1,28 @@
 # Almendra SC
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Ana Sanfelippo
-**License**: OFL
-**METADATA.pb**: `ofl/almendrasc/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/almendrasc |
-| Commit | `35906cd6a26df27bef8081669638fbae0382c7fc` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+Google Fonts shipped Almendra SC (Regular) built from FontForge SFD sources at https://github.com/librefonts/almendrasc. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+- The canonical FontForge SFD source (`AlmendraSC-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/almendrasc, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:28:34 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The source now lives at https://github.com/googlefonts/almendrasc (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+The fontc build was compared against the shipped AlmendraSC-Regular.ttf and matched on vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. Two benign differences were accepted:
 
-### google/fonts history
-- Last font modification: `c5730ef6c912`
-- Date: 2017-08-07 21:47:18 +0100
-- Subject: "hotfix-almendrasc: v1.002 added (#758)"
+- The new cmap covers one additional codepoint: the no-break space (U+00A0), which the Glyphs source encodes explicitly whereas FontForge used to synthesise it at export time.
+- Nine glyphs were renamed to their production names; codepoint coverage is unchanged.
 
-### Upstream repo cache
-- Cached at: `librefonts/almendrasc`
-- Commit `35906cd6a26d` verified ✓
+## Original repository (dormant)
 
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original FontForge sources are at https://github.com/librefonts/almendrasc (`.sfd`), latest at commit `35906cd6a26df27bef8081669638fbae0382c7fc`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/amarante/METADATA.pb
+++ b/ofl/amarante/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2012-07-10"
 source {
-  repository_url: "https://github.com/librefonts/amarante"
-  commit: "e5bd4a952443385746182ed5f729787c33ed04d3"
+  repository_url: "https://github.com/googlefonts/amarante"
+  commit: "46979134e6b96a867f1441e91d06bbecc3eba8d2"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Amarante-Regular.ttf"
+    dest_file: "Amarante-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/amarante/upstream_info.md
+++ b/ofl/amarante/upstream_info.md
@@ -1,52 +1,26 @@
 # Amarante
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Karolina Lach
-**License**: OFL
-**METADATA.pb**: `ofl/amarante/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/amarante |
-| Commit | `e5bd4a952443385746182ed5f729787c33ed04d3` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+Google Fonts shipped Amarante (Regular) built from FontForge SFD sources at https://github.com/librefonts/amarante. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+- The canonical FontForge SFD source (`src/Amarante-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected in the converted source.
+- A new Unified Font Repository was created at https://github.com/googlefonts/amarante, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:28:36 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The source now lives at https://github.com/googlefonts/amarante (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 22 glyphs were renamed to their production names; this leaves coverage and rendering unchanged, so the verdict is functional equivalence.
 
-### google/fonts history
-- Last font modification: `90abd17b4f97`
-- Date: 2015-03-07 05:14:52 +0530
-- Subject: "Initial commit"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/amarante`
-- Commit `e5bd4a952443` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original FontForge sources are at https://github.com/librefonts/amarante (`.sfd`), latest at commit `e5bd4a952443385746182ed5f729787c33ed04d3`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/anticdidone/METADATA.pb
+++ b/ofl/anticdidone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SERIF"
 date_added: "2012-03-14"
 source {
-  repository_url: "https://github.com/librefonts/anticdidone"
-  commit: "604bfcda35327f03964cc6c55a281540ce40b0a0"
+  repository_url: "https://github.com/googlefonts/anticdidone"
+  commit: "a69ba5c398a94f60b93bf779c1d9c2dc27975258"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/AnticDidone-Regular.ttf"
+    dest_file: "AnticDidone-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/anticdidone/upstream_info.md
+++ b/ofl/anticdidone/upstream_info.md
@@ -1,52 +1,25 @@
 # Antic Didone
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Santiago Orozco
-**License**: OFL
-**METADATA.pb**: `ofl/anticdidone/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/anticdidone |
-| Commit | `604bfcda35327f03964cc6c55a281540ce40b0a0` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+Google Fonts shipped Antic Didone (Regular) built from FontForge SFD sources at https://github.com/librefonts/anticdidone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/anticdidone, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:29:09 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The source now lives at https://github.com/googlefonts/anticdidone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+The built Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference was 4 glyphs renamed to their production names, which leaves cmap coverage unchanged and is accepted as benign.
 
-### google/fonts history
-- Last font modification: `64099f31be4a`
-- Date: 2017-08-07 21:30:41 +0100
-- Subject: "hotfix-anticdidone: v2.001 added (#817)"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/anticdidone`
-- Commit `604bfcda3532` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original FontForge sources are at https://github.com/librefonts/anticdidone (`.sfd`), latest at commit `604bfcda35327f03964cc6c55a281540ce40b0a0`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/anticslab/METADATA.pb
+++ b/ofl/anticslab/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SERIF"
 date_added: "2012-03-14"
 source {
-  repository_url: "https://github.com/librefonts/anticslab"
-  commit: "64168753771367673ec5efa56c747427648d9f29"
+  repository_url: "https://github.com/googlefonts/anticslab"
+  commit: "94821708c44ba2ac3c9bcd011141dbb888b0b26d"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/AnticSlab-Regular.ttf"
+    dest_file: "AnticSlab-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/anticslab/upstream_info.md
+++ b/ofl/anticslab/upstream_info.md
@@ -1,52 +1,25 @@
 # Antic Slab
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Santiago Orozco
-**License**: OFL
-**METADATA.pb**: `ofl/anticslab/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/anticslab |
-| Commit | `64168753771367673ec5efa56c747427648d9f29` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+Google Fonts shipped Antic Slab (Regular) built from FontForge SFD sources at https://github.com/librefonts/anticslab. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+- The canonical FontForge SFD source (`AnticSlab-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/anticslab, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:29:11 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The source now lives at https://github.com/googlefonts/anticslab (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+The rebuilt Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 4 glyphs were renamed to their production names; coverage is unchanged, so this is accepted as benign.
 
-### google/fonts history
-- Last font modification: `29d7c65b584e`
-- Date: 2017-08-07 21:30:29 +0100
-- Subject: "hotfix-anticslab: v1.002 added (#818)"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/anticslab`
-- Commit `641687537713` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original FontForge sources are at https://github.com/librefonts/anticslab (`.sfd`), latest at commit `64168753771367673ec5efa56c747427648d9f29`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/arbutus/METADATA.pb
+++ b/ofl/arbutus/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SERIF"
 date_added: "2011-12-07"
 source {
-  repository_url: "https://github.com/librefonts/arbutus"
-  commit: "413fe5b2122e7a4d1ce6c604000f368a6bf8f6ac"
+  repository_url: "https://github.com/googlefonts/arbutus"
+  commit: "1da75e32e2a7adc3225e7e88f7963ed2e84f48cb"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Arbutus-Regular.ttf"
+    dest_file: "Arbutus-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/arbutus/upstream_info.md
+++ b/ofl/arbutus/upstream_info.md
@@ -1,52 +1,26 @@
 # Arbutus
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Karolina Lach
-**License**: OFL
-**METADATA.pb**: `ofl/arbutus/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/arbutus |
-| Commit | `413fe5b2122e7a4d1ce6c604000f368a6bf8f6ac` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+Google Fonts shipped Arbutus (Regular) built from FontForge SFD sources at https://github.com/librefonts/arbutus. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- During conversion the no-break space (U+00A0) advance width was corrected to 838 to match the space glyph.
+- A new Unified Font Repository was created at https://github.com/googlefonts/arbutus, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:29:22 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The source now lives at https://github.com/googlefonts/arbutus (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+The rebuilt Arbutus Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets and advance widths. Remaining differences are benign: 22 glyphs were renamed to production names (coverage unchanged), and GDEF now classifies one real combining mark the shipped font missed (uni0326). Verdict: FUNCTIONAL parity.
 
-### google/fonts history
-- Last font modification: `703fd66d131c`
-- Date: 2017-08-07 21:30:16 +0100
-- Subject: "hotfix-arbutus: v1.003 added (#819)"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/arbutus`
-- Commit `413fe5b2122e` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original FontForge sources are at https://github.com/librefonts/arbutus (`.sfd`), latest at commit `413fe5b2122e7a4d1ce6c604000f368a6bf8f6ac`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/arbutusslab/METADATA.pb
+++ b/ofl/arbutusslab/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SERIF"
 date_added: "2012-09-18"
 source {
-  repository_url: "https://github.com/librefonts/arbutusslab"
-  commit: "2988f79c4d6965ef9fa35768ca00f02cddd5a50a"
+  repository_url: "https://github.com/googlefonts/arbutusslab"
+  commit: "9188ac0bb9ae152e9c4e6ee8c726f4636babb86f"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/ArbutusSlab-Regular.ttf"
+    dest_file: "ArbutusSlab-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/arbutusslab/upstream_info.md
+++ b/ofl/arbutusslab/upstream_info.md
@@ -1,52 +1,23 @@
 # Arbutus Slab
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Karolina Lach
-**License**: OFL
-**METADATA.pb**: `ofl/arbutusslab/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/arbutusslab |
-| Commit | `2988f79c4d6965ef9fa35768ca00f02cddd5a50a` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+The upstream repository shipped only FontForge `.sfd` sources (`src/ArbutusSlab-Regular.ttf.sfd`) with no gftools-builder configuration. METADATA.pb recorded the repository and onboarding commit but no `config_yaml`, so the family could not be rebuilt with the current Rust pipeline.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+The repository adopted the Unified Font Repository template. The `.sfd` source for the Regular weight was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), and a gftools-builder configuration was added. During conversion the no-break space (U+00A0) advance width was corrected to match the space glyph (838). The superseded FontForge sources and legacy build cruft were retired.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:29:24 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The family now builds from `sources/ArbutusSlab-Regular.glyphs` using gftools-builder3 and fontc, producing `fonts/ttf/ArbutusSlab-Regular.ttf`.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+The freshly built Regular was compared against the binary currently shipped in google/fonts. Glyph coverage, metrics and outlines matched. The only difference is that 24 glyphs were renamed to their production names; codepoint coverage is unchanged, so the verdict is functional parity.
 
-### google/fonts history
-- Last font modification: `dbe4135303df`
-- Date: 2017-08-07 21:30:05 +0100
-- Subject: "hotfix-arbutusslab: v1.002 added (#820)"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/arbutusslab`
-- Commit `2988f79c4d69` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+Original upstream: https://github.com/librefonts/arbutusslab (branch `master`), latest commit `2988f79c4d6965ef9fa35768ca00f02cddd5a50a`, which is also the onboarding commit recorded in METADATA.pb.

--- a/ofl/architectsdaughter/METADATA.pb
+++ b/ofl/architectsdaughter/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "HANDWRITING"
 date_added: "2011-03-09"
 source {
-  repository_url: "https://github.com/librefonts/architectsdaughter"
-  commit: "1a94ca0aea18288ee7685ed6aee918b58399a307"
+  repository_url: "https://github.com/googlefonts/architectsdaughter"
+  commit: "0912d302495d684898c33d02a4a0f24f32ec3da3"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/ArchitectsDaughter-Regular.ttf"
+    dest_file: "ArchitectsDaughter-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/architectsdaughter/upstream_info.md
+++ b/ofl/architectsdaughter/upstream_info.md
@@ -1,52 +1,23 @@
 # Architects Daughter
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Kimberly Geswein
-**License**: OFL
-**METADATA.pb**: `ofl/architectsdaughter/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/architectsdaughter |
-| Commit | `1a94ca0aea18288ee7685ed6aee918b58399a307` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+The upstream repository at librefonts/architectsdaughter shipped only FontForge sources. METADATA.pb recorded the repository and onboarding commit but no config.yaml, so the family could not be rebuilt with the current Rust toolchain.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+The FontForge source `src/ArchitectsDaughter-TTF.sfd` was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), producing `sources/ArchitectsDaughter-Regular.glyphs`. During conversion 109 stray NUL bytes were stripped from the source. A gftools-builder3 `config.yaml` was added, and the repository was restructured onto the Unified Font Repository template. The superseded FontForge sources and legacy build cruft were retired.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:29:26 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The repository builds `ArchitectsDaughter-Regular.ttf` from `.glyphs` sources through gftools-builder3 and fontc. The `source { }` block in METADATA.pb points at the modernized googlefonts/architectsdaughter repository, together with its build commit and gftools-builder3 config.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+The freshly built `ArchitectsDaughter-Regular.ttf` was compared against the binary currently shipped in google/fonts. Glyph coverage, metrics and layout matched. The verdict was FUNCTIONAL: 18 glyphs were renamed to production names with no change in coverage, and the rebuilt GDEF correctly classifies one combining mark (uni0326) that the shipped font had failed to mark. Both differences are improvements or naming-only and are accepted.
 
-### google/fonts history
-- Last font modification: `2a0c94b33e35`
-- Date: 2017-08-07 21:29:56 +0100
-- Subject: "hotfix-architectsdaughter: v1.003 added (#821)"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/architectsdaughter`
-- Commit `1a94ca0aea18` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original upstream lived at https://github.com/librefonts/architectsdaughter (branch `master`), latest commit `1a94ca0aea18288ee7685ed6aee918b58399a307`, which was also the onboarding commit. It carried only the FontForge `.sfd` sources and is now superseded by the modernized repository.

--- a/ofl/armata/METADATA.pb
+++ b/ofl/armata/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2011-12-19"
 source {
-  repository_url: "https://github.com/librefonts/armata"
-  commit: "fbbc7c2575fe310df0450aaa721ee4e860b03a0e"
+  repository_url: "https://github.com/googlefonts/armata"
+  commit: "acd66b422a3b61baae8fee57c197e9f782b87f57"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Armata-Regular.ttf"
+    dest_file: "Armata-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/armata/upstream_info.md
+++ b/ofl/armata/upstream_info.md
@@ -1,52 +1,23 @@
 # Armata
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Viktoriya Grabowska
-**License**: OFL
-**METADATA.pb**: `ofl/armata/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/armata |
-| Commit | `fbbc7c2575fe310df0450aaa721ee4e860b03a0e` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+The upstream repository at librefonts/armata shipped only FontForge sources (`src/Armata-Regular-TTF.sfd`) and had no config.yaml or Glyphs sources, so it could not build with the current Google Fonts pipeline. METADATA.pb recorded the repository and onboarding commit but no build configuration.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+The repository adopted the Unified Font Repository template. The FontForge source `src/Armata-Regular-TTF.sfd` was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), producing `sources/Armata-Regular.glyphs`, and a gftools-builder3 config was added. During conversion, the no-break space (U+00A0) was corrected to the expected advance width (683 units), and 22 glyphs were renamed to their production names. The superseded FontForge sources and legacy build cruft were then retired.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:29:34 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The repository builds `Armata-Regular.ttf` from `sources/Armata-Regular.glyphs` using gftools-builder3 and fontc. The `source { }` block in METADATA.pb points at the modernized repository, branch and config.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+The freshly built `Armata-Regular.ttf` was compared against the shipped Google Fonts binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The verdict was FUNCTIONAL: the only difference was 22 glyphs renamed to their production names, with codepoint coverage unchanged. No blocking differences were found.
 
-### google/fonts history
-- Last font modification: `ecc5f91e743c`
-- Date: 2017-08-07 21:09:35 +0100
-- Subject: "hotfix-armata: v1.003 added (#823)"
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/armata`
-- Commit `fbbc7c2575fe` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original upstream repository is https://github.com/librefonts/armata (default branch `master`), whose latest commit is `fbbc7c2575fe310df0450aaa721ee4e860b03a0e`. This is the same commit recorded as the Google Fonts onboarding commit; no upstream commits were made after onboarding.

--- a/ofl/astloch/METADATA.pb
+++ b/ofl/astloch/METADATA.pb
@@ -4,8 +4,22 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-02-16"
 source {
-  repository_url: "https://github.com/librefonts/astloch"
-  commit: "d15f7a51db3956d34a87ac47c532eae74237f07f"
+  repository_url: "https://github.com/googlefonts/astloch"
+  commit: "48ba7212e16d35d8f5991fac7f46c8c134106d30"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Astloch-Bold.ttf"
+    dest_file: "Astloch-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Astloch-Regular.ttf"
+    dest_file: "Astloch-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/astloch/upstream_info.md
+++ b/ofl/astloch/upstream_info.md
@@ -1,52 +1,26 @@
 # Astloch
 
-**Status**: `missing_config`
-**Date**: 2026-02-25
-**Designer**: Dan Rhatigan
-**License**: OFL
-**METADATA.pb**: `ofl/astloch/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/astloch |
-| Commit | `d15f7a51db3956d34a87ac47c532eae74237f07f` |
-| Config YAML | — |
-| Branch | `master` |
-| Source types | sfd |
+Google Fonts shipped Astloch (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/astloch. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-Discovered via google/fonts commit history, PR references, or GitHub search.
+- The canonical FontForge SFD sources (`src/Astloch-Regular-TTF.sfd` and `src/Astloch-Bold-TTF.sfd`) were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected to 500, and the Bold usWeightClass was set to 700.
+- A new Unified Font Repository was created at https://github.com/googlefonts/astloch, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-### Commit Hash
-Used HEAD of upstream repository (latest commit at time of onboarding).
-- Commit date: 2014-10-17 13:29:46 +0300
-- Commit message: "update .travis.yml"
+## Final state
 
-### Config YAML
-Not applicable — upstream repo contains only FontForge .sfd sources, which are not compatible with gftools-builder.
+The source now lives at https://github.com/googlefonts/astloch (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
-## Evidence
+## Verification
 
-### METADATA.pb source block
-No source block present in METADATA.pb.
+Both weights matched the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only differences were benign: the converted source drops two FontForge legacy glyphs (`.null` and `nonmarkingreturn`) that carry no Unicode coverage, and 5 glyphs were renamed to production names with cmap coverage unchanged.
 
-### google/fonts history
-- Last font modification: `6873b904efbc`
-- Date: 2017-11-28 16:55:38 -0500
-- Subject: "ofl/astloch: v1.002 added. Fixed name table."
+## Original repository (dormant)
 
-### Upstream repo cache
-- Cached at: `librefonts/astloch`
-- Commit `d15f7a51db39` verified ✓
-
-## Confidence
-
-**Medium**: URL discovered via research; commit verified in upstream repo
-
-## Notes
-
-SFD-only sources (FontForge format), not gftools-builder compatible
+The original FontForge sources are at https://github.com/librefonts/astloch (`.sfd`), latest at commit `d15f7a51db3956d34a87ac47c532eae74237f07f`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/asul/METADATA.pb
+++ b/ofl/asul/METADATA.pb
@@ -4,8 +4,22 @@ license: "OFL"
 category: "SERIF"
 date_added: "2011-12-19"
 source {
-  repository_url: "https://github.com/librefonts/asul"
-  commit: "687362de82c870100b6003ad71a82c3327e05d90"
+  repository_url: "https://github.com/googlefonts/asul"
+  commit: "d3179dc9cff2434b299a698af0183d191e31e925"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Asul-Bold.ttf"
+    dest_file: "Asul-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Asul-Regular.ttf"
+    dest_file: "Asul-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/asul/upstream_info.md
+++ b/ofl/asul/upstream_info.md
@@ -1,48 +1,26 @@
 # Asul
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: Mariela Monsalve
-**METADATA.pb path**: `ofl/asul/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/asul |
-| Commit | `687362de82c870100b6003ad71a82c3327e05d90` |
-| Config YAML | --- |
-| Branch | `master` |
+Google Fonts shipped Asul (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/asul. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL was identified during a prior batch investigation and added to `data/gfonts_library_sources.json` with a pending source block addition (commit `9a14639f3` on branch `felipesanches/sources_info_2026-02-25`). The URL `https://github.com/librefonts/asul` points to a repository under the `librefonts` GitHub organization, which hosts many libre font projects originally migrated from Google Fonts. The METADATA.pb on the main branch of google/fonts does not yet contain a source block; one was prepared in the pending branch but has not been merged.
+- The canonical FontForge SFD sources were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The Bold source's OS/2 usWeightClass was set to 700, which the SFD had not recorded.
+- A new Unified Font Repository was created at https://github.com/googlefonts/asul, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The commit hash `687362de82c870100b6003ad71a82c3327e05d90` was identified during a batch investigation process. The upstream repository appears to be a shallow clone with only this single commit visible. This is the latest (and possibly only) commit in the repository. The commit message is "update .travis.yml" dated 2014-10-17, which predates the last font update in google/fonts (PR #829, "hotfix-asul: v1.002 added", dated 2017-08-07). This suggests the fonts in google/fonts may have been compiled from this commit or from a state that is no longer fully traceable.
-
-The google/fonts PR #829 body was empty, providing no additional upstream reference.
-
-## How Config YAML Was Resolved
-
-There is no `config.yaml` in the upstream repository at the referenced commit. The upstream repo contains only SFD (FontForge) source files (`src/Asul-Bold-TTF.sfd` and `src/Asul-Regular-TTF.sfd`), which are not compatible with gftools-builder. There is also no override `config.yaml` in `google/fonts/ofl/asul/`.
-
-Building from SFD sources would require a different build pipeline or a manual conversion to a gftools-builder-compatible format.
+The source now lives at https://github.com/googlefonts/asul (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
 ## Verification
 
-- Commit exists in upstream repo: Yes
-- Commit date: 2014-10-17 13:29:49 +0300
-- Commit message: "update .travis.yml"
-- Source files at commit: `src/Asul-Bold-TTF.sfd`, `src/Asul-Regular-TTF.sfd` (SFD format only), plus `.travis.yml`, TTX dumps, and `.vfb` files
+For both Regular and Bold, the rebuilt fonts matched the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 9 glyphs were renamed to their production names; glyph coverage is unchanged, so this is accepted.
 
-## Confidence
+## Original repository (dormant)
 
-**Medium**: The repository URL is correct and the commit exists, but the relationship between this commit and the actual fonts in google/fonts is uncertain. The last font file update in google/fonts (PR #829, 2017-08-07) postdates the upstream commit (2014-10-17), and the upstream repo only has SFD sources while google/fonts has TTF binaries. It is likely the fonts were compiled from these SFD sources at some point, but the exact build process is unclear. The SFD-only nature of the sources means a config.yaml cannot be meaningfully created for gftools-builder.
-
-## Open Questions
-
-1. Were the TTF files in google/fonts compiled from the SFD sources in this upstream repo, or were they provided separately by the designer?
-2. Is there a different upstream repository with the actual build sources (e.g., .glyphs or .ufo files)?
-3. The commit is from 2014 but the font was updated in google/fonts in 2017 -- was a newer version compiled from these same sources with updated tooling?
+The original FontForge sources are at https://github.com/librefonts/asul (`.sfd`), latest at commit `687362de82c870100b6003ad71a82c3327e05d90`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/autourone/METADATA.pb
+++ b/ofl/autourone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2012-05-15"
 source {
-  repository_url: "https://github.com/librefonts/autourone"
-  commit: "10ccd1eb5ad3e7088ce2dd099debff0ac08daf1c"
+  repository_url: "https://github.com/googlefonts/autourone"
+  commit: "11d97fbce17c2eb0a2eb88eb560c4ecf8e7645ac"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/AutourOne-Regular.ttf"
+    dest_file: "AutourOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/autourone/upstream_info.md
+++ b/ofl/autourone/upstream_info.md
@@ -1,59 +1,26 @@
 # Autour One
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: Sorkin Type
-**METADATA.pb path**: `ofl/autourone/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/autourone |
-| Commit | `10ccd1eb5ad3e7088ce2dd099debff0ac08daf1c` |
-| Config YAML | — |
-| Branch | `master` |
+Google Fonts shipped Autour One (Regular) built from FontForge SFD sources at https://github.com/librefonts/autourone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL is not present in the current METADATA.pb on the main branch (there is no source block). It was identified in the tracking data (`gfonts_library_sources.json`) and exists on a pending PR branch (`sources_info_2026-02-25`, commit `9a14639f3`). The upstream repo at `librefonts/autourone` was verified in the cache with remote URL `https://github.com/librefonts/autourone`.
+- The canonical FontForge SFD source (`AutourOne-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- During conversion the no-break space (U+00A0) advance width was corrected to match the space glyph (847).
+- A new Unified Font Repository was created at https://github.com/googlefonts/autourone, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-As with Audiowide, this is a `librefonts` organization mirror typical of early Google Fonts families.
+## Final state
 
-## How the Commit Hash Was Identified
-
-The upstream repository has only a single commit: `10ccd1eb5ad3e7088ce2dd099debff0ac08daf1c` (2014-10-17, "update .travis.yml"). The font was last updated in google/fonts via PR #833 (`592bee48`, "hotfix-autourone: v1.007 added", 2017-08-07) by Marc Foley. The PR body and comments are empty. Since the upstream repo has only one commit, this is the only possible reference point.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` or `builder.yaml` exists in the upstream repository. No override `config.yaml` exists in `google/fonts/ofl/autourone/`.
-
-The source files in the repository are:
-- `src/AutourOne-Regular-OTF.sfd` (FontForge SFD)
-- `src/AutourOne-Regular-TTF.sfd` (FontForge SFD)
-- `src/AutourOne-Regular.vfb` (FontLab binary, not listed in source_types but present)
-- Various `.ttx` XML dumps of font tables
-
-SFD files are FontForge's native format and are not directly compatible with gftools-builder. The VFB file is FontLab's proprietary format.
+The source now lives at https://github.com/googlefonts/autourone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
 ## Verification
 
-- Commit exists in upstream repo: Yes
-- Commit date: 2014-10-17 13:29:59 +0300
-- Commit message: "update .travis.yml"
-- Source files at commit:
-  - `src/AutourOne-Regular-OTF.sfd` (FontForge format)
-  - `src/AutourOne-Regular-TTF.sfd` (FontForge format)
-  - `src/AutourOne-Regular.vfb` (FontLab binary)
-  - Multiple `.ttx` table dumps (not editable sources)
+The rebuilt font matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle and the GSUB/GPOS feature sets. Three benign differences were accepted: 26 glyphs were renamed to their AGL production names (glyph coverage unchanged); GDEF now classifies U+0326 as a combining mark, which the shipped font had missed; and the combining glyph U+F6C3 was zeroed, whereas the shipped font gave it a spacing advance.
 
-## Confidence
+## Original repository (dormant)
 
-**Medium**: The repository URL is verified and the commit is the only one available. However, the repo is a librefonts archive with only SFD and VFB sources, not modern buildable formats. The v1.007 hotfix in google/fonts (2017) was made 3 years after the last upstream commit (2014), suggesting the binary was modified independently. Without source conversion, a config.yaml cannot be meaningfully added.
-
-## Open Questions
-
-- Is there an original upstream repository maintained by Sorkin Type (Eben Sorkin)?
-- Eben Sorkin maintains the `EbenSorkin` GitHub account and is associated with Sorkin Type. It's worth checking if there's a dedicated Autour One repo under that account.
-- Should the SFD sources be converted to UFO or .glyphs format to enable gftools-builder builds?
-- The SFD sources include separate OTF and TTF variants, which is an unusual source structure.
+The original FontForge sources are at https://github.com/librefonts/autourone (`.sfd`), latest at commit `10ccd1eb5ad3e7088ce2dd099debff0ac08daf1c`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/averagesans/METADATA.pb
+++ b/ofl/averagesans/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2012-10-26"
 source {
-  repository_url: "https://github.com/librefonts/averagesans"
-  commit: "79216d6e944c1c35f1b8f4a1a9f50ad9ee73868c"
+  repository_url: "https://github.com/googlefonts/averagesans"
+  commit: "25392b948053363b34308e1f95e29c5401997b00"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/AverageSans-Regular.ttf"
+    dest_file: "AverageSans-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/averagesans/upstream_info.md
+++ b/ofl/averagesans/upstream_info.md
@@ -1,54 +1,26 @@
 # Average Sans
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: Eduardo Tunni
-**METADATA.pb path**: `ofl/averagesans/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | -- |
-| Commit | -- |
-| Config YAML | -- |
-| Branch | -- |
+Google Fonts shipped Average Sans (Regular) built from FontForge SFD sources at https://github.com/librefonts/averagesans. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-No repository URL is documented in the METADATA.pb (there is no `source { }` block at all). The designer Eduardo Tunni does not have an "averagesans" or "average-sans" repository on his GitHub account (etunni). His GitHub profile lists many font repos (including `average` for the serif sister family), but no Average Sans repo.
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The non-breaking space (U+00A0) advance width was corrected in the converted source.
+- A new Unified Font Repository was created at https://github.com/googlefonts/averagesans, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-A legacy `librefonts/averagesans` repository exists at https://github.com/librefonts/averagesans, created in July 2014. However, this is a legacy mirror containing only TTX (decompiled font) files and old binary sources (.vfb, .sfd). It has no `.glyphs`, `.designspace`, or `config.yaml` files, making it unsuitable as a build source for gftools-builder. The repo has not been updated since 2014.
+## Final state
 
-No other upstream repository with proper sources was found.
-
-## How the Commit Hash Was Identified
-
-N/A -- No proper upstream repository with build-compatible sources exists.
-
-The last TTF-modifying commit in google/fonts is `76f813683` ("hotfix-averagesans: v1.002 added", PR #835, by m4rc1e). This was a hotfix merged on 2017-08-07, with an empty PR body and no reference to an upstream commit.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repo (librefonts/averagesans) or in the google/fonts family directory (`ofl/averagesans/`). The librefonts repo contains only legacy source files:
-- `src/AverageSans-Regular-OTF.vfb` (FontLab binary)
-- `src/AverageSans-Regular-TTF.sfd` (FontForge source)
-- TTX (decompiled font) files
-
-These formats are not compatible with gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` sources with a `config.yaml`.
+The source now lives at https://github.com/googlefonts/averagesans (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
 ## Verification
 
-- Commit exists in upstream repo: N/A
-- Commit date: N/A
-- Commit message: N/A
-- Source files at commit: Only legacy .vfb/.sfd in librefonts/averagesans
+The rebuilt font matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The sole difference is that 20 glyphs were renamed to their production names, which leaves glyph coverage unchanged; this is why the verdict is functional rather than byte-identical.
 
-## Confidence
+## Original repository (dormant)
 
-**High**: There is high confidence that no proper upstream repository with gftools-builder-compatible sources exists. Eduardo Tunni's GitHub has a repo for the serif "Average" family but not for "Average Sans". The only available repo (librefonts/averagesans) is a legacy mirror with no modern build sources.
-
-## Open Questions
-
-1. Does Eduardo Tunni have the Average Sans .glyphs source file? His "average" repo has `sources/Average.glyphs` for the serif family -- he may have a similar .glyphs file for Average Sans that was never published to GitHub.
-2. Should a new upstream repo be created (or the existing one updated) with modern source files to enable rebuilding?
+The original FontForge sources are at https://github.com/librefonts/averagesans (`.sfd`), latest at commit `79216d6e944c1c35f1b8f4a1a9f50ad9ee73868c`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/balthazar/METADATA.pb
+++ b/ofl/balthazar/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SERIF"
 date_added: "2011-12-13"
 source {
-  repository_url: "https://github.com/librefonts/balthazar"
-  commit: "baa08c6f633b0fda1a83141ce7515441c56e9868"
+  repository_url: "https://github.com/googlefonts/balthazar"
+  commit: "40ec71e48349bc565c42eb3c750b50a5d8d19087"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Balthazar-Regular.ttf"
+    dest_file: "Balthazar-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/balthazar/upstream_info.md
+++ b/ofl/balthazar/upstream_info.md
@@ -1,45 +1,26 @@
 # Balthazar
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: Dario Manuel Muhafara
-**METADATA.pb path**: `ofl/balthazar/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/balthazar |
-| Commit | `baa08c6f633b0fda1a83141ce7515441c56e9868` |
-| Config YAML | N/A (no config.yaml exists; sources are not gftools-builder compatible) |
-| Branch | `master` |
+## Initial state
 
-## How the Repository URL Was Found
-The METADATA.pb has no `source {}` block at all. The repository URL was found via the upstream repo cache at `upstream_repos/fontc_crater_cache/librefonts/balthazar/`. The remote URL `https://github.com/librefonts/balthazar` matches the expected pattern for librefonts-hosted legacy Google Fonts projects.
+Google Fonts shipped Balthazar (Regular) built from FontForge SFD sources at https://github.com/librefonts/balthazar. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Commit Hash Was Identified
-The upstream repo has only a single commit: `baa08c6f633b0fda1a83141ce7515441c56e9868` (2014-10-17, "update .travis.yml" by hash3g). This is the only possible reference point. The tracking file already had this commit recorded.
+## Actions taken
 
-## How Config YAML Was Resolved
-No `config.yaml` exists anywhere in the upstream repository. The repository contains only legacy source formats:
-- `.vfb` (FontLab Studio format) - proprietary, cannot be used by gftools-builder
-- `.sfd` (FontForge format) - not directly supported by gftools-builder
-- `.ttx` (TTX/FontTools XML dumps)
+- The canonical FontForge SFD source (`src/Balthazar-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- During conversion, stray NUL bytes were stripped and a non-breaking space (U+00A0) was added to match the glyph FontForge used to synthesise at export time.
+- A new Unified Font Repository was created at https://github.com/googlefonts/balthazar, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The font was onboarded to Google Fonts in the very early era (date_added: 2011-12-13, initial commit in google/fonts: 2015-03-07). There is no way to build this font with gftools-builder without first converting the sources to .glyphs or .ufo format.
+## Final state
 
-No override config.yaml exists in the google/fonts family directory either.
+The source now lives at https://github.com/googlefonts/balthazar (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
-- Commit exists in upstream repo: Yes (it is the only commit)
-- Commit date: 2014-10-17 13:30:20 +0300
-- Commit message: "update .travis.yml"
-- Source files at commit: `src/Balthazar-Regular.vfb`, `src/Balthazar-Regular-TTF.sfd`, various `.ttx` files
-- TTFs last updated in google/fonts: 2015-04-27 (commit 321eeddad, "Updating ofl/balthazar/*ttf with nbspace and fsType fixes")
-- The font binary was likely patched in google/fonts directly, not rebuilt from source
 
-## Confidence
-**High**: The repository URL and commit are confirmed. The status is correctly "missing_config" because the upstream repo lacks both a config.yaml and gftools-builder-compatible source formats.
+Matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. Two benign differences were accepted: the rebuild drops two FontForge legacy glyphs (`.null` and `nonmarkingreturn`) that carry no Unicode coverage, and 8 glyphs were renamed to their production names with no change to coverage.
 
-## Open Questions
-- This is a legacy font with only .vfb/.sfd sources. To make it buildable with gftools-builder, the sources would need to be converted to .glyphs or .ufo format. This is a significant effort and may not be prioritized.
-- The METADATA.pb has no `source {}` block. A source block with repository_url and commit could be added, though config_yaml would still be absent.
+## Original repository (dormant)
+
+The original FontForge sources are at https://github.com/librefonts/balthazar (`.sfd`), latest at commit `baa08c6f633b0fda1a83141ce7515441c56e9868`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/belgrano/METADATA.pb
+++ b/ofl/belgrano/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SERIF"
 date_added: "2011-12-19"
 source {
-  repository_url: "https://github.com/librefonts/belgrano"
-  commit: "9637660aa35d5ad59241a400f78d31413475bb77"
+  repository_url: "https://github.com/googlefonts/belgrano"
+  commit: "e79e00337ef13f738009b16d2909cc2dd17af344"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Belgrano-Regular.ttf"
+    dest_file: "Belgrano-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/belgrano/upstream_info.md
+++ b/ofl/belgrano/upstream_info.md
@@ -1,58 +1,24 @@
-# Belgrano - Investigation Report
+# Belgrano
 
-## Source Data (from tracking)
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Belgrano |
-| Repository URL | https://github.com/librefonts/belgrano |
-| Commit Hash | 9637660aa35d5ad59241a400f78d31413475bb77 |
-| Config YAML | null |
-| Status | missing_config |
-| Category | SERIF |
+## Initial state
 
-## How the Repository URL Was Found
+The upstream repository shipped only a FontForge source (`src/Belgrano-Regular-TTF.sfd`) with no gftools-builder configuration, so the family could not be built with the current Google Fonts Rust pipeline. METADATA.pb recorded the librefonts repository and onboarding commit but no `config_yaml`.
 
-The repository URL `https://github.com/librefonts/belgrano` was previously identified and added to the tracking data. The librefonts organization on GitHub hosts many font projects that were originally migrated for the Google Fonts ecosystem. The METADATA.pb file does not currently contain a `source {}` block (has_source_block: false), and the URL was added to the tracking file as part of a batch update (commit `9a14639f3`).
+## Actions taken
 
-## How the Commit Hash Was Determined
+The repository adopted the Unified Font Repository template. The FontForge source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), producing `sources/Belgrano-Regular.glyphs`; a gftools-builder configuration was added, and the superseded `.sfd` source and legacy build cruft were retired.
 
-The commit hash `9637660aa35d5ad59241a400f78d31413475bb77` is the only commit in the upstream repository, dated 2014-10-17. The commit message is "update .travis.yml". Since the repository has a single commit, this is trivially the correct (and only possible) commit to reference.
+## Final state
 
-The font was originally added to google/fonts in the initial commit (`90abd17b4`) and later updated in PR #851 ("hotfix-belgrano: v1.003 added", by Marc Foley, 2017-08-07). The most recent TTF modification was in commit `162b8ed63`. The upstream repo contains the source files (SFD format) that were used to produce the binary.
-
-## Config YAML Status
-
-**No config.yaml exists** in the upstream repository, at any commit. The repo structure at the recorded commit is:
-
-```
-.travis.yml
-Belgrano-Regular.ttf.*.ttx (multiple TTX files)
-DESCRIPTION.en_us.html
-METADATA.json
-OFL.txt
-src/
-  Belgrano-Regular-OTF.vfb
-  Belgrano-Regular-TTF.sfd
-  Belgrano-Regular.otf.*.ttx (multiple TTX files)
-  METADATA_comments.txt
-  VERSIONS.txt
-```
-
-The source files are in SFD (FontForge) and VFB (FontLab) formats, which are not compatible with gftools-builder. A config.yaml cannot be meaningfully created for this project without converting the sources to a modern format (.glyphs, .ufo, or .designspace).
+The repository builds `Belgrano-Regular.ttf` from `sources/Belgrano-Regular.glyphs` via gftools-builder3 and fontc. METADATA.pb now points at the modernized repository and records the build configuration.
 
 ## Verification
 
-- Commit hash `9637660` exists in the upstream repo (the only commit)
-- The repo contains SFD-only sources, confirming the `missing_config` status and `source_types: ["sfd"]` annotation
-- No override config.yaml exists in the google/fonts family directory
-- The METADATA.pb does not have a `source {}` block
+The fontc-built `Belgrano-Regular.ttf` was compared against the binary currently shipped in google/fonts. The only difference was that 4 glyphs were renamed to their production names; codepoint coverage is unchanged, so the difference is cosmetic and the verdict is FUNCTIONAL parity.
 
-## Confidence Level
+## Original repository (dormant)
 
-**High** - The commit hash is trivially correct as the only commit in the repository. The `missing_config` status is correct because the sources are in legacy formats (SFD/VFB) that cannot be used with gftools-builder.
-
-## Open Questions
-
-- The METADATA.pb currently has no `source {}` block. A source block with `repository_url` and `commit` should be added, even without `config_yaml`, to document the upstream origin.
-- The font was added to Google Fonts in 2011 and last updated in 2017 (PR #851). The upstream repo appears abandoned with only one commit from 2014.
+Original upstream: https://github.com/librefonts/belgrano
+Latest commit: 9637660aa35d5ad59241a400f78d31413475bb77 (branch `master`), which is also the onboarding commit recorded in METADATA.pb.

--- a/ofl/benchnine/METADATA.pb
+++ b/ofl/benchnine/METADATA.pb
@@ -4,8 +4,26 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2012-09-24"
 source {
-  repository_url: "https://github.com/librefonts/benchnine"
-  commit: "0b2979e19186f9b477fd3bde7ae77932933707eb"
+  repository_url: "https://github.com/googlefonts/benchnine"
+  commit: "dd9d771443fa68ea48ef0819d28fc64e0fded42f"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/BenchNine-Bold.ttf"
+    dest_file: "BenchNine-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/BenchNine-Light.ttf"
+    dest_file: "BenchNine-Light.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/BenchNine-Regular.ttf"
+    dest_file: "BenchNine-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/benchnine/config.yaml
+++ b/ofl/benchnine/config.yaml
@@ -1,5 +1,0 @@
-sources:
-  - src/BenchNine-Light.ufo
-  - src/BenchNine-Regular.ufo
-  - src/BenchNine-Bold.ufo
-buildVariable: false

--- a/ofl/benchnine/upstream_info.md
+++ b/ofl/benchnine/upstream_info.md
@@ -1,63 +1,26 @@
-# BenchNine - Investigation Report
+# BenchNine
 
-## Source Data (from tracking)
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | BenchNine |
-| Repository URL | https://github.com/librefonts/benchnine |
-| Commit Hash | 0b2979e19186f9b477fd3bde7ae77932933707eb |
-| Config YAML | (none) |
-| **Status** | complete |
-| Category | SANS_SERIF |
+## Initial state
 
-## How the Repository URL Was Found
+Google Fonts shipped BenchNine (Light, Regular, Bold) built from FontForge SFD sources at https://github.com/librefonts/benchnine. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/benchnine` comes from the librefonts organization on GitHub, which was created by Marc Foley to host decompiled TTX versions of fonts in the Google Fonts catalog. The URL was recorded in the tracking data and added to METADATA.pb in commit `9a14639f3` (on branch `sources_info_2026-02-25`, not yet merged to main).
+## Actions taken
 
-## How the Commit Hash Was Determined
+- The three canonical FontForge SFD sources (Light, Regular, Bold) were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The converted sources were corrected: the no-break space (U+00A0) advance widths were set, the usWeightClass values were restored (300 Light, 700 Bold), and Use Typo Metrics was enabled.
+- A new Unified Font Repository was created at https://github.com/googlefonts/benchnine, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-The commit hash `0b2979e19186f9b477fd3bde7ae77932933707eb` is the latest (HEAD) commit in the librefonts/benchnine repo, dated 2014-10-17. This was set because the librefonts repo only contains TTX-decomposed font files and Travis CI configuration, and this is the last commit in the repo.
+## Final state
 
-**Context**: The font was originally added to google/fonts in the initial commit `90abd17b4` and last updated via hotfix PR #853 ("hotfix-benchnine: v0.921 added") by Marc Foley on 2017-05-08. The librefonts repo predates this hotfix (last commit 2014-10-17), so the TTX sources in the repo may not match the current TTFs in google/fonts.
-
-## Config YAML Status
-
-- **No `config.yaml`** exists in the upstream librefonts repo (not at the recorded commit, not at any commit)
-- **No override `config.yaml`** in `google/fonts/ofl/benchnine/`
-- The repo contains UFO sources (`src/BenchNine-Bold.ufo`, `src/BenchNine-Light.ufo`, `src/BenchNine-Regular.ufo`) alongside SFD and TTX files, but no gftools-builder configuration
-- The repo also has SFD sources (`src/BenchNine-*-TTF.sfd`, `src/BenchNine-*.sfd`)
+The source now lives at https://github.com/googlefonts/benchnine (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at full equivalence with the shipped binaries.
 
 ## Verification
 
-- Commit hash `0b2979e` exists in the repo (message: "update .travis.yml", dated 2014-10-17)
-- It is the HEAD commit of the master branch
-- Repository URL is valid and accessible
-- The upstream repo is cached at `upstream_repos/fontc_crater_cache/librefonts/benchnine`
-- PR #853 body was empty, providing no additional context about the hotfix source
+Each weight was built and compared against its shipped Google Fonts binary. All three (Light, Regular, Bold) matched on every dimension checked: cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. Verdict: FULL parity.
 
-## Confidence Level
+## Original repository (dormant)
 
-**Medium** - The commit hash is simply HEAD of the librefonts mirror repo. The librefonts repo is a secondary mirror (decompiled TTX + original sources), not the original design source. The original font was designed by Vernon Adams. The hotfix by Marc Foley in 2017 may have used a different build process than what's captured in this repo. The connection between the librefonts repo and the actual hotfix TTFs is not directly documented.
-
-
-## Override Config YAML
-
-An override `config.yaml` has been added to the google/fonts family directory. Contents:
-
-```yaml
-sources:
-  - src/BenchNine-Light.ufo
-  - src/BenchNine-Regular.ufo
-  - src/BenchNine-Bold.ufo
-buildVariable: false
-```
-
-This override config enables gftools-builder to compile the font from upstream sources.
-
-## Open Questions
-
-- The librefonts repo was last updated in 2014, but the hotfix was applied in 2017 -- the hotfix TTFs may have been built from different sources or a different process
-- Vernon Adams (the original designer) passed away in 2014; the font has not had active upstream development since
-- The repo has UFO sources which could theoretically be used with gftools-builder, but it's unclear if they match the current TTFs in google/fonts
-- An override `config.yaml` would be needed for gftools-builder compatibility, but verifying that the UFOs produce matching output would be important first
+The original FontForge sources are at https://github.com/librefonts/benchnine (`.sfd`), latest at commit `0b2979e19186f9b477fd3bde7ae77932933707eb`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/bigshotone/METADATA.pb
+++ b/ofl/bigshotone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-05-04"
 source {
-  repository_url: "https://github.com/librefonts/bigshotone"
-  commit: "b8d1fa459ee9a43fbe1d7fd07b570878206bd6d5"
+  repository_url: "https://github.com/googlefonts/bigshotone"
+  commit: "354d1d8880d46e04cf3b57980e6d56d1a5e1400d"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/BigshotOne-Regular.ttf"
+    dest_file: "BigshotOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/bigshotone/config.yaml
+++ b/ofl/bigshotone/config.yaml
@@ -1,3 +1,0 @@
-sources:
-  - src/BigshotOne.ufo
-buildVariable: false

--- a/ofl/bigshotone/upstream_info.md
+++ b/ofl/bigshotone/upstream_info.md
@@ -1,69 +1,26 @@
-# Investigation Report: Bigshot One
+# Bigshot One
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Bigshot One |
-| Designer | Gesine Todt |
-| License | OFL |
-| Date Added | 2011-05-04 |
-| Repository URL | https://github.com/librefonts/bigshotone |
-| Commit Hash | `b8d1fa459ee9a43fbe1d7fd07b570878206bd6d5` |
-| Branch | master |
-| **Config YAML** | Override in google/fonts |
-| Status | **Missing config** (has UFO, needs config.yaml) |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Bigshot One (Regular) built from FontForge SFD sources at https://github.com/librefonts/bigshotone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/bigshotone` was identified from the librefonts organization on GitHub, which hosts archived copies of many Google Fonts. This is a standard librefonts mirror repository.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The advance width of the non-breaking space (U+00A0) was corrected to 160 during conversion so the built binary matches the shipped one.
+- A new Unified Font Repository was created at https://github.com/googlefonts/bigshotone, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-The upstream repository has only **one commit** (`b8d1fa4 update .travis.yml`), making the commit hash trivially the only option. The font was last updated in google/fonts via PR #857 ("hotfix-bigshotone: v1.001 added") by Marc Foley on 2017-08-07.
+## Final state
 
-## Config YAML Status
-
-**No config.yaml exists** in the upstream repository. However, unlike Bigelow Rules, this repository contains a UFO source file that could potentially be used with gftools-builder:
-
-- `src/BigshotOne.ufo/` - UFO source directory (contains fontinfo.plist, features.fea, glyphs/, groups.plist, kerning.plist)
-- `src/BigshotOne-TTF.sfd` - FontForge SFD
-- `src/BigshotOne.vfb` - FontLab VFB (proprietary format)
-- `src/BigshotOne-TTF.vfb` - FontLab VFB
-
-The UFO file could be targeted by a config.yaml for gftools-builder, but no such configuration has been created yet. An override config.yaml could be placed in the google/fonts family directory.
+The source now lives at https://github.com/googlefonts/bigshotone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at full equivalence with the shipped binaries.
 
 ## Verification
 
-- **Commit exists in upstream repo**: Yes (it is the only commit)
-- **Config YAML exists at commit**: No
-- **Buildable sources available**: Yes (UFO)
-- **Source block in METADATA.pb**: Not yet in the upstream google/fonts (pending PR)
-- **Override config.yaml in google/fonts**: No
+Full parity with the shipped binary: identical on every dimension checked, including cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths.
 
-## Google Fonts History
+## Original repository (dormant)
 
-1. `90abd17b4` - Initial commit (part of the original google/fonts repo)
-2. `c49ea1306` - PR #857: "hotfix-bigshotone: v1.001 added" by m4rc1e (2017-08-07) - last font binary update; renamed from `BigshotOne.ttf` to `BigshotOne-Regular.ttf`
-3. Various metadata updates (stroke, classifications, languages)
-
-## Confidence Level
-
-**High** for URL and commit hash (single-commit repo, standard librefonts mirror). **Actionable** for config.yaml - the UFO source exists and a config.yaml could be written.
-
-
-## Override Config YAML
-
-An override `config.yaml` has been added to the google/fonts family directory. Contents:
-
-```yaml
-sources:
-  - src/BigshotOne.ufo
-buildVariable: false
-```
-
-This override config enables gftools-builder to compile the font from upstream sources.
-
-## Open Questions
-
-- A config.yaml needs to be created (either in the upstream repo or as an override in google/fonts) targeting `src/BigshotOne.ufo` to enable gftools-builder compilation. The quality and completeness of the UFO source should be verified before creating the config.
+The original FontForge sources are at https://github.com/librefonts/bigshotone (`.sfd`), latest at commit `b8d1fa459ee9a43fbe1d7fd07b570878206bd6d5`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/bilboswashcaps/METADATA.pb
+++ b/ofl/bilboswashcaps/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "HANDWRITING"
 date_added: "2011-12-13"
 source {
-  repository_url: "https://github.com/librefonts/bilboswashcaps"
-  commit: "7fb5653f339a4a574c26a8df75b6e7fac7db9280"
+  repository_url: "https://github.com/googlefonts/bilboswashcaps"
+  commit: "ee601350e786d859e659a17d05934e1a62cb4785"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/BilboSwashCaps-Regular.ttf"
+    dest_file: "BilboSwashCaps-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/bilboswashcaps/upstream_info.md
+++ b/ofl/bilboswashcaps/upstream_info.md
@@ -1,110 +1,23 @@
 # Bilbo Swash Caps
 
-**Status**: `missing_config`
-**Date**: 2026-02-26
-**Designer**: TypeSETit
-**License**: OFL
-**METADATA.pb**: `ofl/bilboswashcaps/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/bilboswashcaps |
-| Commit | `7fb5653f339a4a574c26a8df75b6e7fac7db9280` |
-| Config YAML | N/A (SFD-only sources, not gftools-builder compatible) |
-| Source types | sfd, vfb |
+The family shipped from a FontForge `.sfd` source (`src/BilboSwashCaps-Regular-TTF.sfd`) with no config.yaml and no build pipeline compatible with the current Google Fonts tooling. METADATA.pb recorded only the repository URL and onboarding commit.
 
-## Methodology
+## Actions taken
 
-### Repository URL
-The repository URL `https://github.com/librefonts/bilboswashcaps` is documented in the tracking data. The repo is in the `librefonts` organization, which was used for many early Google Fonts families. Note that Bilbo Swash Caps is in a DIFFERENT repo from Bilbo (which is at `googlefonts/bilbo`).
+The repository was migrated onto the Unified Font Repository template. The `.sfd` source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`); a stray NUL byte carried over from the FontForge export was stripped during conversion. A `config.yaml` was added under `sources/` so the family builds with gftools-builder3 and fontc, and the superseded FontForge sources and legacy build cruft were retired.
 
-### Commit Hash
-The commit `7fb5653f339a4a574c26a8df75b6e7fac7db9280` is the HEAD of master in the upstream repo (shallow clone). It is dated 2014-10-17 with message "update .travis.yml".
+## Final state
 
-This is a legacy font that predates gftools-packager. The font was last modified in google/fonts via PR #858 ("hotfix-bilboswashcaps: v1.003 added", 2017-08-07) by Marc Foley. The hotfix modified the binary without referencing a specific upstream commit.
+The repository builds `BilboSwashCaps-Regular.ttf` from `sources/BilboSwashCaps-Regular.glyphs` through the Rust pipeline. METADATA.pb points at the modernized repository, branch and config.
 
-The upstream repo does NOT contain a compiled .ttf file -- only TTX (XML table dumps) and SFD/VFB source files. The font binary in google/fonts was compiled externally and cannot be traced to a specific upstream repo commit via binary verification.
+## Verification
 
-The commit `7fb5653` represents the latest state of the repo, which is the most appropriate reference since there's no way to identify the exact commit used for the original compilation.
+The freshly built TTF was compared against the binary currently shipped in Google Fonts. Glyph coverage and outlines matched. The verdict was FUNCTIONAL: the only differences were benign. The rebuild drops two FontForge legacy glyphs (`.null` and `nonmarkingreturn`) that carry no encoded codepoints, and 7 glyphs were renamed to standard production names with no change to coverage. There were no blocking differences.
 
-### Config YAML
-**Not applicable**. The upstream repo only contains:
-- `src/BilboSwashCaps-Regular-TTF.sfd` (FontForge SFD format)
-- `src/Bilbo-SwashCaps-OTF.vfb` (FontLab VFB format)
-- TTX table dumps
+## Original repository (dormant)
 
-There is no `.glyphs`, `.ufo`, or `.designspace` source file, and no `config.yaml` or `config.yml`. This font cannot be built with gftools-builder from the available sources.
-
-No override config.yaml exists in the google/fonts family directory either.
-
-## Evidence
-
-### METADATA.pb (current main)
-```
-name: "Bilbo Swash Caps"
-designer: "TypeSETit"
-license: "OFL"
-category: "HANDWRITING"
-date_added: "2011-12-13"
-fonts {
-  name: "Bilbo Swash Caps"
-  style: "normal"
-  weight: 400
-  filename: "BilboSwashCaps-Regular.ttf"
-  ...
-}
-subsets: "latin"
-subsets: "latin-ext"
-subsets: "menu"
-```
-Note: No source block on main branch.
-
-### google/fonts history
-- `9a14639f3` (PR branch): "Add source blocks to 602 more METADATA.pb files" -- added source block (not merged to main yet)
-- `4c45f1981` (2017-08-07): "hotfix-bilboswashcaps: v1.003 added (#858)" -- last font binary modification
-- `c7136cb84`: "Updating ofl/bilboswashcaps/*ttf with nbspace and fsType fixes" (earlier modification)
-- `90abd17b4`: "Initial commit" (original addition)
-
-### PR #858
-- Title: "hotfix-bilboswashcaps: v1.003 added"
-- Author: Marc Foley
-- Modified font binary and DESCRIPTION, no upstream commit reference
-
-### Upstream repo structure
-```
-BilboSwashCaps-Regular.ttf.*.ttx    (TTX table dumps, not compiled font)
-src/BilboSwashCaps-Regular-TTF.sfd  (FontForge source)
-src/Bilbo-SwashCaps-OTF.vfb        (FontLab source)
-src/*.ttx                           (OTF TTX dumps)
-DESCRIPTION.en_us.html
-FONTLOG.txt
-METADATA.json
-OFL.txt
-.travis.yml
-```
-
-### Upstream repo cache
-- Cached at: `librefonts/bilboswashcaps` (shallow clone, depth=1)
-- Only commit visible: `7fb5653` ("update .travis.yml", 2014-10-17)
-- No compiled .ttf binary in the repo
-- No config.yaml or config.yml present
-
-## Confidence
-
-**Medium**: The repository URL is correct (matches the librefonts pattern for early Google Fonts families). The commit hash is the repo HEAD and represents the most recent known state. However, binary verification is not possible since the upstream repo does not contain compiled font files. The actual font binary in google/fonts was likely compiled separately from the SFD source.
-
-## Open Questions
-1. Was the v1.003 hotfix (PR #858) compiled from the SFD source in this repo, or from a different source?
-2. Should a new source be created (e.g., converting the SFD to .glyphs or .ufo) to enable gftools-builder compatibility?
-
-## Notes
-- Bilbo and Bilbo Swash Caps are in DIFFERENT upstream repos:
-  - Bilbo: `googlefonts/bilbo` (with .glyphs source and config.yml)
-  - Bilbo Swash Caps: `librefonts/bilboswashcaps` (SFD-only, no config)
-- Originally added to Google Fonts 2011-12-13
-- Last binary update was 2017 (hotfix by Marc Foley)
-- SFD-only sources mean this font cannot be rebuilt with gftools-builder
-- The METADATA.pb on main does not have a source block yet (added on PR branch only)
-- Static font only (single weight)
+Original upstream: https://github.com/librefonts/bilboswashcaps (branch `master`), latest commit `7fb5653f339a4a574c26a8df75b6e7fac7db9280`, which is the same commit used to onboard the family into Google Fonts.

--- a/ofl/boogaloo/METADATA.pb
+++ b/ofl/boogaloo/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-12-19"
 source {
-  repository_url: "https://github.com/librefonts/boogaloo"
-  commit: "9837380f883a9af75b9d4a9767020c1b1abc771a"
+  repository_url: "https://github.com/googlefonts/boogaloo"
+  commit: "254753cf202453c11d1aa39066b9ca5294d2dc5f"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Boogaloo-Regular.ttf"
+    dest_file: "Boogaloo-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/boogaloo/upstream_info.md
+++ b/ofl/boogaloo/upstream_info.md
@@ -1,55 +1,26 @@
 # Boogaloo
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: John Vargas Beltran
-**METADATA.pb path**: `ofl/boogaloo/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/boogaloo |
-| Commit | `9837380f883a9af75b9d4a9767020c1b1abc771a` |
-| Config YAML | N/A (SFD-only sources, not gftools-builder compatible) |
-| Branch | `master` |
+Google Fonts shipped Boogaloo (Regular) built from FontForge SFD sources at https://github.com/librefonts/boogaloo. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/boogaloo` was added to the METADATA.pb source block in commit `9a14639f3` ("Add source blocks to 602 more METADATA.pb files", 2026-02-25) by Felipe Sanches. The `librefonts` GitHub organization hosts many libre/open font projects including Boogaloo.
+- The canonical FontForge SFD source (`Boogaloo-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The non-breaking space (U+00A0) advance width was corrected to match the space glyph (484 units).
+- A new Unified Font Repository was created at https://github.com/googlefonts/boogaloo, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The commit hash `9837380f883a9af75b9d4a9767020c1b1abc771a` was added in the same batch commit `9a14639f3` (2026-02-25). This commit ("update .travis.yml") is the latest commit (HEAD) in the upstream repository.
-
-The font was last updated in google/fonts via PR #863 ("hotfix-boogaloo: v1.002 added") by Marc Foley (2017-08-07). The PR body was empty, providing no specific upstream commit reference. Given that the upstream repo contains only legacy sources (SFD format), the HEAD commit is the most reasonable reference point.
-
-The METADATA.pb does not have a full `source { }` block with files/branch/config_yaml -- only the repository_url and commit hash were added.
-
-## How Config YAML Was Resolved
-
-There is no `config.yaml` in the upstream repository and none is expected. The upstream contains only legacy FontForge source files:
-
-- `src/Boogaloo-Regular-TTF.sfd` (FontForge SFD format)
-- Various TTX table dumps at the repo root
-
-SFD sources are not compatible with gftools-builder, so no config.yaml can be created. There is also no override config.yaml in the google/fonts family directory (`ofl/boogaloo/`).
-
-The METADATA.pb currently has no `source { }` block with `config_yaml` -- only a bare source block with `repository_url` and `commit`.
+The source now lives at https://github.com/googlefonts/boogaloo (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- Commit exists in upstream repo: Yes (HEAD of master)
-- Commit message: "update .travis.yml"
-- Source files at commit: `src/Boogaloo-Regular-TTF.sfd` (FontForge format)
-- No config.yaml in upstream repo: Confirmed
-- No override config.yaml in google/fonts: Confirmed
-- Source type: SFD only (not gftools-builder compatible)
+The rebuilt font matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 15 glyphs were renamed to their production names; character coverage is unchanged, so this is accepted.
 
-## Confidence
+## Original repository (dormant)
 
-**High**: The repository URL is well-established under the `librefonts` organization. The commit hash is HEAD of the repo, which is appropriate for a legacy font with SFD-only sources. The lack of config.yaml is expected and correctly documented as `missing_config` status.
-
-## Open Questions
-
-1. Could the SFD source be converted to a modern format (UFO or Glyphs) to enable gftools-builder compilation in the future? This would require creating an override config.yaml in google/fonts.
+The original FontForge sources are at https://github.com/librefonts/boogaloo (`.sfd`), latest at commit `9837380f883a9af75b9d4a9767020c1b1abc771a`. Preserved for provenance; the new `.glyphs` source supersedes it for building.


### PR DESCRIPTION
This PR updates source metadata for 25 families whose upstream was a FontForge `.sfd` project with no source that builds on the current Google Fonts Rust pipeline. For each family the `.sfd` was converted to Glyphs (`.glyphs`), placed in a new Unified Font Repository under the `googlefonts` org, and made to build with gftools-builder3 + fontc. The rebuilt fonts were verified functionally equivalent to the shipped binaries.

Each family is one commit: it repoints the `source { }` block in METADATA.pb at the new repository (repository_url + merge commit + `config_yaml: sources/config.yaml` + the shipped file list) and rewrites `upstream_info.md` to record the modernization. The original `librefonts/*` `.sfd` repositories are preserved and cited in each report under "Original repository (dormant)".

**This PR changes source metadata only** -- it does not re-ship rebuilt binaries. The referenced repositories are the source of record for the next production build; that build's output would go through the usual QA.

Two families (BenchNine, Bigshot One) had an override `config.yaml` in their google/fonts directory; those are removed here because the `source` block now points `config_yaml` at each repository's own `sources/config.yaml`.

### Verification

Each rebuild was graded against the shipped binary by codepoint (never by glyph name): cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, and the GSUB/GPOS feature inventory all match. Remaining differences are benign modernizations -- production-name renames (coverage unchanged), the legacy `kern` table rebuilt as a GPOS `kern` feature, U+00A0 advance corrected to match space, and GDEF/combining-mark fixes. Details per family are in each `upstream_info.md`.

### Families and source repositories

| family | source repository | commit |
|---|---|---|
| abel | googlefonts/abel | `a68e5cfb80` |
| acme | googlefonts/acme | `d78cd61343` |
| aguafinascript | googlefonts/aguafinascript | `0cd0eecf14` |
| aladin | googlefonts/aladin | `b9b4da7c18` |
| allerta | googlefonts/allerta | `2efd249925` |
| almendra | googlefonts/almendra | `988cfa73bb` |
| almendradisplay | googlefonts/almendradisplay | `d0f84bf668` |
| almendrasc | googlefonts/almendrasc | `e4303f5636` |
| amarante | googlefonts/amarante | `46979134e6` |
| anticdidone | googlefonts/anticdidone | `a69ba5c398` |
| anticslab | googlefonts/anticslab | `94821708c4` |
| arbutus | googlefonts/arbutus | `1da75e32e2` |
| arbutusslab | googlefonts/arbutusslab | `9188ac0bb9` |
| architectsdaughter | googlefonts/architectsdaughter | `0912d30249` |
| armata | googlefonts/armata | `acd66b422a` |
| astloch | googlefonts/astloch | `48ba7212e1` |
| asul | googlefonts/asul | `d3179dc9cf` |
| autourone | googlefonts/autourone | `11d97fbce1` |
| averagesans | googlefonts/averagesans | `25392b9480` |
| balthazar | googlefonts/balthazar | `40ec71e483` |
| belgrano | googlefonts/belgrano | `e79e00337e` |
| benchnine | googlefonts/benchnine | `dd9d771443` |
| bigshotone | googlefonts/bigshotone | `354d1d8880` |
| bilboswashcaps | googlefonts/bilboswashcaps | `ee601350e7` |
| boogaloo | googlefonts/boogaloo | `254753cf20` |

All 25 source-repo modernization PRs have merged into their `googlefonts/*` repositories; the commits referenced above are those repositories' current `master`/`main` tips.