### PR TITLE
Reference 27 more modernized .glyphs source repositories (SFD -> Glyphs)

### DIFF
--- a/ofl/bowlbyone/METADATA.pb
+++ b/ofl/bowlbyone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-07-13"
 source {
-  repository_url: "https://github.com/librefonts/bowlbyone"
-  commit: "3aca9b57cf9c7b9688b635d5dcfb6d53948e26a2"
+  repository_url: "https://github.com/googlefonts/bowlbyone"
+  commit: "d469e83e10f7c1e7294e5586da5da1d9725f417c"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/BowlbyOne-Regular.ttf"
+    dest_file: "BowlbyOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/bowlbyone/upstream_info.md
+++ b/ofl/bowlbyone/upstream_info.md
@@ -1,56 +1,26 @@
-# Investigation Report: Bowlby One
+# Bowlby One
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Bowlby One |
-| Designer | Vernon Adams |
-| License | OFL |
-| Date Added | 2011-07-13 |
-| Repository URL | https://github.com/librefonts/bowlbyone |
-| Commit Hash | `3aca9b57cf9c7b9688b635d5dcfb6d53948e26a2` |
-| Branch | master |
-| Config YAML | None |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Bowlby One (Regular) built from FontForge SFD sources at https://github.com/librefonts/bowlbyone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/bowlbyone` was previously recorded in the tracking data. The librefonts organization hosts archival copies of many early Google Fonts projects. The repository is accessible and contains the original source files.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- During conversion, stray NUL bytes were stripped from the source and the no-break space advance width was corrected.
+- A new Unified Font Repository was created at https://github.com/googlefonts/bowlbyone, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The repository has only 11 commits total, all from 2014. The recorded commit `3aca9b5` is the tip of master (the latest commit, from 2014-10-17: "update .travis.yml"). This is the only meaningful commit to use as a reference since the repo has not been updated since 2014.
+## Final state
 
-The font binary in google/fonts was last updated in two key commits:
-1. `efb2eb034` (2015-04-27) - nbspace and fsType fixes by Dave Crossland
-2. `5df13fc14` (2017-08-07) - "hotfix-bowlbyone: v1.001 added" by Marc Foley via PR #864
-
-The 2017 hotfix updated the font binary to v1.001. This update was made by Marc Foley (m4rc1e), likely regenerating or modifying the binary outside the upstream repo. The upstream repo was never updated to reflect this change.
-
-## Config YAML Status
-
-**No config.yaml exists** in either the upstream repository or as an override in google/fonts.
-
-The upstream repository only contains SFD (FontForge) and VFB (FontLab) source files:
-- `src/BowlbyOne-Regular-TTF.sfd`
-- `src/BowlbyOne-Regular.vfb`
-
-These formats are not compatible with gftools-builder. There are no `.glyphs`, `.ufo`, or `.designspace` files.
+The source now lives at https://github.com/googlefonts/bowlbyone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- **Repository accessible**: Yes, `librefonts/bowlbyone` is accessible on GitHub
-- **Commit exists**: Yes, `3aca9b5` verified on GitHub (2014-10-17)
-- **Local cache**: Repo cached at `upstream_repos/fontc_crater_cache/librefonts/bowlbyone/`
-- **Commit matches tip**: Yes, the recorded commit is the latest commit in the repo
-- **Source files**: SFD and VFB only (not gftools-builder compatible)
+The rebuilt Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, and GSUB/GPOS feature sets. The differences are cosmetic and accepted: two FontForge legacy glyphs (`.null`, `nonmarkingreturn`) were dropped, six glyphs were renamed to production names with coverage unchanged, and three real combining marks (U+030F, U+0311, U+0326) were zeroed and correctly classified in GDEF, where the shipped font had left them with spurious spacing advances and no mark class.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** - The repository URL and commit hash are correct. The commit is the tip of an archival repo that has not been updated since 2014. The font binary in google/fonts was later modified independently (2015, 2017) without corresponding upstream changes.
-
-## Open Questions
-
-1. The 2017 hotfix (v1.001, PR #864) was done by Marc Foley. It is unclear where the updated source for v1.001 resides, if anywhere.
-2. Since only SFD/VFB sources exist, a config.yaml cannot be created for gftools-builder. This family may need to remain in "missing_config" status permanently, or an alternative build approach would need to be developed.
+The original FontForge sources are at https://github.com/librefonts/bowlbyone (`.sfd`), latest at commit `3aca9b57cf9c7b9688b635d5dcfb6d53948e26a2`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/bowlbyonesc/METADATA.pb
+++ b/ofl/bowlbyonesc/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-07-06"
 source {
-  repository_url: "https://github.com/librefonts/bowlbyonesc"
-  commit: "9566646d9feaafcdc1c23174931ac4599803442b"
+  repository_url: "https://github.com/googlefonts/bowlbyonesc"
+  commit: "7fc977deba6f6a55ede3fd17ebfc9d299afdfd83"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/BowlbyOneSC-Regular.ttf"
+    dest_file: "BowlbyOneSC-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/bowlbyonesc/config.yaml
+++ b/ofl/bowlbyonesc/config.yaml
@@ -1,3 +1,0 @@
-sources:
-  - src/BowlbyOneSC-Regular.ufo
-buildVariable: false

--- a/ofl/bowlbyonesc/upstream_info.md
+++ b/ofl/bowlbyonesc/upstream_info.md
@@ -1,71 +1,26 @@
-# Investigation Report: Bowlby One SC
+# Bowlby One SC
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Bowlby One SC |
-| Designer | Vernon Adams |
-| License | OFL |
-| Date Added | 2011-07-06 |
-| Repository URL | https://github.com/librefonts/bowlbyonesc |
-| Commit Hash | `9566646d9feaafcdc1c23174931ac4599803442b` |
-| Branch | master |
-| **Config YAML** | Override in google/fonts |
-| **Status** | complete |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Bowlby One SC (Regular) built from FontForge SFD sources at https://github.com/librefonts/bowlbyonesc. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/bowlbyonesc` was previously recorded in the tracking data. The librefonts organization hosts archival copies of many early Google Fonts projects. The repository is accessible on GitHub.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected to 616 in the converted source.
+- A new Unified Font Repository was created at https://github.com/googlefonts/bowlbyonesc, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The repository has only 12 commits total, all from 2014. The recorded commit `9566646` is the tip of master (the latest commit, from 2014-10-17: "update .travis.yml"). This is the only meaningful commit to use as a reference since the repo has not been updated since 2014.
+## Final state
 
-The font binary in google/fonts was last updated in:
-- `c6a838cef` (2015-04-27) - "Updating ofl/bowlbyonesc/*ttf with nbspace and fsType fixes" by Dave Crossland
-
-Unlike Bowlby One, Bowlby One SC has not received any additional hotfix updates since 2015.
-
-## Config YAML Status
-
-**No config.yaml exists** in either the upstream repository or as an override in google/fonts.
-
-The upstream repository contains a mix of source formats:
-- `src/BowlbyOneSC-Regular.sfd` (FontForge format)
-- `src/BowlbyOneSC-Regular-TTF.vfb` (FontLab format)
-- `src/BowlbyOneSC-Regular.ufo` (UFO format - gftools-buildable)
-- `src/BowlbyOneSC-TThints.vfb` (FontLab hinting file)
-
-**Important**: The presence of a UFO source means this family could potentially be built with gftools-builder if a config.yaml were created. However, the UFO source dates from 2014 and may not produce output matching the current binary (which was modified in 2015 for nbspace/fsType fixes).
+The source now lives at https://github.com/googlefonts/bowlbyonesc (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- **Repository accessible**: Yes, `librefonts/bowlbyonesc` is accessible on GitHub
-- **Commit exists**: Yes, `9566646` verified on GitHub (2014-10-17)
-- **Local cache**: Repo cached at `upstream_repos/fontc_crater_cache/librefonts/bowlbyonesc/`
-- **Commit matches tip**: Yes, the recorded commit is the latest commit in the repo
-- **Source files**: SFD, VFB, and UFO (UFO is gftools-builder compatible in principle)
+Matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle and the GSUB/GPOS feature sets. Accepted differences: the FontForge-only `nonmarkingreturn` glyph was dropped; 7 glyphs were renamed to production names (coverage unchanged); and three combining marks (U+030F, U+0311, U+0326) are now classified as marks in GDEF and given zero advance widths, correcting the shipped font, which had missed those GDEF classes and given the same marks spacing advances.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** - The repository URL and commit hash are correct. The commit is the tip of an archival repo that has not been updated since 2014. The current tracking notes say "Has gftools-buildable sources (ufo), needs config.yaml" which is accurate.
-
-
-## Override Config YAML
-
-An override `config.yaml` has been added to the google/fonts family directory. Contents:
-
-```yaml
-sources:
-  - src/BowlbyOneSC-Regular.ufo
-buildVariable: false
-```
-
-This override config enables gftools-builder to compile the font from upstream sources.
-
-## Open Questions
-
-1. The UFO source file exists but is from 2014. Would building from this UFO produce output matching the current binary in google/fonts (which had nbspace/fsType fixes applied in 2015)? Testing would be needed.
-2. A config.yaml could potentially be created as an override in google/fonts to build from the UFO source, but the output would need to be verified against the current binary.
-3. This family was created by Vernon Adams, who passed away in 2014. The source is unlikely to receive further updates.
+The original FontForge sources are at https://github.com/librefonts/bowlbyonesc (`.sfd`), latest at commit `9566646d9feaafcdc1c23174931ac4599803442b`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/breeserif/METADATA.pb
+++ b/ofl/breeserif/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SERIF"
 date_added: "2011-12-19"
 source {
-  repository_url: "https://github.com/librefonts/breeserif"
-  commit: "86684a17aaa88ce2d9d85d77f9e9ce1f64c06462"
+  repository_url: "https://github.com/googlefonts/breeserif"
+  commit: "80b004f6325a65a90f50de70facec1c98d36ff9d"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/BreeSerif-Regular.ttf"
+    dest_file: "BreeSerif-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/breeserif/upstream_info.md
+++ b/ofl/breeserif/upstream_info.md
@@ -1,49 +1,23 @@
-# Investigation Report: Bree Serif
+# Bree Serif
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Bree Serif |
-| Designer | TypeTogether |
-| License | OFL |
-| Date Added | 2011-12-19 |
-| Repository URL | https://github.com/librefonts/breeserif |
-| Commit Hash | `86684a17aaa88ce2d9d85d77f9e9ce1f64c06462` |
-| Branch | master |
-| Config YAML | N/A (SFD-only sources) |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+The family shipped from a FontForge `.sfd` source (`src/BreeSerif-Regular-TTF.sfd`) with no gftools-builder configuration. The METADATA.pb source block pointed at the librefonts repository but carried no `config_yaml`, so the family could not be rebuilt with the current pipeline.
 
-The repository URL `https://github.com/librefonts/breeserif` was identified from the `librefonts` organization on GitHub, which hosts many libre font projects. It was added to the tracking data and a source block was prepared on branch `sources_info_2026-02-25` (commit `9a14639f3`), though this has not yet been merged to google/fonts main.
+## Actions taken
 
-## How Commit Determined
+The `.sfd` source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), producing `BreeSerif-Regular.glyphs`. During conversion the non-breaking space (U+00A0) glyph width was corrected to match the regular space. The repository was restructured on the Unified Font Repository template, a gftools-builder configuration was added, and the superseded FontForge sources and legacy build cruft were retired.
 
-The commit hash `86684a17aaa88ce2d9d85d77f9e9ce1f64c06462` is the only commit in the upstream repository, authored on 2014-10-17 by hash3g with message "update .travis.yml". Since the repo has only one commit, this is definitively the latest (and only) available state.
+## Final state
 
-The font was originally added to google/fonts in the initial commit (`90abd17b4`) and later updated via hotfix in PR #866 (`faaf4889d`: "hotfix-breeserif: v1.002 added"). These early hotfix commits did not include upstream repo or commit hash references.
-
-## Config YAML Status
-
-- **No `config.yaml` exists** in the upstream repository
-- **No override `config.yaml`** exists in google/fonts
-- The upstream sources are in SFD (FontForge) format only: `src/BreeSerif-Regular-TTF.sfd` and `src/BreeSerif-Regular-OTF.vfb`
-- These formats are not compatible with gftools-builder, so no config.yaml can be created
-- The family is correctly marked as `missing_config` with note "SFD-only sources (FontForge format), not gftools-builder compatible"
+The family now builds from `.glyphs` with gftools-builder3 and fontc. A single static instance, Bree Serif Regular, is produced.
 
 ## Verification
 
-1. **Commit exists in upstream**: Confirmed. `86684a17aaa88ce2d9d85d77f9e9ce1f64c06462` is the sole commit in the cached repo at `upstream_repos/fontc_crater_cache/librefonts/breeserif`
-2. **Source format**: SFD and VFB files only - no `.glyphs`, `.ufo`, or `.designspace` files
-3. **No config.yaml possible**: Not gftools-builder compatible due to legacy source format
-4. **METADATA.pb source block**: Currently not present on google/fonts main branch; prepared on branch `sources_info_2026-02-25` with `repository_url` and `commit` only (no `config_yaml` field)
+The fontc-built TTF was compared against the shipped `BreeSerif-Regular.ttf`. The result is a FUNCTIONAL match: glyph coverage, metrics and layout are equivalent. The only difference is benign: 21 glyphs were renamed to their production names, leaving codepoint coverage unchanged. No blocking differences were found.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** - The repo has only one commit, so the hash is unambiguous. The URL is the correct librefonts mirror. The lack of config.yaml is expected since the sources are in FontForge SFD format, which predates the gftools-builder workflow.
-
-## Open Questions
-
-1. The source block for this family has been prepared but is not yet merged to google/fonts main (pending PR on `sources_info_2026-02-25` branch).
-2. TypeTogether may have more recent sources for Bree Serif in a different format (Glyphs/UFO), but the librefonts repository only contains the legacy SFD sources.
+Original upstream: https://github.com/librefonts/breeserif (branch `master`), latest commit `86684a17aaa88ce2d9d85d77f9e9ce1f64c06462`. This was also the onboarding commit for the family. The modernized sources now live in the googlefonts fork.

--- a/ofl/bubblegumsans/METADATA.pb
+++ b/ofl/bubblegumsans/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-11-23"
 source {
-  repository_url: "https://github.com/librefonts/bubblegumsans"
-  commit: "fcf8bdd5e83b65186641b2b67fd957ff061666e3"
+  repository_url: "https://github.com/googlefonts/bubblegumsans"
+  commit: "ad8f70f6b46d0c3e66f2e38f943435eb2b6bb625"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/BubblegumSans-Regular.ttf"
+    dest_file: "BubblegumSans-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/bubblegumsans/upstream_info.md
+++ b/ofl/bubblegumsans/upstream_info.md
@@ -1,53 +1,26 @@
 # Bubblegum Sans
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config (SFD-only sources)
-**Designer**: Sudtipos
-**METADATA.pb path**: `ofl/bubblegumsans/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/bubblegumsans |
-| Commit | `fcf8bdd5e83b65186641b2b67fd957ff061666e3` |
-| Config YAML | N/A (SFD-only sources, not gftools-builder compatible) |
-| Branch | `master` |
+Google Fonts shipped Bubblegum Sans (Regular) built from FontForge SFD sources at https://github.com/librefonts/bubblegumsans. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/bubblegumsans` was identified from the `librefonts` organization, which hosts archived Google Fonts sources in a standardized structure. This was not added by gftools-packager but rather by the batch source block addition in commit `9a14639f3` ("Add source blocks to 602 more METADATA.pb files", 2026-02-25). The METADATA.pb had no source block prior to this.
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A non-breaking space (U+00A0) was added to the source, matching the glyph that FontForge used to synthesise at export time.
+- A new Unified Font Repository was created at https://github.com/googlefonts/bubblegumsans, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The commit `fcf8bdd5e83b65186641b2b67fd957ff061666e3` is the **only commit** in the repository (message: "update .travis.yml", by hash3g, 2014-10-17). This is a single-commit archive repository under the `librefonts` organization. Since there is only one commit, identification is unambiguous.
-
-The font was originally added to google/fonts in the initial commit `90abd17b4` and last had its binary updated in commit `75e7dd823` ("Updating ofl/bubblegumsans/*ttf with nbspace and fsType fixes", 2015-04-27 by Dave Crossland). These updates were done directly in the google/fonts repo, not via gftools-packager from the upstream repo. The librefonts repo serves as an archive of the original source files.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository. The source files are:
-- `src/BubblegumSans-Regular-TTF.sfd` (FontForge SFD format)
-- `src/BubblegumSans-Regular-OTF.vfb` (FontLab VFB format)
-
-These are legacy source formats that are not compatible with gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` sources. No override config.yaml exists in the google/fonts family directory either.
-
-The font has not been rebuilt from sources using modern tooling. The binary in google/fonts was originally added and later patched directly.
+The source now lives at https://github.com/googlefonts/bubblegumsans (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- Commit exists in upstream repo: Yes (it is the only commit)
-- Commit date: 2014-10-17 13:31:31 +0300
-- Commit message: "update .travis.yml"
-- Commit author: hash3g
-- Source files at commit: `src/BubblegumSans-Regular-TTF.sfd`, `src/BubblegumSans-Regular-OTF.vfb`
-- Config YAML: Does not exist
-- No gftools-packager history: Font was added before the packager workflow existed
+The rebuilt Bubblegum Sans Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. Remaining differences are benign: 7 glyphs renamed to production names (coverage unchanged), and two FontForge legacy glyphs (`.null`, `nonmarkingreturn`) dropped as they carry no encoded characters. Verdict: FUNCTIONAL parity.
 
-## Confidence
+## Original repository (dormant)
 
-**Medium**: The repository URL is correct for the librefonts archive. The commit hash is trivially correct (only one commit). However, the relationship between the upstream repo and the binary in google/fonts is weak -- the font binary was likely compiled outside of this repo and the repo serves primarily as an archive of source files and TTX dumps. The font cannot be rebuilt with gftools-builder from these sources.
-
-## Open Questions
-
-1. The font sources are in SFD/VFB format only. To enable rebuilding with gftools-builder, the sources would need to be converted to `.glyphs` or `.ufo` format and a new upstream repo or config.yaml created. This is a low priority for a single-weight static font that has not been updated since 2015.
+The original FontForge sources are at https://github.com/librefonts/bubblegumsans (`.sfd`), latest at commit `fcf8bdd5e83b65186641b2b67fd957ff061666e3`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/bubblerone/METADATA.pb
+++ b/ofl/bubblerone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2012-05-09"
 source {
-  repository_url: "https://github.com/librefonts/bubblerone"
-  commit: "be2343608e5751bca73956b02860a1758e1e29a7"
+  repository_url: "https://github.com/googlefonts/bubblerone"
+  commit: "110b02cb1d151f5c8288d01c98121bab0094da19"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/BubblerOne-Regular.ttf"
+    dest_file: "BubblerOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/bubblerone/upstream_info.md
+++ b/ofl/bubblerone/upstream_info.md
@@ -1,57 +1,26 @@
 # Bubbler One
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config (SFD-only sources)
-**Designer**: Brenda Gallo
-**METADATA.pb path**: `ofl/bubblerone/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/bubblerone |
-| Commit | `be2343608e5751bca73956b02860a1758e1e29a7` |
-| Config YAML | N/A (SFD-only sources, not gftools-builder compatible) |
-| Branch | `master` |
+Google Fonts shipped Bubbler One (Regular) built from FontForge SFD sources at https://github.com/librefonts/bubblerone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/bubblerone` was identified from the `librefonts` organization, which hosts archived Google Fonts sources. This was added by the batch source block addition in commit `9a14639f3` ("Add source blocks to 602 more METADATA.pb files", 2026-02-25). The METADATA.pb had no source block prior to this.
+- The canonical FontForge SFD source (`BubblerOne-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The converted source was corrected: a NO-BREAK SPACE (U+00A0) glyph was added, since FontForge used to synthesise it at export time, and "Use Typo Metrics" (fsSelection bit 7) was set.
+- A new Unified Font Repository was created at https://github.com/googlefonts/bubblerone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The commit `be2343608e5751bca73956b02860a1758e1e29a7` is the **only commit** in the repository (message: "update .travis.yml", by hash3g, 2014-10-17). This is a single-commit archive repository under the `librefonts` organization. Since there is only one commit, identification is unambiguous.
-
-The font has a richer update history in google/fonts compared to many librefonts families:
-1. Initial commit `90abd17b4` (2012)
-2. Hotfix PR #867 (`70a30639c`, "hotfix-bubblerone: v1.002 added")
-3. Compliance fixes (`011460f75`, "Several hotfixes to bring font into compliance (mainly vertical metrics)")
-4. Version bump (`078516296`, "Bumped version")
-
-These updates were done directly in the google/fonts repo, not by pulling from the librefonts archive. The librefonts repo contains the original source files only.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository. The source files are:
-- `src/BubblerOne-Regular-TTF.sfd` (FontForge SFD format)
-
-This is a legacy source format not compatible with gftools-builder. The repo also contains extensive TTX dumps of the compiled font tables. No override config.yaml exists in the google/fonts family directory.
+The source now lives at https://github.com/googlefonts/bubblerone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- Commit exists in upstream repo: Yes (it is the only commit)
-- Commit date: 2014-10-17 13:31:34 +0300
-- Commit message: "update .travis.yml"
-- Commit author: hash3g
-- Source files at commit: `src/BubblerOne-Regular-TTF.sfd`
-- Config YAML: Does not exist
-- No gftools-packager history: Font updates were done directly in google/fonts
+The rebuilt font matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The accepted differences are benign: two unencoded FontForge legacy glyphs (`.null`, `nonmarkingreturn`) were dropped, four glyphs were renamed to production names with coverage unchanged, and the `.notdef` advance width differs (203 vs 510).
 
-## Confidence
+## Original repository (dormant)
 
-**Medium**: The repository URL is correct for the librefonts archive. The commit hash is trivially correct (only one commit). However, the font binary in google/fonts was updated multiple times after the librefonts archive was created, so the compiled font does NOT correspond to these source files. The font cannot be rebuilt with gftools-builder from these sources.
-
-## Open Questions
-
-1. The font binary in google/fonts has been updated several times (hotfixes, version bumps) after the librefonts archive was created. The SFD source in the archive likely does not correspond to the current binary. To enable rebuilding, the sources would need to be converted to modern formats.
-2. The hotfix in PR #867 and subsequent updates suggest the font was modified directly at the binary level or from sources not present in the librefonts repo.
+The original FontForge sources are at https://github.com/librefonts/bubblerone (`.sfd`), latest at commit `be2343608e5751bca73956b02860a1758e1e29a7`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/butcherman/METADATA.pb
+++ b/ofl/butcherman/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-12-19"
 source {
-  repository_url: "https://github.com/librefonts/butcherman"
-  commit: "92a34525b5032c76484c49e652f649e52d1465e5"
+  repository_url: "https://github.com/googlefonts/butcherman"
+  commit: "f4f7f3e2cd993e09bb72e154c5fd34f3dc99d3c0"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Butcherman-Regular.ttf"
+    dest_file: "Butcherman-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/butcherman/upstream_info.md
+++ b/ofl/butcherman/upstream_info.md
@@ -1,48 +1,30 @@
-# Butcherman - Investigation Report
+# Butcherman
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| **Family Name** | Butcherman |
-| **Designer** | Typomondo |
-| **License** | OFL |
-| **Date Added** | 2011-12-19 |
-| **Repository URL** | https://github.com/librefonts/butcherman |
-| **Commit Hash** | `92a34525b5032c76484c49e652f649e52d1465e5` |
-| **Branch** | master |
-| **Config YAML** | N/A |
-| **Status** | missing_config |
+## Initial state
 
-## How URL Was Found
+Google Fonts shipped Butcherman (Regular) built from FontForge SFD sources at https://github.com/librefonts/butcherman. The shipped binary is pre-OpenType: it has no GSUB, no GPOS and no legacy kern table. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/butcherman` was added as part of a batch source block addition in commit `9a14639f3` ("Add source blocks to 602 more METADATA.pb files"). The librefonts GitHub organization hosts mirrors/archives of many Google Fonts source repos. The URL is consistent with the standard librefonts naming convention for this family.
+## Actions taken
 
-## How Commit Was Determined
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The upstream SFD defines a Standard Ligatures (`liga`) lookup (`n n -> n_n`, `o o -> o_o`) that FontForge's TTF export had dropped, so the shipped binary never applied it. To keep this modernization a strict equivalence, that feature was removed from the converted source so the rebuild matches the shipped binary. Restoring it is proposed separately (see below).
+- A new Unified Font Repository was created at https://github.com/googlefonts/butcherman, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The recorded commit `92a34525b5032c76484c49e652f649e52d1465e5` is the **only commit** in the entire repository. The repo was initialized by hash3g on 2014-10-17 with the message "update .travis.yml". Since there is only one commit, it is trivially the correct reference point -- it represents the only state the repo has ever been in.
+## Final state
 
-The font binaries in google/fonts were last updated via PR #870 ("hotfix-butcherman: v1.004 added"), authored by m4rc1e and merged on 2017-08-07. This was a hotfix to the font file (66148 -> 66100 bytes), likely addressing minor issues.
-
-## Config YAML Status
-
-**No config.yaml exists** in the upstream repository and no override config.yaml exists in the google/fonts family directory.
-
-The repository contains only SFD (FontForge) source files at `src/Butcherman-Regular.sfd` and `src/Butcherman-Regular-TTF.sfd`. These are FontForge-format sources that are **not compatible with gftools-builder**, which requires `.glyphs`, `.ufo`, or `.designspace` sources.
-
-No config.yaml can be created for this family without first converting the sources to a gftools-compatible format.
+The source now lives at https://github.com/googlefonts/butcherman (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary. The rebuilt font has no GSUB, matching the shipped binary.
 
 ## Verification
 
-- **Repository URL**: Confirmed valid; repo is cloned at `upstream_repos/fontc_crater_cache/librefonts/butcherman/`
-- **Commit hash**: Verified -- it is the only commit in the repo (HEAD of master)
-- **Source files**: Only SFD files present (`src/Butcherman-Regular.sfd`, `src/Butcherman-Regular-TTF.sfd`)
-- **Font binary history**: Last updated in google/fonts via PR #870 (m4rc1e, 2017-08-07)
+The rebuilt Butcherman-Regular was compared against the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths, and had no blocking differences. Accepted differences: two FontForge legacy glyphs (`.null`, `nonmarkingreturn`) were dropped; 17 glyphs were renamed to their production names, with codepoint coverage unchanged; GDEF now classifies five real combining marks that the shipped font missed; and those five marks were given zero advance where the shipped font had assigned them spacing advances.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** -- The repository URL is correct and the commit hash is trivially verified as the sole commit. The missing_config status is accurate because only SFD sources exist, which cannot be built with gftools-builder.
+The original FontForge sources are at https://github.com/librefonts/butcherman (`.sfd`), latest at commit `92a34525b5032c76484c49e652f649e52d1465e5`. Preserved for provenance; the new `.glyphs` source supersedes it for building.
 
-## Open Questions
+## Pending improvement (separate review)
 
-None. The data is complete and verified. The family will remain in `missing_config` status unless the sources are converted to a gftools-compatible format.
+The `liga` lookup the shipped font lacks was recovered during conversion and is preserved on a separate branch. Restoring it changes rendering (the `nn` and `oo` doubles), so it is proposed as a follow-up that a Google Fonts onboarder must review and QA before it ships. It is not part of this equivalence modernization.

--- a/ofl/cagliostro/METADATA.pb
+++ b/ofl/cagliostro/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2011-11-30"
 source {
-  repository_url: "https://github.com/librefonts/cagliostro"
-  commit: "5c0de59bedd45c878edfeeeb31e2105f987e7270"
+  repository_url: "https://github.com/googlefonts/cagliostro"
+  commit: "871f5caf05c9d0a09e8eb11f9c43e27bb8679673"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Cagliostro-Regular.ttf"
+    dest_file: "Cagliostro-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/cagliostro/upstream_info.md
+++ b/ofl/cagliostro/upstream_info.md
@@ -1,54 +1,26 @@
-# Cagliostro - Investigation Report
+# Cagliostro
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Cagliostro |
-| Designer | MADType |
-| License | OFL |
-| Date Added | 2011-11-30 |
-| Repository URL | https://github.com/librefonts/cagliostro |
-| Commit Hash | 5c0de59bedd45c878edfeeeb31e2105f987e7270 |
-| Config YAML | None |
-| Status | missing_config |
+## Initial state
 
-## How URL Was Found
+Google Fonts shipped Cagliostro (Regular) built from FontForge SFD sources at https://github.com/librefonts/cagliostro. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/cagliostro` was added as part of the bulk source block addition in commit `9a14639f3` (2026-02-25). The librefonts GitHub organization hosts archived copies of many early Google Fonts projects. This is a standard librefonts archive repository.
+## Actions taken
 
-## How Commit Was Determined
+- The canonical FontForge SFD source (`src/Cagliostro-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The converted source was cleaned up: stray NUL bytes were stripped and the no-break space (U+00A0) advance was corrected to 250.
+- A new Unified Font Repository was created at https://github.com/googlefonts/cagliostro, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The commit hash `5c0de59bedd45c878edfeeeb31e2105f987e7270` is the only commit in the repository (and therefore HEAD). It was made on 2014-10-17 with the message "update .travis.yml". This is a single-commit archive repository.
+## Final state
 
-Cagliostro was part of the initial commit (`90abd17b4`) in the google/fonts repository, making it one of the earliest families in the collection. The librefonts repository is an archive, not an active development repository.
-
-## Config YAML Status
-
-**No config.yaml exists** in the upstream repository and none is expected. The repository contains:
-- `src/Cagliostro-Regular-TTF.sfd` (FontForge SFD format) - This is a legacy format not supported by gftools-builder.
-- `src/Cagliostro-Regular.vfb` (FontLab format) - Also a legacy format not supported by gftools-builder.
-- TTX decompositions of the OTF font in the root directory and src directory.
-- Standard metadata files (DESCRIPTION, FONTLOG, OFL, METADATA.json).
-
-There is no override `config.yaml` in the google/fonts family directory either.
-
-This family cannot be built with gftools-builder because the only sources are in SFD (FontForge) and VFB (FontLab) formats, neither of which is a supported input format.
+The source now lives at https://github.com/googlefonts/cagliostro (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- **Repository URL**: Valid. The librefonts/cagliostro repository exists and is accessible.
-- **Commit Hash**: Verified. The hash `5c0de59bedd45c878edfeeeb31e2105f987e7270` is the sole commit in the repository.
-- **Source Files**: SFD and VFB formats only (legacy, not gftools-buildable).
-- **Font Origin**: This is a very early Google Fonts family (initial commit). The librefonts repo is an archive.
+The rebuilt Cagliostro Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle and the GSUB/GPOS feature sets. The remaining differences are cosmetic and expected from the conversion: two synthetic FontForge legacy glyphs (`.null`, `nonmarkingreturn`) were dropped, 9 glyphs were renamed to production names with no change in coverage, GDEF now correctly classifies two combining marks the shipped font missed (uni0307, uni0326), and two combining marks (U+0307, U+F6C3) had their spacing advances zeroed to match their combining-mark role.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** for the repository URL and commit hash. The librefonts repo is a well-known archive with only one commit, so there is no ambiguity.
-
-**Note**: The designer is listed as "MADType" (Matthew Desmond, mattdesmond@gmail.com per the copyright string, http://www.madtype.com).
-
-## Open Questions
-
-1. Is there any plan to convert the SFD/VFB sources to a modern format (Glyphs/UFO) for this family?
-2. The original designer Matthew Desmond (MADType) may have more recent source files.
+The original FontForge sources are at https://github.com/librefonts/cagliostro (`.sfd`), latest at commit `5c0de59bedd45c878edfeeeb31e2105f987e7270`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/cambo/METADATA.pb
+++ b/ofl/cambo/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SERIF"
 date_added: "2011-12-19"
 source {
-  repository_url: "https://github.com/librefonts/cambo"
-  commit: "3b97d12b34a587e8868700ffa711df7dc6aa0d04"
+  repository_url: "https://github.com/googlefonts/cambo"
+  commit: "a2c35dbad5014c97b1ca438b895d95c7411e0e04"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Cambo-Regular.ttf"
+    dest_file: "Cambo-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/cambo/upstream_info.md
+++ b/ofl/cambo/upstream_info.md
@@ -1,51 +1,26 @@
-# Cambo - Investigation Report
+# Cambo
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Cambo |
-| Designer | HT Fonts |
-| License | OFL |
-| Date Added | 2011-12-19 |
-| Repository URL | https://github.com/librefonts/cambo |
-| Commit Hash | 3b97d12b34a587e8868700ffa711df7dc6aa0d04 |
-| Branch | master |
-| Config YAML | N/A |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Cambo (Regular) built from FontForge SFD sources at https://github.com/librefonts/cambo. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/cambo` was added as part of a batch source blocks commit (9a14639f3, "Add source blocks to 602 more METADATA.pb files"). The librefonts organization on GitHub hosts mirrors of many Google Fonts projects. The METADATA.pb in google/fonts previously had no source block.
+## Actions taken
 
-Note that the original designer is HT Fonts, but no repo was found at `huertatipografica/cambo` on GitHub. The librefonts mirror is the only known upstream repository.
+- The canonical FontForge SFD source (`src/Cambo-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The non-breaking space (U+00A0) advance width was corrected in the converted source.
+- A new Unified Font Repository was created at https://github.com/googlefonts/cambo, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-## How Commit Determined
+## Final state
 
-The commit `3b97d12b34a587e8868700ffa711df7dc6aa0d04` is the HEAD (and only commit) of the librefonts/cambo repository, dated 2014-10-17. The commit message is "update .travis.yml". This is a single-commit repo that mirrors the original sources.
-
-The font binary in google/fonts was last updated in commit d4b4f127f (2015-04-27, "Updating ofl/cambo/*ttf with nbspace and fsType fixes" by Dave Crossland), which was a metadata fix, not a rebuild from sources. The initial font was added in commit 90abd17b4 ("Initial commit").
-
-Since the librefonts repo has only one commit, the recorded hash is the only valid option and represents the complete state of the upstream mirror.
-
-## Config YAML Status
-
-No `config.yaml` exists in the upstream repository. No override `config.yaml` exists in google/fonts either.
-
-The upstream repo contains only FontForge SFD sources (`src/Cambo-Regular-TTF.sfd`) and VFB files (`src/Cambo-Regular-OTF.vfb`, `src/Cambo-Regular.vfb`). These are not gftools-builder compatible formats. A config.yaml for SFD sources could theoretically be created, but SFD building support in gftools-builder is limited.
+The source now lives at https://github.com/googlefonts/cambo (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
 ## Verification
 
-- **Commit hash verified**: The hash `3b97d12` exists in the librefonts/cambo repository and is HEAD of master. CONFIRMED.
-- **Repository accessible**: librefonts/cambo is a valid GitHub repository. CONFIRMED.
-- **Source files**: Only SFD and VFB formats available, no .glyphs/.ufo/.designspace sources.
-- **Single-commit repo**: Only one commit in the entire history (2014-10-17).
+Matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference was 10 glyphs renamed to their production names, which leaves cmap coverage unchanged; the fonts are therefore functionally equivalent.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** - The repository URL and commit hash are correct. The librefonts mirror is the only known upstream. The font was originally added to Google Fonts in 2011 and has not been rebuilt from sources since.
-
-## Open Questions
-
-- The original designer (HT Fonts) may have source files in other formats (e.g., .glyphs) that are not publicly available.
-- No path to gftools-builder compatibility without source conversion from SFD/VFB format.
+The original FontForge sources are at https://github.com/librefonts/cambo (`.sfd`), latest at commit `3b97d12b34a587e8868700ffa711df7dc6aa0d04`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/candal/METADATA.pb
+++ b/ofl/candal/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2011-03-09"
 source {
-  repository_url: "https://github.com/librefonts/candal"
-  commit: "64c937069fed67f562829846315a0e2e7789e6a6"
+  repository_url: "https://github.com/googlefonts/candal"
+  commit: "ed7ac22d003047196e34bcf6465f2ad5871493e8"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Candal-Regular.ttf"
+    dest_file: "Candal.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/candal/upstream_info.md
+++ b/ofl/candal/upstream_info.md
@@ -1,51 +1,26 @@
-# Candal - Investigation Report
+# Candal
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Candal |
-| Designer | Vernon Adams |
-| License | OFL |
-| Date Added | 2011-03-09 |
-| Repository URL | https://github.com/librefonts/candal |
-| Commit Hash | 64c937069fed67f562829846315a0e2e7789e6a6 |
-| Branch | master |
-| Config YAML | N/A |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Candal (Regular) built from FontForge SFD sources at https://github.com/librefonts/candal. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/candal` was added as part of the batch source blocks commit (9a14639f3, "Add source blocks to 602 more METADATA.pb files"). The librefonts organization hosts mirrors of many Google Fonts projects. The METADATA.pb in google/fonts previously had no source block.
+## Actions taken
 
-Vernon Adams, the original designer, passed away in 2014. His fonts were preserved in the librefonts mirrors.
+- The canonical FontForge SFD source (`src/Candal-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected to 713 units to match the space glyph, replacing the value FontForge previously synthesised at export.
+- A new Unified Font Repository was created at https://github.com/googlefonts/candal, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## How Commit Determined
+## Final state
 
-The commit `64c937069fed67f562829846315a0e2e7789e6a6` is the HEAD (and only commit) of the librefonts/candal repository, dated 2014-10-17. The commit message is "update .travis.yml". This is a single-commit repo.
-
-The font binary in google/fonts was last updated in commit cfa69ab46 (2015-04-27, "Updating ofl/candal/*ttf with nbspace and fsType fixes" by Dave Crossland), which was a metadata-only fix (file size unchanged), not a rebuild from sources. The initial font was added in 90abd17b4 ("Initial commit").
-
-Since the librefonts repo has only one commit, the recorded hash is the only valid option.
-
-## Config YAML Status
-
-No `config.yaml` exists in the upstream repository. No override `config.yaml` exists in google/fonts either.
-
-The upstream repo contains only FontForge SFD sources (`src/Candal.sfd`, `src/Candal-TTF.sfd`) and VFB files (`src/Candal-TTF.vfb`, `src/Candal.vfb`). These are not gftools-builder compatible formats.
+The source now lives at https://github.com/googlefonts/candal (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- **Commit hash verified**: The hash `64c9370` exists in the librefonts/candal repository and is HEAD of master. CONFIRMED.
-- **Repository accessible**: librefonts/candal is a valid GitHub repository. CONFIRMED.
-- **Source files**: Only SFD and VFB formats available, no .glyphs/.ufo/.designspace sources.
-- **Single-commit repo**: Only one commit in the entire history (2014-10-17).
+The rebuilt Candal Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle and GSUB/GPOS feature sets. The accepted differences are all benign: 15 glyphs were renamed to production names with unchanged coverage; GDEF now classifies 5 real combining marks (uni0307, uni030F, uni0311, uni0326, uni0326.1) that the shipped font failed to mark; and 4 combining marks (U+0307, U+030F, U+0311, U+0326) were given zero advance widths, correcting the spacing advances the shipped font wrongly assigned them.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** - The repository URL and commit hash are correct. The librefonts mirror is the only known upstream, and Vernon Adams (the designer) is deceased, so no additional source repo is expected.
-
-## Open Questions
-
-- No path to gftools-builder compatibility without source conversion from SFD/VFB format.
-- The font has not been updated since the initial onboarding (only metadata fixes).
+The original FontForge sources are at https://github.com/librefonts/candal (`.sfd`), latest at commit `64c937069fed67f562829846315a0e2e7789e6a6`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/cantataone/METADATA.pb
+++ b/ofl/cantataone/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/cantataone"
-  commit: "947c3dd6e969867a02166335a27c48c0a7f9123d"
+  repository_url: "https://github.com/googlefonts/cantataone"
+  commit: "12fb64c8cad39f95d18ea97713683cdebe08693a"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/CantataOne-Regular.ttf"
+    dest_file: "CantataOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/cantataone/upstream_info.md
+++ b/ofl/cantataone/upstream_info.md
@@ -1,74 +1,23 @@
 # Cantata One
 
-**Date investigated**: 2026-02-27
-**Status**: missing_config
-**Designer**: Joana Correia (design), Eben Sorkin (mastering)
-**METADATA.pb path**: `ofl/cantataone/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/cantataone |
-| Commit | `947c3dd6e969867a02166335a27c48c0a7f9123d` |
-| Config YAML | -- |
-| Branch | master |
+The family shipped from the librefonts `cantataone` repository, whose only editable sources were FontForge `.sfd` files (`src/CantataOne-Regular-TTF.sfd`). METADATA.pb carried a bare `source { }` block with the repository URL and onboarding commit but no build configuration, and the sources could not be built by the current Rust toolchain.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/cantataone` was already recorded in the tracking file. Verification confirms:
+The single master `src/CantataOne-Regular-TTF.sfd` was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), producing `sources/CantataOne-Regular.glyphs`. During conversion the non-breaking space (U+00A0) advance width was corrected to 682 units to match the space glyph. A `config.yaml` for gftools-builder3 was added, and the repository was restructured to the Unified Font Repository template. The superseded `.sfd` sources and legacy build cruft were retired.
 
-- The GitHub repo returns HTTP 200 and is accessible.
-- The repo was created on 2014-07-16 and last pushed on 2014-10-17.
-- The repo contains matching source files (SFD, VFB) and the same FONTLOG.txt, DESCRIPTION.en_us.html, and OFL.txt files found in `ofl/cantataone/` in google/fonts.
-- The librefonts organization hosts many Google Fonts family repos in a decomposed TTX format used by the fontc_crater_cache system.
+## Final state
 
-The font was originally hosted on Google Code (referenced in the DESCRIPTION.en_us.html: "Source files are available from Google Code") before being migrated to the librefonts GitHub organization.
-
-## How the Commit Hash Was Identified
-
-The upstream repository contains exactly **one commit**: `947c3dd6e969867a02166335a27c48c0a7f9123d`.
-
-- **Commit date**: 2014-10-17 13:32:04 +0300
-- **Author**: hash3g <hash.3g@gmail.com>
-- **Message**: "update .travis.yml"
-- Despite the commit message referencing only `.travis.yml`, this is the initial (and only) commit that created the entire repository with all files.
-
-Since there is only a single commit, it is unambiguously the correct reference point. The font binary in google/fonts was part of the initial google/fonts repository commit (`90abd17b4`, dated 2015-03-07) and has never been updated since. The font was added to Google Fonts on 2012-02-29 (per METADATA.pb `date_added`), predating the GitHub repo creation (2014-07-16), indicating the original source was on Google Code.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository, and no override `config.yaml` exists in the google/fonts family directory (`ofl/cantataone/`).
-
-The upstream repo contains only legacy source formats:
-- `src/CantataOne-Regular.vfb` -- FontLab VFB (original source with contour overlaps)
-- `src/CantataOne-Regular-OTF.sfd` -- FontForge SFD (merged contours, OTF-targeted)
-- `src/CantataOne-Regular-TTF.sfd` -- FontForge SFD (TrueType outlines with hinting)
-
-These formats are **not compatible with gftools-builder**. A config.yaml cannot be meaningfully created because gftools-builder requires `.glyphs`, `.ufo`, or `.designspace` source files. The sources would need to be converted to a modern format before a config.yaml could be useful.
+The repository builds `CantataOne-Regular.ttf` from `.glyphs` sources with gftools-builder3 and fontc. METADATA.pb now points at the modernized repository and records the build configuration.
 
 ## Verification
 
-- Commit exists in upstream repo: **Yes**
-- Commit date: 2014-10-17 13:32:04 +0300
-- Commit message: "update .travis.yml"
-- Source files at commit:
-  - `src/CantataOne-Regular.vfb` (FontLab binary)
-  - `src/CantataOne-Regular-OTF.sfd` (FontForge Spline Font Database)
-  - `src/CantataOne-Regular-TTF.sfd` (FontForge Spline Font Database)
-  - `src/CantataOne-Regular.otf.*` (decomposed OTF TTX tables)
-  - `CantataOne-Regular.ttf.*` (decomposed TTF TTX tables)
-  - `.travis.yml` (fontbakery CI config)
-  - `FONTLOG.txt`, `DESCRIPTION.en_us.html`, `OFL.txt`, `METADATA.json`
+The freshly built `CantataOne-Regular.ttf` was compared against the binary currently shipped in google/fonts. The result is FUNCTIONAL parity: character-map coverage and per-weight metrics match. The only difference is that 23 glyphs were renamed to their production names, which leaves the encoded coverage unchanged. No blocking differences were found.
 
-## Additional Notes
+## Original repository (dormant)
 
-- The font was designed by Joana Maria Correia da Silva and mastered by Eben Sorkin (Sorkin Type Co).
-- Version 1.002 is the latest, with hinting added via TTFAutohint v0.8 (per FONTLOG.txt).
-- The `.travis.yml` references fontbakery-build.py and fontbakery-report.py, vintage CI tooling from 2014.
-- The METADATA.pb in google/fonts has no `source { }` block.
-- The font has never been updated in google/fonts since the initial repository commit.
-
-## Confidence
-
-**HIGH**: The upstream repository has a single commit, making identification unambiguous. The repository URL is confirmed accessible and contains matching source files. The status is "missing_config" because the sources are in legacy formats (SFD/VFB) that are not compatible with gftools-builder, so no config.yaml can be created without first converting the sources to a modern format.
+The original upstream lives at https://github.com/librefonts/cantataone (branch `master`). Its latest commit is `947c3dd6e969867a02166335a27c48c0a7f9123d`, which is also the commit from which the shipped binary was onboarded. That repository is now dormant; ongoing maintenance moves to the modernized fork.

--- a/ofl/carterone/METADATA.pb
+++ b/ofl/carterone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-05-04"
 source {
-  repository_url: "https://github.com/librefonts/carterone"
-  commit: "9943144e585a736a95509a85b92fbf2bb29060c2"
+  repository_url: "https://github.com/googlefonts/carterone"
+  commit: "dfb0d97f8eb2fa66680b6098cdde15277b069b2b"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/CarterOne-Regular.ttf"
+    dest_file: "CarterOne.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/carterone/upstream_info.md
+++ b/ofl/carterone/upstream_info.md
@@ -1,61 +1,26 @@
-# Investigation: Carter One
+# Carter One
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Carter One |
-| Designer | Vernon Adams |
-| License | OFL |
-| Date Added | 2011-05-04 |
-| Repository URL | https://github.com/librefonts/carterone |
-| Commit Hash | `9943144e585a736a95509a85b92fbf2bb29060c2` |
-| Branch | master |
-| Config YAML | None |
-| Override Config | No |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Carter One (Regular) built from FontForge SFD sources at https://github.com/librefonts/carterone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/carterone` was recorded in the tracking data and added to the METADATA.pb source block in commit `9a14639f3` on branch `sources_info_2026-02-25` (not yet merged to main). This is a librefonts mirror repository.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source (`CarterOne-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- During conversion the outlines were mapped to standard production glyph names and the FontForge legacy `.null` glyph was dropped.
+- A new Unified Font Repository was created at https://github.com/googlefonts/carterone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The commit hash `9943144e585a736a95509a85b92fbf2bb29060c2` is the HEAD (and only) commit of the upstream repository, with the message "update .travis.yml". The repository has only a single commit.
+## Final state
 
-The font was part of the initial google/fonts commit (`90abd17b4`). No subsequent updates to the font binary have been made in google/fonts -- the TTF has remained unchanged since the initial commit.
+The source now lives at https://github.com/googlefonts/carterone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- **Commit exists in upstream repo**: Yes. `9943144` is the HEAD and sole commit.
-- **Repository accessible**: Yes, cached at `upstream_repos/fontc_crater_cache/librefonts/carterone/`.
-- **Source files present**: The `src/` directory contains:
-  - `CarterOne-TTF.sfd` -- FontForge SFD format (buildable)
-  - `CarterOne.vfb` -- FontLab Studio binary format (not buildable by gftools-builder)
-  - `METADATA_comments.txt` and `VERSIONS.txt` -- documentation files
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only differences are benign: the FontForge legacy `.null` glyph was dropped, and 6 glyphs were renamed to standard production names with Unicode coverage unchanged.
 
-## Config YAML Status
+## Original repository (dormant)
 
-**SFD source available but no config.yaml.** Unlike the Carrois Gothic families which only have VFB files, Carter One has an SFD (FontForge Spline Font Database) file at `src/CarterOne-TTF.sfd`. SFD files can potentially be used with gftools-builder.
-
-However, no config.yaml exists in the upstream repository, and no override config.yaml exists in the google/fonts family directory.
-
-An override config.yaml could be created with:
-
-```yaml
-buildVariable: false
-sources:
-  - src/CarterOne-TTF.sfd
-```
-
-This would make the family buildable, similar to what was done for Carme.
-
-## Confidence Level
-
-**HIGH** -- The commit hash is the only commit in the single-commit repository. The repository URL is a standard librefonts mirror. The font binary in google/fonts has been unchanged since the initial commit, consistent with using the HEAD of the upstream.
-
-## Open Questions
-
-- An override config.yaml could be created in google/fonts to make this family buildable from SFD sources. This would change the status from `missing_config` to `complete`.
-- It should be verified that building from the SFD source produces output matching (or acceptably close to) the current binary in google/fonts before creating such an override.
-- Vernon Adams, the original designer, passed away in 2014. Any updates to this font would need to be handled by the community.
+The original FontForge sources are at https://github.com/librefonts/carterone (`.sfd`), latest at commit `9943144e585a736a95509a85b92fbf2bb29060c2`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/cevicheone/METADATA.pb
+++ b/ofl/cevicheone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-12-07"
 source {
-  repository_url: "https://github.com/librefonts/cevicheone"
-  commit: "afec42c6e7445edd88c3f45b7a51b5da6b43b027"
+  repository_url: "https://github.com/googlefonts/cevicheone"
+  commit: "1af833a0fd47b174386916453a54e6bf1f6d5a34"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/CevicheOne-Regular.ttf"
+    dest_file: "CevicheOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/cevicheone/upstream_info.md
+++ b/ofl/cevicheone/upstream_info.md
@@ -1,51 +1,26 @@
 # Ceviche One
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: Miguel Hernandez
-**METADATA.pb path**: `ofl/cevicheone/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/cevicheone |
-| Commit | `afec42c6e7445edd88c3f45b7a51b5da6b43b027` |
-| Config YAML | N/A (SFD-only sources) |
-| Branch | `master` |
+Google Fonts shipped Ceviche One (Regular) built from FontForge SFD sources at https://github.com/librefonts/cevicheone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/cevicheone` was already documented in the tracking data. It was added to METADATA.pb in commit `9a14639f3` ("Add source blocks to 602 more METADATA.pb files", 2026-02-25). The repository is part of the `librefonts` GitHub organization which hosts many Google Fonts upstream sources. Note that the METADATA.pb currently has no `source { }` block in the live version -- the source block was added as part of a batch enrichment.
+- The canonical FontForge SFD source (`src/CevicheOne-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A non-breaking space (U+00A0) was added to the converted source, restoring a glyph that FontForge used to synthesise at export time.
+- A new Unified Font Repository was created at https://github.com/googlefonts/cevicheone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The commit `afec42c6e7445edd88c3f45b7a51b5da6b43b027` is the **only commit** in the upstream repository (message: "update .travis.yml"). This is a single-commit repository, making the hash unambiguous. The font files in google/fonts were last updated in commit `08e091b33` (2015-04-27, "Updating ofl/cevicheone/*ttf with nbspace and fsType fixes") by Dave Crossland, which was a minor binary fix. The original font was added in the initial commit `90abd17b4`.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository, and no override `config.yaml` exists in the google/fonts family directory (`ofl/cevicheone/`).
-
-The upstream repository contains only legacy source formats:
-- `src/CevicheOne-Regular-TTF.sfd` (FontForge SFD format)
-- `src/CevicheOne-Regular-OTF.vfb` (FontLab VFB format)
-- Various TTX decomposition files
-
-Neither SFD nor VFB formats are compatible with gftools-builder. A `config.yaml` cannot be created without first converting the sources to a modern format (`.glyphs` or `.ufo`).
+The source now lives at https://github.com/googlefonts/cevicheone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- Repository URL accessible: Yes
-- Commit exists in upstream repo: Yes (it is the only commit)
-- Commit date: Not explicitly dated in log, but the repo has only this one commit
-- Commit message: "update .travis.yml"
-- Source files at commit: `src/CevicheOne-Regular-TTF.sfd`, `src/CevicheOne-Regular-OTF.vfb`
+The newly built Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference was that 8 glyphs were renamed to their production names; coverage was unchanged, so the verdict is functional equivalence.
 
-## Confidence
+## Original repository (dormant)
 
-**High**: The repository URL and commit hash are straightforward -- the repo has only one commit. The URL is confirmed by its presence in the librefonts organization. The lack of config.yaml is expected given the legacy source formats (SFD/VFB only).
-
-## Open Questions
-
-1. The sources are in legacy formats (SFD and VFB). To enable gftools-builder builds, these would need to be converted to `.glyphs` or `.ufo` format. This is not a trivial conversion and may require manual review by a type designer.
-2. The family was added to Google Fonts in 2011 (date_added: 2011-12-07). The upstream repository appears to be a post-hoc archive rather than the original development location.
+The original FontForge sources are at https://github.com/librefonts/cevicheone (`.sfd`), latest at commit `afec42c6e7445edd88c3f45b7a51b5da6b43b027`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/chango/METADATA.pb
+++ b/ofl/chango/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-12-13"
 source {
-  repository_url: "https://github.com/librefonts/chango"
-  commit: "ca58222d6319223db35d6e76052ef9a78cca43f7"
+  repository_url: "https://github.com/googlefonts/chango"
+  commit: "fed28f46958e46610efc52780476adcfc91745e6"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Chango-Regular.ttf"
+    dest_file: "Chango-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/chango/upstream_info.md
+++ b/ofl/chango/upstream_info.md
@@ -1,54 +1,31 @@
 # Chango
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: Fontstage
-**METADATA.pb path**: `ofl/chango/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/chango |
-| Commit | `ca58222d6319223db35d6e76052ef9a78cca43f7` |
-| Config YAML | N/A (SFD-only sources) |
-| Branch | `master` |
+The family shipped from a FontForge project (`src/Chango-Regular-TTF.sfd`) with no gftools-builder configuration. METADATA.pb pointed at the librefonts repository but recorded no config_yaml, so the family could not be rebuilt with the current pipeline.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/chango` was already documented in the tracking data. It was added to METADATA.pb in commit `9a14639f3` ("Add source blocks to 602 more METADATA.pb files", 2026-02-25). The repository is part of the `librefonts` GitHub organization which hosts many Google Fonts upstream sources.
+The repository adopted the Unified Font Repository template. The FontForge source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), producing `sources/Chango-Regular.glyphs`, and a gftools-builder configuration was added. The no-break space (U+00A0) advance width was corrected to 400 to match the space glyph. The superseded FontForge sources and legacy build cruft were retired.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The commit `ca58222d6319223db35d6e76052ef9a78cca43f7` is the **only commit** in the upstream repository (2014-10-17, "update .travis.yml"). This is a single-commit repository, making the hash unambiguous.
-
-The font files in google/fonts have never been updated since the initial commit `90abd17b4`. The font was added to Google Fonts on 2011-12-13 (date_added field).
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository, and no override `config.yaml` exists in the google/fonts family directory (`ofl/chango/`).
-
-The upstream repository contains only legacy source formats:
-- `src/Chango-Regular-TTF.sfd` (FontForge SFD format)
-- `src/Chango-Regular-OTF.vfb` (FontLab VFB format)
-- Various TTX decomposition files
-
-Neither SFD nor VFB formats are compatible with gftools-builder. A `config.yaml` cannot be created without first converting the sources to a modern format (`.glyphs` or `.ufo`).
+The repository builds Chango Regular from the `.glyphs` source with gftools-builder3 and fontc, driven by its build configuration.
 
 ## Verification
 
-- Repository URL accessible: Yes
-- Commit exists in upstream repo: Yes (it is the only commit)
-- Commit date: 2014-10-17 13:32:32 +0300
-- Commit message: "update .travis.yml"
-- Source files at commit: `src/Chango-Regular-TTF.sfd`, `src/Chango-Regular-OTF.vfb`
+The freshly built Chango Regular was compared against the binary currently shipped in Google Fonts. Glyph coverage, metrics and layout matched; the verdict was FUNCTIONAL with only benign differences:
 
-## Confidence
+- The FontForge legacy glyph `nonmarkingreturn` was dropped (FontForge synthesised it at export time; it carries no rendering meaning).
+- 13 glyphs were renamed to their AGL production names; coverage was unchanged.
+- The GDEF table now classifies two real combining marks that the shipped font missed (U+0307, U+0326).
+- One combining mark (U+0307) was zero-width, whereas the shipped font gave it a spacing advance.
 
-**High**: The repository URL and commit hash are straightforward -- the repo has only one commit. The URL is confirmed by its presence in the librefonts organization. The lack of config.yaml is expected given the legacy source formats (SFD/VFB only).
+No blocking differences were found.
 
-## Open Questions
+## Original repository (dormant)
 
-1. The sources are in legacy formats (SFD and VFB). To enable gftools-builder builds, these would need to be converted to `.glyphs` or `.ufo` format. This is not a trivial conversion and may require manual review by a type designer.
-2. The family was added to Google Fonts in 2011 (date_added: 2011-12-13). The upstream repository appears to be a post-hoc archive created in 2014, rather than the original development location.
-3. The designer "Fontstage" does not appear to have an active online presence. Any source conversion work would likely need to be done by the Google Fonts team.
+Original upstream: https://github.com/librefonts/chango
+Latest commit: ca58222d6319223db35d6e76052ef9a78cca43f7 (branch `master`)

--- a/ofl/chauphilomeneone/METADATA.pb
+++ b/ofl/chauphilomeneone/METADATA.pb
@@ -4,8 +4,22 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2012-04-04"
 source {
-  repository_url: "https://github.com/librefonts/chauphilomeneone"
-  commit: "ac51123e5c7a33cd48b4fdf686b91922ea68c422"
+  repository_url: "https://github.com/googlefonts/chauphilomeneone"
+  commit: "d7246600bbdfd898596bb8ebab13c484e5b21a55"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/ChauPhilomeneOne-Italic.ttf"
+    dest_file: "ChauPhilomeneOne-Italic.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/ChauPhilomeneOne-Regular.ttf"
+    dest_file: "ChauPhilomeneOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/chauphilomeneone/upstream_info.md
+++ b/ofl/chauphilomeneone/upstream_info.md
@@ -1,50 +1,25 @@
-# Investigation: Chau Philomene One
+# Chau Philomene One
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Chau Philomene One |
-| Designer | Vicente Lamonaca |
-| License | OFL |
-| Date Added | 2012-04-04 |
-| Repository URL | https://github.com/librefonts/chauphilomeneone |
-| Commit | `ac51123e5c7a33cd48b4fdf686b91922ea68c422` |
-| Branch | master |
-| Config YAML | None (not applicable) |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Chau Philomene One (Regular and Italic) built from FontForge SFD sources at https://github.com/librefonts/chauphilomeneone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/chauphilomeneone` was added to the METADATA.pb source block by commit `9a14639f3` ("Add source blocks to 602 more METADATA.pb files"). The `librefonts` organization on GitHub hosts many open-source font projects that were associated with early Google Fonts onboarding.
+## Actions taken
 
-## How Commit Determined
+- The two canonical FontForge SFD sources (`ChauPhilomeneOne-Regular-TTF.sfd` and `ChauPhilomeneOne-Italic-TTF.sfd`) were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/chauphilomeneone, building both fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-The commit `ac51123e5c7a33cd48b4fdf686b91922ea68c422` is the only commit (HEAD) in the upstream repository, dated 2014-10-17. Its message is "update .travis.yml".
+## Final state
 
-The font was originally added to google/fonts in the initial commit (`90abd17b4`), and later updated via PR #876 ("hotfix-chauphilomeneone: v1.002 added") by Marc Foley (m4rc1e) on 2017-05-08. Since the upstream repo has only one commit and it predates all google/fonts updates, this commit is unambiguously the correct reference.
-
-## Config YAML Status
-
-**Not applicable.** The upstream repository contains source files in legacy formats:
-
-- `src/ChauPhilomeneOne-Regular-TTF.sfd` and `src/ChauPhilomeneOne-Italic-TTF.sfd` (FontForge SFD format)
-- `src/ChauPhilomeneOne-Regular-OTF.vfb` and `src/ChauPhilomeneOne-Italic-OTF.vfb` (FontLab VFB format)
-- TTX decomposed font tables
-
-There are no `.glyphs`, `.ufo`, or `.designspace` files that would be compatible with gftools-builder. No `config.yaml` exists in the upstream repo or as an override in the google/fonts family directory.
+The source now lives at https://github.com/googlefonts/chauphilomeneone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
 ## Verification
 
-- **Repository URL**: Verified -- the upstream repo is cached at `upstream_repos/fontc_crater_cache/librefonts/chauphilomeneone`.
-- **Commit**: Verified as HEAD (and only commit) of the upstream repo. Predates all google/fonts updates.
-- **Source type**: SFD and VFB sources -- neither compatible with gftools-builder.
-- **No config.yaml**: Correctly absent given the source formats.
+For both Regular and Italic, the rebuilt fonts matched the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 4 glyphs were renamed to their standard production names; glyph coverage is unchanged and the difference is cosmetic to the source, so equivalence is functional.
 
-## Confidence Level
+## Original repository (dormant)
 
-**Very High** -- The repository has only one commit, making the commit reference unambiguous. The source formats (SFD, VFB) are well-documented as legacy formats.
-
-## Open Questions
-
-None. The status is correctly `missing_config` because the source formats (SFD, VFB) are not compatible with gftools-builder. No action needed unless the font is eventually migrated to a modern source format.
+The original FontForge sources are at https://github.com/librefonts/chauphilomeneone (`.sfd`), latest at commit `ac51123e5c7a33cd48b4fdf686b91922ea68c422`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/chelaone/METADATA.pb
+++ b/ofl/chelaone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2012-10-05"
 source {
-  repository_url: "https://github.com/librefonts/chelaone"
-  commit: "cb9b95fc0510c91bc45664e5a62ed3893c09bfba"
+  repository_url: "https://github.com/googlefonts/chelaone"
+  commit: "cb7da0a381984ec348a9c88e2095f9592149c838"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/ChelaOne-Regular.ttf"
+    dest_file: "ChelaOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/chelaone/upstream_info.md
+++ b/ofl/chelaone/upstream_info.md
@@ -1,59 +1,26 @@
-# Chela One - Investigation Report
+# Chela One
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| **Family Name** | Chela One |
-| **Designer** | Miguel Hernandez |
-| **License** | OFL |
-| **Category** | DISPLAY |
-| **Date Added** | 2012-10-05 |
-| **Repository URL** | https://github.com/librefonts/chelaone |
-| **Commit Hash** | cb9b95fc0510c91bc45664e5a62ed3893c09bfba |
-| **Branch** | master |
-| **Config YAML** | N/A |
-| **Status** | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Chela One (Regular) built from FontForge SFD sources at https://github.com/librefonts/chelaone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/chelaone` was identified from the librefonts organization on GitHub, which hosts mirrors/archives of many early Google Fonts families. The upstream repo is cloned at `upstream_repos/fontc_crater_cache/librefonts/chelaone/`.
+## Actions taken
 
-The repository remote confirms: `origin https://github.com/librefonts/chelaone`.
+- The canonical FontForge SFD source (`ChelaOne-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A no-break space (U+00A0) was added to the source, matching the glyph FontForge used to synthesise at export time.
+- A new Unified Font Repository was created at https://github.com/googlefonts/chelaone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## How Commit Determined
+## Final state
 
-The repository has only a single commit:
-
-```
-cb9b95f update .travis.yml
-```
-
-HEAD is `cb9b95fc0510c91bc45664e5a62ed3893c09bfba`, which is the only commit in the repository. This makes commit verification trivial -- there is only one commit, so it must be the correct one.
-
-The font was originally added to google/fonts in commit `90abd17b4` ("Initial commit") and was last updated for binary fixes in `c72712175` ("Updating ofl/chelaone/*ttf with nbspace and fsType fixes", 2015-04-27). A source block was added to METADATA.pb on a pending PR branch (`sources_info_2026-02-25`) via commit `9a14639f3`, but this has not yet been merged to google/fonts main.
-
-## Config YAML Status
-
-**No config.yaml possible.** The upstream repository contains only legacy source formats:
-- `src/ChelaOne-Regular-TTF.sfd` (FontForge SFD format)
-- `src/ChelaOne-Regular-OTF.vfb` (FontLab VFB format)
-
-Neither SFD nor VFB formats are compatible with gftools-builder. There are no `.glyphs`, `.ufo`, or `.designspace` source files. A config.yaml cannot be created without first converting the sources to a modern format.
+The source now lives at https://github.com/googlefonts/chelaone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- **Repository URL**: Verified - cloned and accessible at `upstream_repos/fontc_crater_cache/librefonts/chelaone/`
-- **Commit hash**: Verified - matches HEAD, and is the only commit in the repo
-- **Source block**: Pending merge via PR branch `sources_info_2026-02-25`
-- **METADATA.pb on main**: Currently has no source block (pending PR)
+The rebuilt Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 8 glyphs were renamed to their production names, which leaves character coverage unchanged; this is why the verdict is functional rather than byte-identical.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** for repository URL and commit hash. The librefonts repo is the recognized upstream, and with only one commit, the hash is unambiguous.
-
-**N/A** for config.yaml -- SFD-only sources make this impossible without source conversion.
-
-## Open Questions
-
-- None. This is a legacy font with SFD-only sources. It would require source conversion to a modern format (e.g., .glyphs or .ufo) before a config.yaml could be created.
+The original FontForge sources are at https://github.com/librefonts/chelaone (`.sfd`), latest at commit `cb9b95fc0510c91bc45664e5a62ed3893c09bfba`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/cherryswash/METADATA.pb
+++ b/ofl/cherryswash/METADATA.pb
@@ -4,8 +4,22 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2012-10-05"
 source {
-  repository_url: "https://github.com/librefonts/cherryswash"
-  commit: "84e28ad7cc2937ce20bac9dd6f2689cb42c6814a"
+  repository_url: "https://github.com/googlefonts/cherryswash"
+  commit: "f1c0f2dbc3f64ef4f85e54544626e6d629599e4c"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/CherrySwash-Bold.ttf"
+    dest_file: "CherrySwash-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/CherrySwash-Regular.ttf"
+    dest_file: "CherrySwash-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/cherryswash/upstream_info.md
+++ b/ofl/cherryswash/upstream_info.md
@@ -1,53 +1,26 @@
-# Cherry Swash - Investigation Report
+# Cherry Swash
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Cherry Swash |
-| Designer | Nataliya Kasatkina |
-| License | OFL |
-| Date Added | 2012-10-05 |
-| Repository URL | https://github.com/librefonts/cherryswash |
-| Commit | `84e28ad7cc2937ce20bac9dd6f2689cb42c6814a` |
-| Branch | master |
-| Config YAML | N/A |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Cherry Swash (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/cherryswash. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/cherryswash` was already documented in the tracking data. This is a librefonts mirror repository containing the font sources. The repo contains SFD (FontForge) and VFB source files along with TTX decompositions.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD sources (`CherrySwash-Regular-TTF.sfd` and `CherrySwash-Bold-TTF.sfd`) were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- U+00A0 (no-break space) was added to both sources, since FontForge used to synthesise it at export time, and the Bold source had its OS/2 usWeightClass set to 700.
+- A new Unified Font Repository was created at https://github.com/googlefonts/cherryswash, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-The upstream repository has only a single commit:
-- `84e28ad7cc2937ce20bac9dd6f2689cb42c6814a` (2014-10-17) - "update .travis.yml"
+## Final state
 
-This is the one and only commit in the repository, so it is trivially the correct commit reference. The source block was added to METADATA.pb in commit `9a14639f3` as part of a batch update adding source blocks to 602 families.
-
-## Config YAML Status
-
-**No config.yaml exists** - neither in the upstream repository nor as an override in the google/fonts family directory.
-
-The upstream repo contains only legacy source formats:
-- `src/CherrySwash-Regular-TTF.sfd` (FontForge SFD)
-- `src/CherrySwash-Bold-TTF.sfd` (FontForge SFD)
-- `src/CherrySwash-Regular-OTF.vfb` (FontLab VFB)
-- `src/CherrySwash-Bold-OTF.vfb` (FontLab VFB)
-
-These formats are not compatible with gftools-builder, which requires `.glyphs`, `.glyphx`, `.ufo`, or `.designspace` sources. No config.yaml can be created without first converting the sources to a modern format.
+The source now lives at https://github.com/googlefonts/cherryswash (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
 ## Verification
 
-- Repository URL verified: accessible at https://github.com/librefonts/cherryswash
-- Commit hash verified: matches the only commit in the repository
-- Font files last modified in google/fonts: `35089d38b` (2015-04-27) - "nbspace and fsType fixes"
-- No source block exists in the current METADATA.pb on main (the batch update `9a14639f3` is in a pending PR branch)
+Both weights matched the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 8 glyphs were renamed to their production names; character coverage is unchanged, so the difference is cosmetic.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** - Repository URL and commit hash are definitively correct. The repo has only one commit, making verification trivial. The missing_config status is accurate since only SFD/VFB sources exist.
-
-## Open Questions
-
-None. This family cannot have a config.yaml without source format conversion.
+The original FontForge sources are at https://github.com/librefonts/cherryswash (`.sfd`), latest at commit `84e28ad7cc2937ce20bac9dd6f2689cb42c6814a`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/chicle/METADATA.pb
+++ b/ofl/chicle/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-11-30"
 source {
-  repository_url: "https://github.com/librefonts/chicle"
-  commit: "4ee3e89dbbdcfc0d56f7e1e3cc3d2de009219502"
+  repository_url: "https://github.com/googlefonts/chicle"
+  commit: "f68c0fa9e45e089b7cb3fb7bbef873b9e7bf8123"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Chicle-Regular.ttf"
+    dest_file: "Chicle-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/chicle/upstream_info.md
+++ b/ofl/chicle/upstream_info.md
@@ -1,51 +1,23 @@
-# Chicle - Investigation Report
+# Chicle
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Chicle |
-| Designer | Sudtipos (Angel Koziupa, Alejandro Paul) |
-| License | OFL |
-| Date Added | 2011-11-30 |
-| Repository URL | https://github.com/librefonts/chicle |
-| Commit | `4ee3e89dbbdcfc0d56f7e1e3cc3d2de009219502` |
-| Branch | master |
-| Config YAML | N/A |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+The family shipped from FontForge `.sfd` sources with no gftools-builder configuration. METADATA.pb pointed at the librefonts mirror with an onboarding commit but no config_yaml, so the family could not be rebuilt with the current pipeline.
 
-The repository URL `https://github.com/librefonts/chicle` was already documented in the tracking data. This is a librefonts mirror repository containing the font sources. The repo contains SFD (FontForge) and VFB source files along with TTX decompositions.
+## Actions taken
 
-## How Commit Determined
+The FontForge source `src/Chicle-Regular-TTF.sfd` was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), producing `sources/Chicle-Regular.glyphs`. During conversion 4 stray NUL bytes were stripped and a U+00A0 no-break space glyph was added, which FontForge used to synthesise at export time. A build configuration was added so the family builds with gftools-builder3 and fontc.
 
-The upstream repository has only a single commit:
-- `4ee3e89dbbdcfc0d56f7e1e3cc3d2de009219502` (2014-10-17) - "update .travis.yml"
+## Final state
 
-This is the one and only commit in the repository, so it is trivially the correct commit reference. The source block was added to METADATA.pb in commit `9a14639f3` as part of a batch update adding source blocks to 602 families.
-
-## Config YAML Status
-
-**No config.yaml exists** - neither in the upstream repository nor as an override in the google/fonts family directory.
-
-The upstream repo contains only legacy source formats:
-- `src/Chicle-Regular-TTF.sfd` (FontForge SFD)
-- `src/Chicle-Regular-OTF.vfb` (FontLab VFB)
-
-These formats are not compatible with gftools-builder, which requires `.glyphs`, `.glyphx`, `.ufo`, or `.designspace` sources. No config.yaml can be created without first converting the sources to a modern format.
+The repository was adopted into the Unified Font Repository template and now builds Chicle-Regular from the `.glyphs` source. The superseded `.sfd` sources and legacy build cruft were retired.
 
 ## Verification
 
-- Repository URL verified: accessible at https://github.com/librefonts/chicle
-- Commit hash verified: matches the only commit in the repository
-- Font files last modified in google/fonts: `b736f39c3` (2015-04-27) - "nbspace and fsType fixes"
-- No source block exists in the current METADATA.pb on main (the batch update `9a14639f3` is in a pending PR branch)
+The Rust-built `Chicle-Regular.ttf` was compared against the shipped binary. Codepoint coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths all agreed; the verdict is FUNCTIONAL. The only difference is benign: 7 glyphs were renamed to their production names, which leaves the codepoint coverage unchanged.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** - Repository URL and commit hash are definitively correct. The repo has only one commit, making verification trivial. The missing_config status is accurate since only SFD/VFB sources exist.
-
-## Open Questions
-
-None. This family cannot have a config.yaml without source format conversion.
+Original upstream: https://github.com/librefonts/chicle (branch `master`), latest commit `4ee3e89dbbdcfc0d56f7e1e3cc3d2de009219502`. This was also the onboarding commit recorded in the previous METADATA.pb source block.

--- a/ofl/concertone/METADATA.pb
+++ b/ofl/concertone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-11-23"
 source {
-  repository_url: "https://github.com/librefonts/concertone"
-  commit: "c2160f498dbb0ebf8394fbd117c21d2160cdef01"
+  repository_url: "https://github.com/googlefonts/concertone"
+  commit: "b002b9370c7365b13d6a79e4718eb6aa8e3d0dc6"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/ConcertOne-Regular.ttf"
+    dest_file: "ConcertOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/concertone/upstream_info.md
+++ b/ofl/concertone/upstream_info.md
@@ -1,47 +1,26 @@
-# Concert One - Investigation Report
+# Concert One
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Concert One |
-| Designer | Johan Kallas, Mihkel Virkus |
-| Repository URL | https://github.com/librefonts/concertone |
-| Commit | c2160f498dbb0ebf8394fbd117c21d2160cdef01 |
-| Branch | master |
-| Config YAML | N/A (SFD-only sources) |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Concert One (Regular) built from FontForge SFD sources at https://github.com/librefonts/concertone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/concertone` was identified from the librefonts organization, which hosts mirrored source repositories for many early Google Fonts families. The initial bulk PR [#10270](https://github.com/google/fonts/pull/10270) ("Add source blocks to 602 more METADATA.pb files", branch `sources_info_2026-02-25`, commit `9a14639f3`) was closed without merge. The follow-up [PR #10271](https://github.com/google/fonts/pull/10271), which split the changes into one commit per family on branch `sources_per_family_2026-02-26`, was merged on 2026-02-26; the Concert One source block was added by commit `56d250fda` in that PR.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source (`ConcertOne-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- Seven glyphs were renamed to their production names during conversion; character coverage was unchanged.
+- A new Unified Font Repository was created at https://github.com/googlefonts/concertone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The commit `c2160f498dbb0ebf8394fbd117c21d2160cdef01` is the HEAD (and only commit in the shallow clone) of the `librefonts/concertone` repository. The commit message is "update .travis.yml". This is a standard librefonts repo pattern where the single visible commit represents the latest state of the source archive.
+## Final state
 
-## Config YAML Status
-
-No config.yaml exists in the upstream repository. The source files are:
-- `src/ConcertOne-Regular-TTF.sfd` (FontForge SFD format)
-- `src/ConcertOne-Regular-OTF.vfb` (FontLab VFB format)
-
-These formats are not compatible with gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` sources. No override config.yaml exists in the google/fonts family directory either.
+The source now lives at https://github.com/googlefonts/concertone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- Repository URL returns HTTP 200
-- Commit hash matches the HEAD of the cached repo
-- The font binary in google/fonts was last modified by a v-metrics hotfix (commit `dc96bd2ff`, May 2024, by Emma Marichal) applied directly to the binary - no upstream source changes
-- Source block exists in main-branch METADATA.pb, added via [PR #10271](https://github.com/google/fonts/pull/10271) (merge commit `bb77776a5`)
+Identical to the shipped ConcertOne-Regular.ttf on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that seven glyphs were renamed to production names, which leaves character coverage unchanged; the result is accepted as functionally equivalent.
 
-## Confidence Level
+## Original repository (dormant)
 
-**High** for repository URL and commit hash. The librefonts repo is the canonical source archive.
-
-**N/A** for config.yaml - the sources are in legacy formats (SFD/VFB) not supported by gftools-builder.
-
-## Open Questions
-
-1. The v-metrics hotfix was applied directly to the binary in google/fonts without corresponding upstream changes. Should this be documented more formally?
-2. Would it be worthwhile to convert the SFD sources to a gftools-builder compatible format?
+The original FontForge sources are at https://github.com/librefonts/concertone (`.sfd`), latest at commit `c2160f498dbb0ebf8394fbd117c21d2160cdef01`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/condiment/METADATA.pb
+++ b/ofl/condiment/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "HANDWRITING"
 date_added: "2012-01-25"
 source {
-  repository_url: "https://github.com/librefonts/condiment"
-  commit: "0a1933e09c9008136f997c47c75ddf6b00a8d884"
+  repository_url: "https://github.com/googlefonts/condiment"
+  commit: "a89340dd6409f34edd3d00dba5326e870b910f2a"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Condiment-Regular.ttf"
+    dest_file: "Condiment-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/condiment/upstream_info.md
+++ b/ofl/condiment/upstream_info.md
@@ -1,47 +1,25 @@
-# Condiment - Investigation Report
+# Condiment
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Condiment |
-| Designer | Sudtipos (Angel Koziupa, Alejandro Paul) |
-| Repository URL | https://github.com/librefonts/condiment |
-| Commit | 0a1933e09c9008136f997c47c75ddf6b00a8d884 |
-| Branch | master |
-| Config YAML | N/A (SFD-only sources) |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Condiment (Regular) built from FontForge SFD sources at https://github.com/librefonts/condiment. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/condiment` was identified from the librefonts organization. The initial bulk PR [#10270](https://github.com/google/fonts/pull/10270) ("Add source blocks to 602 more METADATA.pb files", branch `sources_info_2026-02-25`, commit `9a14639f3`) was closed without merge. The follow-up [PR #10271](https://github.com/google/fonts/pull/10271), which split the changes into one commit per family on branch `sources_per_family_2026-02-26`, was merged on 2026-02-26; the Condiment source block was added by commit `48f72851f` in that PR.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source (`Condiment-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`). During conversion four glyphs were given their standard production names, leaving codepoint coverage unchanged.
+- A new Unified Font Repository was created at https://github.com/googlefonts/condiment, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The commit `0a1933e09c9008136f997c47c75ddf6b00a8d884` is the HEAD (and only commit in the shallow clone) of the `librefonts/condiment` repository. The commit message is "update .travis.yml". This follows the standard librefonts repo pattern.
+## Final state
 
-## Config YAML Status
-
-No config.yaml exists in the upstream repository. The source files are:
-- `src/Condiment-Regular-TTF.sfd` (FontForge SFD format)
-- `src/Condiment-Regular-OTF.vfb` (FontLab VFB format)
-
-These formats are not compatible with gftools-builder. No override config.yaml exists in the google/fonts family directory.
+The source now lives at https://github.com/googlefonts/condiment (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- Repository URL returns HTTP 200
-- Commit hash matches the HEAD of the cached repo
-- The font binary has never been updated since the initial commit and the deploy commit
-- Added to Google Fonts on 2012-01-25
-- Source block exists in main-branch METADATA.pb, added via [PR #10271](https://github.com/google/fonts/pull/10271) (merge commit `bb77776a5`)
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that four glyphs were renamed to their production names; the set of encoded codepoints is unchanged, so this is accepted as functionally equivalent.
 
-## Confidence Level
+## Original repository (dormant)
 
-**High** for repository URL and commit hash.
-
-**N/A** for config.yaml - the sources are in legacy formats (SFD/VFB) not supported by gftools-builder.
-
-## Open Questions
-
-None. This is a straightforward legacy font with SFD-only sources in a standard librefonts archive repository.
+The original FontForge sources are at https://github.com/librefonts/condiment (`.sfd`), latest at commit `0a1933e09c9008136f997c47c75ddf6b00a8d884`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/contrailone/METADATA.pb
+++ b/ofl/contrailone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2011-10-26"
 source {
-  repository_url: "https://github.com/librefonts/contrailone"
-  commit: "21ed60440130b6afcdd5e7555e9fe7c8c4344146"
+  repository_url: "https://github.com/googlefonts/contrailone"
+  commit: "755f2a5959072b2ce7e09b555cc55917bf3c7ce0"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/ContrailOne-Regular.ttf"
+    dest_file: "ContrailOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/contrailone/upstream_info.md
+++ b/ofl/contrailone/upstream_info.md
@@ -1,49 +1,25 @@
-# Contrail One - Investigation Report
+# Contrail One
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Contrail One |
-| Designer | Riccardo De Franceschi |
-| Repository URL | https://github.com/librefonts/contrailone |
-| Commit | 21ed60440130b6afcdd5e7555e9fe7c8c4344146 |
-| Branch | master |
-| Config YAML | N/A (SFD-only sources) |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Contrail One (Regular) built from FontForge SFD sources at https://github.com/librefonts/contrailone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/contrailone` was identified from the librefonts organization. The initial bulk PR [#10270](https://github.com/google/fonts/pull/10270) ("Add source blocks to 602 more METADATA.pb files", branch `sources_info_2026-02-25`, commit `9a14639f3`) was closed without merge. The follow-up [PR #10271](https://github.com/google/fonts/pull/10271), which split the changes into one commit per family on branch `sources_per_family_2026-02-26`, was merged on 2026-02-26; the Contrail One source block was added by commit `6c7562912` in that PR.
+## Actions taken
 
-The copyright in METADATA.pb mentions Sorkin Type Co (Eben Sorkin) as the foundry.
+- The canonical FontForge SFD source (`src/ContrailOne-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/contrailone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## How Commit Determined
+## Final state
 
-The commit `21ed60440130b6afcdd5e7555e9fe7c8c4344146` is the HEAD (and only commit in the shallow clone) of the `librefonts/contrailone` repository. The commit message is "update .travis.yml". This follows the standard librefonts repo pattern.
-
-## Config YAML Status
-
-No config.yaml exists in the upstream repository. The source files are:
-- `src/ContrailOne-Regular-TTF.sfd` (FontForge SFD format)
-- `src/ContrailOne-Regular.vfb` (FontLab VFB format)
-
-These formats are not compatible with gftools-builder. No override config.yaml exists in the google/fonts family directory.
+The source now lives at https://github.com/googlefonts/contrailone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- Repository URL returns HTTP 200 (inferred from successful git clone in cache)
-- Commit hash matches the HEAD of the cached repo
-- The font binary has never been updated since the initial commit and the deploy commit
-- Added to Google Fonts on 2011-10-26
-- Source block exists in main-branch METADATA.pb, added via [PR #10271](https://github.com/google/fonts/pull/10271) (merge commit `bb77776a5`)
+The rebuilt Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets and advance widths. Three accepted differences remain: the two non-encoded FontForge legacy glyphs (`.null`, `nonmarkingreturn`) were dropped; 8 glyphs were renamed to production names with no change to coverage; and the GDEF table now classifies `uni0326` as a combining mark, which the shipped font had missed.
 
-## Confidence Level
+## Original repository (dormant)
 
-**High** for repository URL and commit hash.
-
-**N/A** for config.yaml - the sources are in legacy formats (SFD/VFB) not supported by gftools-builder.
-
-## Open Questions
-
-None. This is a straightforward legacy font with SFD/VFB sources in a standard librefonts archive repository.
+The original FontForge sources are at https://github.com/librefonts/contrailone (`.sfd`), latest at commit `21ed60440130b6afcdd5e7555e9fe7c8c4344146`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/convergence/METADATA.pb
+++ b/ofl/convergence/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2011-11-09"
 source {
-  repository_url: "https://github.com/librefonts/convergence"
-  commit: "475145997c07041d94fabe462233b89f15450a41"
+  repository_url: "https://github.com/googlefonts/convergence"
+  commit: "0f57768c9ddc32b357bf4d32897b8ea4e846d71e"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Convergence-Regular.ttf"
+    dest_file: "Convergence-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/convergence/upstream_info.md
+++ b/ofl/convergence/upstream_info.md
@@ -1,45 +1,25 @@
 # Convergence
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Convergence |
-| Repository URL | https://github.com/librefonts/convergence |
-| Commit Hash | `475145997c07041d94fabe462233b89f15450a41` |
-| Branch | master |
-| Config YAML | N/A (SFD-only sources) |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Convergence (Regular) built from FontForge SFD sources at https://github.com/librefonts/convergence. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/convergence` is part of the librefonts GitHub organization, which hosts archival copies of early Google Fonts projects. The URL was already documented in the tracking data and matches the git remote of the cached upstream repo at `upstream_repos/fontc_crater_cache/librefonts/convergence`.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source (`src/Convergence-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/convergence, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The upstream repository contains exactly **one commit**: `475145997c07041d94fabe462233b89f15450a41` ("update .travis.yml"). Since this is the only commit in the repository, it is trivially the correct reference. The librefonts repos were created as archival snapshots of the font projects' state when they were onboarded to Google Fonts.
+## Final state
 
-The font file in google/fonts (`Convergence-Regular.ttf`) was added only in the initial commit (`90abd17b4`, 2015-03-07) and has never been modified since on the main branch.
-
-## Config YAML Status
-
-**No config.yaml exists** in the upstream repository. The source files are:
-- `src/Convergence-Regular-TTF.sfd` (FontForge SFD format)
-- `src/Convergence-Regular.vfb` (FontLab VFB format)
-
-These are legacy font formats that are **not compatible with gftools-builder**. No override `config.yaml` exists in the google/fonts family directory either.
+The source now lives at https://github.com/googlefonts/convergence (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- **Repository accessible**: Yes (verified via git remote URL)
-- **Commit hash valid**: Yes - matches the only commit in the repo
-- **Font file unchanged since onboarding**: Yes - only modified in initial commit on main
-- **Source block in METADATA.pb**: Pending (exists on feature branch `sources_info_2026-02-25`, not yet merged to main)
+The rebuilt Convergence-Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle and GSUB/GPOS feature sets. The accepted differences are all benign: 9 glyphs were renamed to their production names (coverage unchanged), the FontForge legacy glyph `nonmarkingreturn` was dropped, GDEF now classifies three real combining marks that the shipped font had missed (uni0307, uni0307.cap, uni0326), and one combining mark (U+0307) was zeroed to remove the spurious spacing advance FontForge had given it.
 
-## Confidence Level
+## Original repository (dormant)
 
-**High** - Single-commit librefonts archival repository. The commit hash is unambiguous.
-
-## Open Questions
-
-None. The family has SFD-only sources and cannot be rebuilt with gftools-builder without a source format conversion.
+The original FontForge sources are at https://github.com/librefonts/convergence (`.sfd`), latest at commit `475145997c07041d94fabe462233b89f15450a41`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/cookie/METADATA.pb
+++ b/ofl/cookie/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "HANDWRITING"
 date_added: "2011-10-12"
 source {
-  repository_url: "https://github.com/librefonts/cookie"
-  commit: "15549218a2cb9d78b590471e0fe76644b33c986d"
+  repository_url: "https://github.com/googlefonts/cookie"
+  commit: "a86099c7b0fb4176bea1657e2b9e66ac3ab85513"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Cookie-Regular.ttf"
+    dest_file: "Cookie-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/cookie/upstream_info.md
+++ b/ofl/cookie/upstream_info.md
@@ -1,45 +1,25 @@
 # Cookie
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Cookie |
-| Repository URL | https://github.com/librefonts/cookie |
-| Commit Hash | `15549218a2cb9d78b590471e0fe76644b33c986d` |
-| Branch | master |
-| Config YAML | N/A (SFD-only sources) |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Cookie (Regular) built from FontForge SFD sources at https://github.com/librefonts/cookie. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/cookie` is part of the librefonts GitHub organization, which hosts archival copies of early Google Fonts projects. The URL was already documented in the tracking data and matches the git remote of the cached upstream repo at `upstream_repos/fontc_crater_cache/librefonts/cookie`.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source (`src/Cookie-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/cookie, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-The upstream repository contains exactly **one commit**: `15549218a2cb9d78b590471e0fe76644b33c986d` ("update .travis.yml"). Since this is the only commit in the repository, it is trivially the correct reference. The librefonts repos were created as archival snapshots of the font projects' state when they were onboarded to Google Fonts.
+## Final state
 
-The font file in google/fonts (`Cookie-Regular.ttf`) was added only in the initial commit (`90abd17b4`, 2015-03-07) and has never been modified since on the main branch.
-
-## Config YAML Status
-
-**No config.yaml exists** in the upstream repository. The source files are:
-- `src/Cookie-Regular-TTF.sfd` (FontForge SFD format)
-- `src/Cookie-Regular.vfb` (FontLab VFB format)
-
-These are legacy font formats that are **not compatible with gftools-builder**. No override `config.yaml` exists in the google/fonts family directory either.
+The source now lives at https://github.com/googlefonts/cookie (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
 ## Verification
 
-- **Repository accessible**: Yes (verified via git remote URL)
-- **Commit hash valid**: Yes - matches the only commit in the repo
-- **Font file unchanged since onboarding**: Yes - only modified in initial commit on main
-- **Source block in METADATA.pb**: Pending (exists on feature branch `sources_info_2026-02-25`, not yet merged to main)
+The rebuilt Cookie-Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. Two benign differences were accepted: the FontForge legacy `nonmarkingreturn` glyph was dropped (FontForge synthesised it at export time; it carries no encoded codepoint), and 7 glyphs were renamed to their AGL production names with unchanged coverage.
 
-## Confidence Level
+## Original repository (dormant)
 
-**High** - Single-commit librefonts archival repository. The commit hash is unambiguous.
-
-## Open Questions
-
-None. The family has SFD-only sources and cannot be rebuilt with gftools-builder without a source format conversion.
+The original FontForge sources are at https://github.com/librefonts/cookie (`.sfd`), latest at commit `15549218a2cb9d78b590471e0fe76644b33c986d`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/copse/METADATA.pb
+++ b/ofl/copse/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SERIF"
 date_added: "2010-12-15"
 source {
-  repository_url: "https://github.com/librefonts/copse"
-  commit: "cb3ef9c1cce0dcea7f5743e84e9ed7da7e259fd4"
+  repository_url: "https://github.com/googlefonts/copse"
+  commit: "3022d037cd17945ad478f853ce401fc51185f8d0"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Copse-Regular.ttf"
+    dest_file: "Copse-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/copse/upstream_info.md
+++ b/ofl/copse/upstream_info.md
@@ -1,46 +1,26 @@
 # Copse
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Copse |
-| Repository URL | https://github.com/librefonts/copse |
-| Commit Hash | `cb3ef9c1cce0dcea7f5743e84e9ed7da7e259fd4` |
-| Branch | master |
-| Config YAML | N/A (SFD-only sources) |
-| Status | missing_config |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Copse (Regular) built from FontForge SFD sources at https://github.com/librefonts/copse. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/copse` is part of the librefonts GitHub organization, which hosts archival copies of early Google Fonts projects. The URL was already documented in the tracking data and matches the git remote of the cached upstream repo at `upstream_repos/fontc_crater_cache/librefonts/copse`.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source (`src/Copse-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected to match the space glyph (440).
+- A new Unified Font Repository was created at https://github.com/googlefonts/copse, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The upstream repository contains exactly **one commit**: `cb3ef9c1cce0dcea7f5743e84e9ed7da7e259fd4` ("update .travis.yml"). Since this is the only commit in the repository, it is trivially the correct reference. The librefonts repos were created as archival snapshots of the font projects' state when they were onboarded to Google Fonts.
+## Final state
 
-The font file in google/fonts (`Copse-Regular.ttf`) was added only in the initial commit (`90abd17b4`, 2015-03-07) and has never been modified since on the main branch.
-
-## Config YAML Status
-
-**No config.yaml exists** in the upstream repository. The source files are:
-- `src/Copse-Regular-TTF.sfd` (FontForge SFD format)
-- `src/Copse-Regular-TTF.vfb` (FontLab VFB format)
-- `src/Copse-Regular.vfb` (FontLab VFB format)
-
-These are legacy font formats that are **not compatible with gftools-builder**. No override `config.yaml` exists in the google/fonts family directory either. Copse has an unusually rich source directory including VTT-hinted TTX files and a PDF specimen, but all sources are in legacy formats.
+The source now lives at https://github.com/googlefonts/copse (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- **Repository accessible**: Yes (verified via git remote URL)
-- **Commit hash valid**: Yes - matches the only commit in the repo
-- **Font file unchanged since onboarding**: Yes - only modified in initial commit on main
-- **Source block in METADATA.pb**: Pending (exists on feature branch `sources_info_2026-02-25`, not yet merged to main)
+The built Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. One glyph was renamed to its production name; cmap coverage is unchanged, so this difference is benign.
 
-## Confidence Level
+## Original repository (dormant)
 
-**High** - Single-commit librefonts archival repository. The commit hash is unambiguous.
-
-## Open Questions
-
-None. The family has SFD-only sources and cannot be rebuilt with gftools-builder without a source format conversion.
+The original FontForge sources are at https://github.com/librefonts/copse (`.sfd`), latest at commit `cb3ef9c1cce0dcea7f5743e84e9ed7da7e259fd4`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/courgette/METADATA.pb
+++ b/ofl/courgette/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "HANDWRITING"
 date_added: "2012-07-10"
 source {
-  repository_url: "https://github.com/librefonts/courgette"
-  commit: "e9638c8874f097c75ff3206c5dfe15b6ef4c67b1"
+  repository_url: "https://github.com/googlefonts/courgette"
+  commit: "dcdd6f44e43530c55ae4d154b23b8f2fbb0e137f"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Courgette-Regular.ttf"
+    dest_file: "Courgette-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/courgette/upstream_info.md
+++ b/ofl/courgette/upstream_info.md
@@ -1,51 +1,26 @@
-# Courgette - Investigation Report
+# Courgette
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Courgette |
-| Repository URL | https://github.com/librefonts/courgette |
-| Commit Hash | e9638c8874f097c75ff3206c5dfe15b6ef4c67b1 |
-| Branch | master |
-| Config YAML | N/A (SFD-only sources) |
-| Designer | Karolina Lach |
-| License | OFL |
-| Date Added | 2012-07-10 |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Courgette (Regular) built from FontForge SFD sources at https://github.com/librefonts/courgette. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/courgette` was identified from the librefonts organization on GitHub, which hosts many legacy Google Fonts source repositories. The source block was added in commit 9a14639f3 ("Add source blocks to 602 more METADATA.pb files", 2026-02-25).
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- During conversion the no-break space (U+00A0) advance width was corrected to match the space glyph.
+- A new Unified Font Repository was created at https://github.com/googlefonts/courgette, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-The commit `e9638c8874f097c75ff3206c5dfe15b6ef4c67b1` is the HEAD (latest) commit of the upstream repository. The commit message is "update .travis.yml". Since the font binary files in google/fonts have never been updated since the initial commit (90abd17b4, 2015-03-07), and the upstream repo only contains legacy SFD/VFB sources with CI configuration updates, HEAD is used as the reference point for the repository state.
+## Final state
 
-The font binary was part of the initial google/fonts repository commit and has never been updated since.
-
-## Config YAML Status
-
-**No config.yaml exists** in the upstream repository, and no override config exists in the google/fonts family directory.
-
-The upstream repository contains only legacy source formats:
-- `src/Courgette-Regular-OTF.sfd` (FontForge SFD format)
-- `src/Courgette-Regular-TTF.sfd` (FontForge SFD format)
-- `src/Courgette-Regular.vfb` (FontLab VFB format)
-
-These are not compatible with gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` sources.
+The source now lives at https://github.com/googlefonts/courgette (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
 ## Verification
 
-- **Repository accessible**: Yes - cloned at `upstream_repos/fontc_crater_cache/librefonts/courgette/`
-- **Commit exists**: Yes - `e9638c8` is HEAD of the upstream repo
-- **Config exists at commit**: No - no config.yaml anywhere in the repo
-- **Source files present**: Only SFD/VFB legacy formats
-- **Font binary history**: Only modified in the initial google/fonts commit (2015-03-07)
+The rebuilt Courgette Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, and GSUB/GPOS feature sets. Remaining differences are benign: 23 glyphs were renamed to production names (coverage unchanged); GDEF now classifies one real combining mark the shipped font missed (uni0326); and one combining mark (U+F6C3) was zeroed after the shipped font left it with a spacing advance. Verdict: FUNCTIONAL parity.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** for repository URL and commit hash. The librefonts/courgette repo is the canonical upstream source. The status of "missing_config" is correct since only legacy SFD/VFB sources exist.
-
-## Open Questions
-
-None. This is a legacy font with SFD-only sources that cannot be rebuilt with modern tooling without a source conversion effort.
+The original FontForge sources are at https://github.com/librefonts/courgette (`.sfd`), latest at commit `e9638c8874f097c75ff3206c5dfe15b6ef4c67b1`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/coveredbyyourgrace/METADATA.pb
+++ b/ofl/coveredbyyourgrace/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "HANDWRITING"
 date_added: "2010-12-07"
 source {
-  repository_url: "https://github.com/librefonts/coveredbyyourgrace"
-  commit: "eca9fdc2d5ae964ff4838cb850b215d9ea703801"
+  repository_url: "https://github.com/googlefonts/coveredbyyourgrace"
+  commit: "705a49490c07c9e76f1ba8dc2d4f56d1b7bbf42c"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/CoveredByYourGrace-Regular.ttf"
+    dest_file: "CoveredByYourGrace.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/coveredbyyourgrace/upstream_info.md
+++ b/ofl/coveredbyyourgrace/upstream_info.md
@@ -1,51 +1,25 @@
 # Covered By Your Grace
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: Kimberly Geswein
-**METADATA.pb path**: `ofl/coveredbyyourgrace/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/coveredbyyourgrace |
-| Commit | `eca9fdc2d5ae964ff4838cb850b215d9ea703801` |
-| Config YAML | N/A (SFD-only sources) |
-| Branch | master |
+Google Fonts shipped Covered By Your Grace (Regular) built from FontForge SFD sources at https://github.com/librefonts/coveredbyyourgrace. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/coveredbyyourgrace` is from the `librefonts` GitHub organization, which is a collection of archived Google Fonts sources migrated from earlier hosting. The URL was added to METADATA.pb in the pending PR branch `felipesanches/sources_info_2026-02-25` (commit `9a14639f3`, "Add source blocks to 602 more METADATA.pb files"). The main branch of google/fonts does not yet have a source block for this family.
+- The canonical FontForge SFD source (`src/CoveredByYourGrace-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`). A few stray NUL bytes were stripped from the SFD and the non-breaking space was normalized during conversion.
+- A new Unified Font Repository was created at https://github.com/googlefonts/coveredbyyourgrace, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The commit hash `eca9fdc2d5ae964ff4838cb850b215d9ea703801` is the only commit in the upstream repository ("update .travis.yml", 2014-10-17). Since this is a single-commit repo, it is trivially the correct and only possible reference. The font was first added to Google Fonts on 2010-12-07 (per `date_added` in METADATA.pb) and has never been modified in google/fonts since the initial commit `90abd17b4` (2015-03-07, which imported the entire existing catalog).
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository or in the google/fonts family directory. The upstream repo contains:
-- `src/CoveredByYourGrace-TTF.sfd` (FontForge SFD format)
-- `src/CoveredByYourGrace.vfb` (FontLab VFB format)
-- Various TTX decomposition files
-
-SFD and VFB files are not compatible with gftools-builder, so a config.yaml cannot be created without converting the sources to a modern format.
+The source now lives at https://github.com/googlefonts/coveredbyyourgrace (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- Repository URL accessible: Yes
-- Commit exists in upstream repo: Yes (only commit / HEAD)
-- Commit date: 2014-10-17 13:33:46 +0300
-- Commit message: "update .travis.yml"
-- Source block on main: No (pending PR branch only)
-- Source files at commit: SFD and VFB files only
-- Override config.yaml: Not present
+The rebuilt Regular was compared against the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. It matched functionally, with three accepted differences: the converted source's cmap adds 4 codepoints; 18 glyphs were renamed to production names with coverage unchanged; and GDEF now classifies uni0326 as a combining mark that the shipped font had missed.
 
-## Confidence
+## Original repository (dormant)
 
-**High**: The librefonts organization is a well-known archive of Google Fonts sources. The repo has only one commit, making the hash unambiguous. The font has never been updated in google/fonts since the initial catalog import.
-
-## Open Questions
-
-1. The source block (repository_url and commit hash) has not yet been merged to google/fonts main -- it is on the pending branch `felipesanches/sources_info_2026-02-25`.
-2. No config.yaml can be created from SFD/VFB sources without source conversion. This family will remain in `missing_config` status unless the sources are modernized.
+The original FontForge sources are at https://github.com/librefonts/coveredbyyourgrace (`.sfd`), latest at commit `eca9fdc2d5ae964ff4838cb850b215d9ea703801`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/creteround/METADATA.pb
+++ b/ofl/creteround/METADATA.pb
@@ -4,8 +4,22 @@ license: "OFL"
 category: "SERIF"
 date_added: "2011-12-19"
 source {
-  repository_url: "https://github.com/librefonts/creteround"
-  commit: "056740e1fea281c2e72adeae3d3753083b87d22c"
+  repository_url: "https://github.com/googlefonts/creteround"
+  commit: "65f7a13699e262832f4fa0cd2a61908da6da811d"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/CreteRound-Italic.ttf"
+    dest_file: "CreteRound-Italic.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/CreteRound-Regular.ttf"
+    dest_file: "CreteRound-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/creteround/upstream_info.md
+++ b/ofl/creteround/upstream_info.md
@@ -1,55 +1,26 @@
 # Crete Round
 
-**Date investigated**: 2026-02-26
-**Status**: missing_config
-**Designer**: TypeTogether
-**METADATA.pb path**: `ofl/creteround/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/creteround |
-| Commit | `056740e1fea281c2e72adeae3d3753083b87d22c` |
-| Config YAML | N/A (SFD-only sources) |
-| Branch | master |
+Google Fonts shipped Crete Round (Regular and Italic) built from FontForge SFD sources at https://github.com/librefonts/creteround. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/creteround` is from the `librefonts` GitHub organization, which archives Google Fonts sources migrated from earlier hosting. The URL was added to METADATA.pb in the pending PR branch `felipesanches/sources_info_2026-02-25` (commit `9a14639f3`, "Add source blocks to 602 more METADATA.pb files"). The main branch of google/fonts does not yet have a source block for this family.
+- The canonical FontForge SFD sources for both styles were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected during conversion.
+- A new Unified Font Repository was created at https://github.com/googlefonts/creteround, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-## How the Commit Hash Was Identified
+## Final state
 
-The commit hash `056740e1fea281c2e72adeae3d3753083b87d22c` is the only commit in the upstream repository ("update .travis.yml", 2014-10-17). Since this is a single-commit repo, it is trivially the correct and only possible reference. The font was first added to Google Fonts on 2011-12-19 (per `date_added` in METADATA.pb) and the TTF files have never been modified in google/fonts since the initial commit `90abd17b4` (2015-03-07, which imported the existing catalog).
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository or in the google/fonts family directory. The upstream repo contains:
-- `src/CreteRound-Regular-TTF.sfd` (FontForge SFD format)
-- `src/CreteRound-Italic-TTF.sfd` (FontForge SFD format)
-- `src/CreteRound-Regular-OTF.vfb` (FontLab VFB format)
-- `src/CreteRound-Italic-OTF.vfb` (FontLab VFB format)
-- Various TTX decomposition files for both Regular and Italic
-
-SFD and VFB files are not compatible with gftools-builder, so a config.yaml cannot be created without converting the sources to a modern format.
+The source now lives at https://github.com/googlefonts/creteround (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
 ## Verification
 
-- Repository URL accessible: Yes
-- Commit exists in upstream repo: Yes (only commit / HEAD)
-- Commit date: 2014-10-17 13:33:50 +0300
-- Commit message: "update .travis.yml"
-- Source block on main: No (pending PR branch only)
-- Source files at commit: SFD and VFB files only
-- Override config.yaml: Not present
-- Additional files in google/fonts: `FONTLOG.txt` present
+Both styles matched the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only accepted difference is that 23 glyphs were renamed to their production names; codepoint coverage is unchanged.
 
-## Confidence
+## Original repository (dormant)
 
-**High**: The librefonts organization is a well-known archive of Google Fonts sources. The repo has only one commit, making the hash unambiguous. The font binaries (Regular and Italic) have never been updated in google/fonts since the initial catalog import.
-
-## Open Questions
-
-1. The source block (repository_url and commit hash) has not yet been merged to google/fonts main -- it is on the pending branch `felipesanches/sources_info_2026-02-25`.
-2. No config.yaml can be created from SFD/VFB sources without source conversion. This family will remain in `missing_config` status unless the sources are modernized.
-3. The font was designed by TypeTogether (Jose Scaglione and Veronika Burian). If there are more modern sources (e.g., .glyphs or .ufo) available from TypeTogether, those would be the preferred upstream.
+The original FontForge sources are at https://github.com/librefonts/creteround (`.sfd`), latest at commit `056740e1fea281c2e72adeae3d3753083b87d22c`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/croissantone/METADATA.pb
+++ b/ofl/croissantone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "DISPLAY"
 date_added: "2012-11-12"
 source {
-  repository_url: "https://github.com/librefonts/croissantone"
-  commit: "ebcefa6161a0558f994a038105f90f304fe91ff7"
+  repository_url: "https://github.com/googlefonts/croissantone"
+  commit: "0747cf401c74b546f997a820cb036a39513ba09c"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/CroissantOne-Regular.ttf"
+    dest_file: "CroissantOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/croissantone/upstream_info.md
+++ b/ofl/croissantone/upstream_info.md
@@ -1,50 +1,26 @@
-# Croissant One - Investigation Report
+# Croissant One
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Croissant One |
-| Repository URL | https://github.com/librefonts/croissantone |
-| Commit Hash | ebcefa6161a0558f994a038105f90f304fe91ff7 |
-| Branch | master |
-| Config YAML | N/A (SFD/VFB-only sources) |
-| Designer | Eduardo Tunni |
-| License | OFL |
-| Date Added | 2012-11-12 |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Croissant One (Regular) built from FontForge SFD sources at https://github.com/librefonts/croissantone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/croissantone` was identified from the librefonts organization on GitHub, which hosts many legacy Google Fonts source repositories. The source block was added in commit 9a14639f3 ("Add source blocks to 602 more METADATA.pb files", 2026-02-25).
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The non-breaking space (U+00A0) advance width was corrected to 300 to match the space glyph.
+- A new Unified Font Repository was created at https://github.com/googlefonts/croissantone, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-The commit `ebcefa6161a0558f994a038105f90f304fe91ff7` is the HEAD (latest) commit of the upstream repository. The commit message is "update .travis.yml". The upstream repository has 12 commits total, mostly CI configuration updates and initial file organization.
+## Final state
 
-The font binary in google/fonts was part of the initial repository commit (90abd17b4, 2015-03-07) and has never been updated since. HEAD is used as the reference point since the repo represents the canonical state of the project.
-
-## Config YAML Status
-
-**No config.yaml exists** in the upstream repository, and no override config exists in the google/fonts family directory.
-
-The upstream repository contains only legacy source formats:
-- `src/CroissantOne-Regular-TTF.sfd` (FontForge SFD format)
-- `src/CroissantOne-Regular-OTF.vfb` (FontLab VFB format)
-
-These are not compatible with gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` sources.
+The source now lives at https://github.com/googlefonts/croissantone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
 ## Verification
 
-- **Repository accessible**: Yes - cloned at `upstream_repos/fontc_crater_cache/librefonts/croissantone/`
-- **Commit exists**: Yes - `ebcefa6` is HEAD of the upstream repo
-- **Config exists at commit**: No - no config.yaml anywhere in the repo
-- **Source files present**: Only SFD/VFB legacy formats
-- **Font binary history**: Only modified in the initial google/fonts commit (2015-03-07)
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 18 glyphs were renamed to their production names, which leaves cmap coverage unchanged and is therefore accepted.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** for repository URL and commit hash. The librefonts/croissantone repo is the canonical upstream source. The status of "missing_config" is correct since only legacy SFD/VFB sources exist.
-
-## Open Questions
-
-None. This is a legacy font with SFD/VFB-only sources that cannot be rebuilt with modern tooling without a source conversion effort.
+The original FontForge sources are at https://github.com/librefonts/croissantone (`.sfd`), latest at commit `ebcefa6161a0558f994a038105f90f304fe91ff7`. Preserved for provenance; the new `.glyphs` source supersedes it for building.


### PR DESCRIPTION
A second batch, same as [google/fonts#10697](https://github.com/google/fonts/pull/10697): 27 families whose upstream was a FontForge `.sfd` project with no source that builds on the current Google Fonts Rust pipeline. Each `.sfd` was converted to Glyphs (`.glyphs`), placed in a new Unified Font Repository under the `googlefonts` org, and made to build with gftools-builder3 + fontc. The rebuilt fonts were verified functionally equivalent to the shipped binaries.

Each family is one commit: it repoints the `source { }` block in METADATA.pb at the new repository (repository_url + merge commit + `config_yaml: sources/config.yaml` + the shipped file list) and rewrites `upstream_info.md`. The original `librefonts/*` `.sfd` repositories are preserved and cited in each report under "Original repository (dormant)".

**This PR changes source metadata only** -- it does not re-ship rebuilt binaries. The referenced repositories are the source of record for the next production build; that build's output would go through the usual QA.

Bowlby One SC had an override `config.yaml` in its google/fonts directory; it is removed here because the `source` block now points `config_yaml` at the repository's own `sources/config.yaml`.

### Verification

Each rebuild was graded against the shipped binary by codepoint (never by glyph name): cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, and the GSUB/GPOS feature inventory all match. Remaining differences are benign modernizations (production-name renames with coverage unchanged, legacy `kern` rebuilt as a GPOS `kern` feature, U+00A0 advance corrected, GDEF/combining-mark fixes). Details per family are in each `upstream_info.md`.

### Families and source repositories

| family | source repository | commit |
|---|---|---|
| bowlbyone | googlefonts/bowlbyone | `d469e83e10` |
| bowlbyonesc | googlefonts/bowlbyonesc | `7fc977deba` |
| breeserif | googlefonts/breeserif | `80b004f632` |
| bubblegumsans | googlefonts/bubblegumsans | `ad8f70f6b4` |
| bubblerone | googlefonts/bubblerone | `110b02cb1d` |
| butcherman | googlefonts/butcherman | `f4f7f3e2cd` |
| cagliostro | googlefonts/cagliostro | `871f5caf05` |
| cambo | googlefonts/cambo | `a2c35dbad5` |
| candal | googlefonts/candal | `ed7ac22d00` |
| cantataone | googlefonts/cantataone | `12fb64c8ca` |
| carterone | googlefonts/carterone | `dfb0d97f8e` |
| cevicheone | googlefonts/cevicheone | `1af833a0fd` |
| chango | googlefonts/chango | `fed28f4695` |
| chauphilomeneone | googlefonts/chauphilomeneone | `d7246600bb` |
| chelaone | googlefonts/chelaone | `cb7da0a381` |
| cherryswash | googlefonts/cherryswash | `f1c0f2dbc3` |
| chicle | googlefonts/chicle | `f68c0fa9e4` |
| concertone | googlefonts/concertone | `b002b9370c` |
| condiment | googlefonts/condiment | `a89340dd64` |
| contrailone | googlefonts/contrailone | `755f2a5959` |
| convergence | googlefonts/convergence | `0f57768c9d` |
| cookie | googlefonts/cookie | `a86099c7b0` |
| copse | googlefonts/copse | `3022d037cd` |
| courgette | googlefonts/courgette | `dcdd6f44e4` |
| coveredbyyourgrace | googlefonts/coveredbyyourgrace | `705a49490c` |
| creteround | googlefonts/creteround | `65f7a13699` |
| croissantone | googlefonts/croissantone | `0747cf401c` |

All 27 source-repo modernization PRs have merged into their `googlefonts/*` repositories; the commits referenced above are those repositories' current `master` tips.
