### PR TITLE
Reference 16 more modernized .glyphs source repositories (SFD -> Glyphs)

### DIFF
--- a/ofl/dawningofanewday/METADATA.pb
+++ b/ofl/dawningofanewday/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "HANDWRITING"
 date_added: "2011-04-14"
 source {
-  repository_url: "https://github.com/librefonts/dawningofanewday"
-  commit: "45ea90b8015692ee7fe07e417ea1c88392373ce3"
+  repository_url: "https://github.com/googlefonts/dawningofanewday"
+  commit: "a0c504721994bbcde597e453115c481419e7c43f"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/DawningofaNewDay-Regular.ttf"
+    dest_file: "DawningofaNewDay.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/dawningofanewday/upstream_info.md
+++ b/ofl/dawningofanewday/upstream_info.md
@@ -1,51 +1,26 @@
-# Dawning of a New Day - Investigation Report
+# Dawning of a New Day
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Dawning of a New Day |
-| Designer | Kimberly Geswein |
-| Repository URL | https://github.com/librefonts/dawningofanewday |
-| Commit Hash | `45ea90b8015692ee7fe07e417ea1c88392373ce3` |
-| Branch | master |
-| Config YAML | None (no gftools-builder compatible sources) |
-| Status | missing_config |
-| Date Added | 2011-04-14 |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Dawning of a New Day (Regular) built from FontForge SFD sources at https://github.com/librefonts/dawningofanewday. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/dawningofanewday` is a librefonts archive repository. These repos were created by the Google Fonts team (hash3g) as archives of the font source files in TTX/SFD/VFB format.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source (`DawningofaNewDay-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- During conversion, embedded NUL bytes were stripped from the source and the no-break space (U+00A0) advance width was corrected.
+- A new Unified Font Repository was created at https://github.com/googlefonts/dawningofanewday, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The upstream repository has only a single commit: `45ea90b8015692ee7fe07e417ea1c88392373ce3` (hash3g, Oct 17 2014, "update .travis.yml"). This is the only commit and therefore the HEAD of the master branch. The font binary in google/fonts has not been updated since the initial commit (90abd17b4).
+## Final state
 
-## Config YAML Status
-
-- **No config.yaml in upstream**: The upstream repository does not contain a config.yaml file
-- **No override config.yaml in google/fonts**: None exists
-- **Source files are not gftools-builder compatible**: The upstream contains:
-  - `src/DawningofaNewDay-TTF.sfd` (FontForge SFD format)
-  - `src/DawningofaNewDay.vfb` (FontLab VFB format)
-  - Various TTX decompositions
-- These source formats (SFD, VFB) are not supported by gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` files
-- **No source block in METADATA.pb**: The current METADATA.pb has no `source { }` block
+The source now lives at https://github.com/googlefonts/dawningofanewday (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- Repository URL is valid and accessible: https://github.com/librefonts/dawningofanewday
-- Commit `45ea90b` is the only commit in the repo and matches HEAD
-- The upstream repo is cached at `upstream_repos/fontc_crater_cache/librefonts/dawningofanewday/`
-- This is a legacy font (added 2011-04-14) that predates gftools-builder infrastructure
+The rebuilt font matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. Two benign differences were accepted: the FontForge legacy `nonmarkingreturn` glyph was dropped (it carried no cmap coverage), and 5 glyphs were renamed to their production names with no change to coverage.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** for URL and commit. The librefonts archive is the only known upstream. The commit is trivially correct as there is only one commit.
-
-**N/A** for config_yaml - there is no gftools-builder compatible source, so no config.yaml can be created without converting the sources first.
-
-## Open Questions
-
-- Would this font benefit from source conversion (SFD to .glyphs or .ufo) to enable gftools-builder compatibility?
-- The librefonts archive is a secondary source; the original designer (Kimberly Geswein) may have the original source files in a different format.
+The original FontForge sources are at https://github.com/librefonts/dawningofanewday (`.sfd`), latest at commit `45ea90b8015692ee7fe07e417ea1c88392373ce3`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/daysone/METADATA.pb
+++ b/ofl/daysone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2011-08-17"
 source {
-  repository_url: "https://github.com/librefonts/daysone"
-  commit: "76642af05e1a7734f94e1b22abdbc37b6bfb933c"
+  repository_url: "https://github.com/googlefonts/daysone"
+  commit: "5a4d7f229c497dd3f4cf1b8c23da954c3e45e2cf"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/DaysOne-Regular.ttf"
+    dest_file: "DaysOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/daysone/upstream_info.md
+++ b/ofl/daysone/upstream_info.md
@@ -1,51 +1,26 @@
-# Days One - Investigation Report
+# Days One
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Days One |
-| Designer | Jovanny Lemonad |
-| Repository URL | https://github.com/librefonts/daysone |
-| Commit Hash | `76642af05e1a7734f94e1b22abdbc37b6bfb933c` |
-| Branch | master |
-| Config YAML | None (no gftools-builder compatible sources) |
-| Status | missing_config |
-| Date Added | 2011-08-17 |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Days One (Regular) built from FontForge SFD sources at https://github.com/librefonts/daysone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/daysone` is a librefonts archive repository. These repos were created by the Google Fonts team (hash3g) as archives of the font source files in TTX/SFD/VFB format.
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source (`src/DaysOne-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The non-breaking space (U+00A0) advance width was corrected to match the space glyph (717 units).
+- A new Unified Font Repository was created at https://github.com/googlefonts/daysone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The upstream repository has only a single commit: `76642af05e1a7734f94e1b22abdbc37b6bfb933c` (hash3g, Oct 17 2014, "update .travis.yml"). This is the only commit and therefore the HEAD of the master branch. The font binary in google/fonts has not been updated since the initial commit (90abd17b4).
+## Final state
 
-## Config YAML Status
-
-- **No config.yaml in upstream**: The upstream repository does not contain a config.yaml file
-- **No override config.yaml in google/fonts**: None exists
-- **Source files are not gftools-builder compatible**: The upstream contains:
-  - `src/DaysOne-Regular-TTF.sfd` (FontForge SFD format)
-  - `src/DaysOne-Regular.vfb` (FontLab VFB format)
-  - Various TTX decompositions
-- These source formats (SFD, VFB) are not supported by gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` files
-- **No source block in METADATA.pb**: The current METADATA.pb has no `source { }` block
+The source now lives at https://github.com/googlefonts/daysone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- Repository URL is valid and accessible: https://github.com/librefonts/daysone
-- Commit `76642af` is the only commit in the repo and matches HEAD
-- The upstream repo is cached at `upstream_repos/fontc_crater_cache/librefonts/daysone/`
-- This is a legacy font (added 2011-08-17) that predates gftools-builder infrastructure
+The rebuilt Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. Two benign differences were accepted: 98 glyphs were renamed to production names (glyph coverage unchanged), and the legacy `kern` table (2470 pairs) was modernized into a GPOS `kern` feature.
 
-## Confidence Level
+## Original repository (dormant)
 
-**HIGH** for URL and commit. The librefonts archive is the only known upstream. The commit is trivially correct as there is only one commit.
-
-**N/A** for config_yaml - there is no gftools-builder compatible source, so no config.yaml can be created without converting the sources first.
-
-## Open Questions
-
-- Would this font benefit from source conversion (SFD to .glyphs or .ufo) to enable gftools-builder compatibility?
-- The librefonts archive is a secondary source; the original designer (Jovanny Lemonad) may have the original source files in a different format.
+The original FontForge sources are at https://github.com/librefonts/daysone (`.sfd`), latest at commit `76642af05e1a7734f94e1b22abdbc37b6bfb933c`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/delius/METADATA.pb
+++ b/ofl/delius/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "HANDWRITING"
 date_added: "2011-07-27"
 source {
-  repository_url: "https://github.com/librefonts/delius"
-  commit: "5bd1633b6b5175d36e260f3f6d06686482d32212"
+  repository_url: "https://github.com/googlefonts/delius"
+  commit: "99e93e1a8034bf205d3978eaa98b8254a8faff3e"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Delius-Regular.ttf"
+    dest_file: "Delius-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/delius/upstream_info.md
+++ b/ofl/delius/upstream_info.md
@@ -1,57 +1,26 @@
-# Delius - Investigation Report
+# Delius
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Delius |
-| Designer | Natalia Raices |
-| License | OFL |
-| Repository URL | https://github.com/librefonts/delius |
-| Commit Hash | 5bd1633b6b5175d36e260f3f6d06686482d32212 |
-| Branch | master |
-| Config YAML | N/A (SFD-only sources) |
-| Status | missing_config |
-| Date Added | 2011-07-27 |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Delius (Regular) built from FontForge SFD sources at https://github.com/librefonts/delius. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/delius` was identified through the librefonts GitHub organization, which hosts many of the older Google Fonts projects. The URL was added to the tracking data and a source block was prepared (commit `9a14639f3`, currently on a PR branch `sources_info_2026-02-25`, not yet merged to main).
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD source (`Delius-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected to 238 in the converted source.
+- A new Unified Font Repository was created at https://github.com/googlefonts/delius, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The commit `5bd1633b6b5175d36e260f3f6d06686482d32212` is the HEAD of the master branch in the upstream repo (the only visible commit in the shallow clone: "update .travis.yml"). This is a legacy font from the initial google/fonts commit (2015-03-07). The font has been in the catalog since 2011-07-27.
+## Final state
 
-The TTF file in google/fonts was last modified in the deploy commit `76adaf1d2` (2021-11-01, "deploy: c7e2740...") which was a bulk deployment affecting many fonts. Before that, it was in the initial commit `90abd17b4`.
-
-Since this is a legacy font with SFD-only sources, the commit hash serves mainly to reference the state of the upstream repository rather than a specific build commit. The upstream repo contains:
-- `src/Delius-Regular-TTF.sfd` (FontForge source)
-- `src/Delius-Regular.vfb` (FontLab source)
-- TTX decompositions of the font tables
-- No modern build sources (.glyphs, .ufo, .designspace)
-
-## Config YAML Status
-
-- No `config.yaml` exists in the upstream repository
-- No override `config.yaml` exists in google/fonts at `ofl/delius/`
-- The upstream repo only contains SFD (FontForge) and VFB (FontLab) source formats
-- These formats are not compatible with gftools-builder
-- A config.yaml cannot be created without converting the sources to a modern format first
+The source now lives at https://github.com/googlefonts/delius (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- Repository URL is valid and accessible
-- Upstream repo cloned at `upstream_repos/fontc_crater_cache/librefonts/delius/` (shallow clone)
-- Commit `5bd1633` verified as HEAD of master
-- No modern source files found (.glyphs, .ufo, .designspace)
-- METADATA.pb in google/fonts main branch currently has no source block (a PR branch adds one)
+The rebuilt Delius Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 11 glyphs were renamed to their production names; character coverage is unchanged, so this is benign.
 
-## Confidence Level
+## Original repository (dormant)
 
-**High** for repository URL (well-established librefonts organization). **Medium** for commit hash (it's the HEAD of the repo, but it's a shallow clone so we can't verify the full history). **N/A** for config_yaml (sources are in legacy format only).
-
-## Open Questions
-
-- The font sources would need to be converted to a modern format (e.g., .glyphs or .ufo) before a config.yaml could be created.
-- The source block for METADATA.pb has been prepared on branch `sources_info_2026-02-25` but is not yet merged.
-- Since this is a very old font (2011) with SFD sources, it may not be a priority for source documentation.
+The original FontForge sources are at https://github.com/librefonts/delius (`.sfd`), latest at commit `5bd1633b6b5175d36e260f3f6d06686482d32212`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/deliusswashcaps/METADATA.pb
+++ b/ofl/deliusswashcaps/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "HANDWRITING"
 date_added: "2011-08-03"
 source {
-  repository_url: "https://github.com/librefonts/deliusswashcaps"
-  commit: "a18d931eb4b66533df5df07d91e0851938a96121"
+  repository_url: "https://github.com/googlefonts/deliusswashcaps"
+  commit: "2bcc0f94b70fdc0c94bc30d803f8c646224c1eab"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/DeliusSwashCaps-Regular.ttf"
+    dest_file: "DeliusSwashCaps-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/deliusswashcaps/upstream_info.md
+++ b/ofl/deliusswashcaps/upstream_info.md
@@ -1,57 +1,23 @@
-# Delius Swash Caps - Investigation Report
+# Delius Swash Caps
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Delius Swash Caps |
-| Designer | Natalia Raices |
-| License | OFL |
-| Repository URL | https://github.com/librefonts/deliusswashcaps |
-| Commit Hash | a18d931eb4b66533df5df07d91e0851938a96121 |
-| Branch | master |
-| Config YAML | N/A (SFD-only sources) |
-| Status | missing_config |
-| Date Added | 2011-08-03 |
+## Initial state
 
-## How URL Found
+The family shipped a single static TTF (Delius Swash Caps Regular) whose only upstream source was a FontForge `.sfd` file (`src/DeliusSwashCaps-Regular-TTF.sfd`). METADATA.pb pointed at the dormant librefonts repository and carried no `config_yaml`, so the family could not be rebuilt with the current Google Fonts tooling.
 
-The repository URL `https://github.com/librefonts/deliusswashcaps` was identified through the librefonts GitHub organization. Like the other Delius variants (Delius, Delius Unicase), each variant has its own separate repository under the librefonts organization. A source block was prepared in commit `9a14639f3` (on PR branch `sources_info_2026-02-25`, not yet merged to main).
+## Actions taken
 
-## How Commit Determined
+The repository was re-based on the Unified Font Repository template. The FontForge source was converted to Glyphs (`DeliusSwashCaps-Regular.glyphs`) with babelfont-rs (upstream commit `219c0bb`), a `config.yaml` was added for gftools-builder3, and the superseded `.sfd` sources and legacy build cruft were retired. During conversion the no-break space (U+00A0) advance width was corrected to match the space glyph (238 units).
 
-The commit `a18d931eb4b66533df5df07d91e0851938a96121` is the HEAD of the master branch in the upstream repo (the only visible commit in the shallow clone: "update .travis.yml"). This is a legacy font added to the Google Fonts catalog on 2011-08-03 and present since the initial google/fonts commit (2015-03-07).
+## Final state
 
-The TTF file in google/fonts was last modified in the deploy commit `76adaf1d2` (2021-11-01). Before that, it was in the initial commit.
-
-The upstream repo contains:
-- `src/DeliusSwashCaps-Regular-TTF.sfd` (FontForge source)
-- `src/DeliusSwashCaps-Regular.vfb` (FontLab source)
-- TTX decompositions of the font tables
-- No modern build sources (.glyphs, .ufo, .designspace)
-
-## Config YAML Status
-
-- No `config.yaml` exists in the upstream repository
-- No override `config.yaml` exists in google/fonts at `ofl/deliusswashcaps/`
-- The upstream repo only contains SFD (FontForge) and VFB (FontLab) source formats
-- These formats are not compatible with gftools-builder
-- A config.yaml cannot be created without converting the sources to a modern format first
+The repository builds Delius Swash Caps Regular from the `.glyphs` source through gftools-builder3 + fontc. The `source { }` block in METADATA.pb now points at the modernized googlefonts repository, branch and build config.
 
 ## Verification
 
-- Repository URL is valid and accessible
-- Upstream repo cloned at `upstream_repos/fontc_crater_cache/librefonts/deliusswashcaps/` (shallow clone)
-- Commit `a18d931` verified as HEAD of master
-- No modern source files found (.glyphs, .ufo, .designspace)
-- METADATA.pb in google/fonts main branch currently has no source block (a PR branch adds one)
+The freshly built Regular was compared against the shipped `DeliusSwashCaps-Regular.ttf`. Character-map coverage matched. The verdict is FUNCTIONAL, with only benign differences: the FontForge legacy helper glyphs (`.null`, `nonmarkingreturn`) were dropped; 11 glyphs were renamed to production names with no change in coverage; GDEF now correctly classifies one combining mark (U+0326) that the shipped font left unclassified; and the private-use combining glyph U+F6C3 was zeroed to a true mark advance (the shipped font gave it a spacing advance). No blocking differences were found.
 
-## Confidence Level
+## Original repository (dormant)
 
-**High** for repository URL. **Medium** for commit hash (HEAD of shallow clone). **N/A** for config_yaml (legacy source format only).
-
-## Open Questions
-
-- Same situation as Delius and Delius Unicase: sources would need conversion to modern format for gftools-builder compatibility.
-- The copyright string references Reserved Font Names: "Delius", "Delius Unicase", "Delius Swash Caps" - all three variants share the same designer (Natalia Raices) and were created as a family.
-- The source block for METADATA.pb has been prepared on branch `sources_info_2026-02-25` but is not yet merged.
+The original upstream lived at https://github.com/librefonts/deliusswashcaps (branch `master`), latest commit `a18d931eb4b66533df5df07d91e0851938a96121`, which is the same commit recorded for the original onboarding.

--- a/ofl/deliusunicase/METADATA.pb
+++ b/ofl/deliusunicase/METADATA.pb
@@ -4,8 +4,22 @@ license: "OFL"
 category: "HANDWRITING"
 date_added: "2011-10-12"
 source {
-  repository_url: "https://github.com/librefonts/deliusunicase"
-  commit: "cf094caecc96589701f341db1994fd10642e3c88"
+  repository_url: "https://github.com/googlefonts/deliusunicase"
+  commit: "2440c19ebfa6d4a898d9b8d439e9888e7d2fd71f"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/DeliusUnicase-Bold.ttf"
+    dest_file: "DeliusUnicase-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/DeliusUnicase-Regular.ttf"
+    dest_file: "DeliusUnicase-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/deliusunicase/upstream_info.md
+++ b/ofl/deliusunicase/upstream_info.md
@@ -1,63 +1,26 @@
-# Delius Unicase - Investigation Report
+# Delius Unicase
 
-## Source Data
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|---|---|
-| Family Name | Delius Unicase |
-| Designer | Natalia Raices |
-| License | OFL |
-| Repository URL | https://github.com/librefonts/deliusunicase |
-| Commit Hash | cf094caecc96589701f341db1994fd10642e3c88 |
-| Branch | master |
-| Config YAML | N/A (SFD-only sources) |
-| Status | missing_config |
-| Date Added | 2011-10-12 |
+## Initial state
 
-## How URL Found
+Google Fonts shipped Delius Unicase (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/deliusunicase. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The repository URL `https://github.com/librefonts/deliusunicase` was identified through the librefonts GitHub organization. This is the third variant in the Delius family (alongside Delius and Delius Swash Caps), each hosted in its own repository. A source block was prepared in commit `9a14639f3` (on PR branch `sources_info_2026-02-25`, not yet merged to main).
+## Actions taken
 
-## How Commit Determined
+- The canonical FontForge SFD sources (`DeliusUnicase-Regular-TTF.sfd` and `DeliusUnicase-Bold-TTF.sfd`) were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected, and the Bold master had its OS/2 usWeightClass set to 700.
+- A new Unified Font Repository was created at https://github.com/googlefonts/deliusunicase, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-The commit `cf094caecc96589701f341db1994fd10642e3c88` is the HEAD of the master branch in the upstream repo (the only visible commit in the shallow clone: "update .travis.yml"). This is a legacy font added to the Google Fonts catalog on 2011-10-12.
+## Final state
 
-Unlike the other Delius variants which have only one weight, Delius Unicase has two weights:
-- DeliusUnicase-Regular.ttf (400)
-- DeliusUnicase-Bold.ttf (700)
-
-The TTF files in google/fonts were last modified in the deploy commit `76adaf1d2` (2021-11-01). Before that, they were in the initial commit.
-
-The upstream repo contains:
-- `src/DeliusUnicase-Regular-TTF.sfd` and `src/DeliusUnicase-Bold-TTF.sfd` (FontForge sources)
-- `src/DeliusUnicase-Regular.vfb` and `src/DeliusUnicase-Bold.vfb` (FontLab sources)
-- TTX decompositions of the font tables for both weights
-- No modern build sources (.glyphs, .ufo, .designspace)
-
-## Config YAML Status
-
-- No `config.yaml` exists in the upstream repository
-- No override `config.yaml` exists in google/fonts at `ofl/deliusunicase/`
-- The upstream repo only contains SFD (FontForge) and VFB (FontLab) source formats
-- These formats are not compatible with gftools-builder
-- A config.yaml cannot be created without converting the sources to a modern format first
+The source now lives at https://github.com/googlefonts/deliusunicase (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
 ## Verification
 
-- Repository URL is valid and accessible
-- Upstream repo cloned at `upstream_repos/fontc_crater_cache/librefonts/deliusunicase/` (shallow clone)
-- Commit `cf094ca` verified as HEAD of master
-- No modern source files found (.glyphs, .ufo, .designspace)
-- Source files for both Regular and Bold weights are present in `src/` directory
-- METADATA.pb in google/fonts main branch currently has no source block (a PR branch adds one)
+Both weights matched the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, and GSUB/GPOS feature sets. The accepted differences are benign: the FontForge legacy glyph `nonmarkingreturn` was dropped; 11 glyphs were renamed to production names with coverage unchanged; GDEF now classifies the real combining mark uni0326 that the shipped font had missed; and the combining mark U+F6C3, which the shipped font gave a spacing advance, was zeroed.
 
-## Confidence Level
+## Original repository (dormant)
 
-**High** for repository URL. **Medium** for commit hash (HEAD of shallow clone). **N/A** for config_yaml (legacy source format only).
-
-## Open Questions
-
-- Same situation as Delius and Delius Swash Caps: sources would need conversion to modern format for gftools-builder compatibility.
-- This is the only Delius variant with multiple weights (Regular + Bold), so source conversion would be more involved.
-- The source block for METADATA.pb has been prepared on branch `sources_info_2026-02-25` but is not yet merged.
-- The copyright string references Reserved Font Names: "Delius", "Delius Unicase", "Delius Swash Caps".
+The original FontForge sources are at https://github.com/librefonts/deliusunicase (`.sfd`), latest at commit `cf094caecc96589701f341db1994fd10642e3c88`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/devonshire/METADATA.pb
+++ b/ofl/devonshire/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "HANDWRITING"
 date_added: "2011-11-16"
 source {
-  repository_url: "https://github.com/librefonts/devonshire"
-  commit: "7d88bb81c76ccd1b7d48a15ae97a00c45f9ffb01"
+  repository_url: "https://github.com/googlefonts/devonshire"
+  commit: "7a5ccf2a745c1b08c55181ce87fb522dedcbe631"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Devonshire-Regular.ttf"
+    dest_file: "Devonshire-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/devonshire/upstream_info.md
+++ b/ofl/devonshire/upstream_info.md
@@ -1,42 +1,30 @@
 # Devonshire
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Devonshire is a handwriting/display typeface designed by Brian J. Bonislawsky (Astigmatic). The only known upstream repo is a librefonts mirror containing TTX-decomposed files and legacy source formats (SFD/VFB). No gftools-compatible sources exist.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Devonshire (Regular) built from FontForge SFD sources at https://github.com/librefonts/devonshire. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-- **Designer**: Astigmatic (Brian J. Bonislawsky)
-- **Date added to Google Fonts**: 2011-11-16
-- **Repository URL**: https://github.com/librefonts/devonshire
-- **Commit**: `7d88bb81c76ccd1b7d48a15ae97a00c45f9ffb01` (single commit "update .travis.yml")
-- **Source formats available**: SFD (FontForge), VFB (FontLab), TTX decomposed files
-- **config_yaml**: None (not applicable - no gftools-buildable sources)
-- **Override config.yaml**: None in google/fonts
+## Actions taken
 
-## Repository Analysis
+- The canonical FontForge SFD source (`Devonshire-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- During conversion the `aalt` feature was repaired and the no-break space (U+00A0) advance width was corrected to 202.
+- A new Unified Font Repository was created at https://github.com/googlefonts/devonshire, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The librefonts/devonshire repo is a mirror repository created by Mikhail Kashkin. It contains:
-- TTX-decomposed font tables (the binary .ttf decompiled into XML)
-- `src/Devonshire-Regular-TTF.sfd` - FontForge source
-- `src/Devonshire-Regular-OTF.vfb` - FontLab Studio source (binary, proprietary format)
-- Standard metadata files (FONTLOG.txt, METADATA.json, OFL.txt)
+## Final state
 
-The repo has a single commit in its history (after unshallowing): `7d88bb8 update .travis.yml`.
+The source now lives at https://github.com/googlefonts/devonshire (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-The FONTLOG.txt in google/fonts mentions two VFB source files as the canonical sources, indicating the font was originally designed in FontLab Studio.
+## Verification
 
-## google/fonts History
+The rebuilt Devonshire-Regular was compared against the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. It was functionally equivalent, with no blocking differences, and with the following accepted differences:
 
-The font binary has not been updated since the initial commit (90abd17b4) of the google/fonts repository. The source block was added in commit 9a14639f3 (2026-02-25) as part of a batch update.
+- Two FontForge legacy glyphs (`.null`, `nonmarkingreturn`) were dropped; they carry no cmap coverage.
+- 20 glyphs were renamed to their production names; codepoint coverage is unchanged.
+- GDEF now classifies three real combining marks (U+0312, U+0315, U+0326) as marks, which the shipped font missed, and those marks were given zero advance; the shipped font had incorrectly assigned them spacing advances.
 
-## Status
+## Original repository (dormant)
 
-- **repository_url**: Correct (https://github.com/librefonts/devonshire)
-- **commit**: `7d88bb8` is the only/latest commit in the repo
-- **config_yaml**: N/A - SFD/VFB sources are not gftools-builder compatible
-- **Overall**: missing_config (SFD-only sources, not gftools-builder compatible)
-
-## Recommendation
-
-Status should remain `missing_config` with the note that sources are SFD/VFB format only. The font would need to be converted to .glyphs or .ufo format and a config.yaml created before it could be built with gftools-builder.
+The original FontForge sources are at https://github.com/librefonts/devonshire (`.sfd`), latest at commit `7d88bb81c76ccd1b7d48a15ae97a00c45f9ffb01`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/donegalone/METADATA.pb
+++ b/ofl/donegalone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SERIF"
 date_added: "2012-11-26"
 source {
-  repository_url: "https://github.com/librefonts/donegalone"
-  commit: "b0af18fd94255bfdfe07e90db984167564abd565"
+  repository_url: "https://github.com/googlefonts/donegalone"
+  commit: "3fccfd33ed0b9eefdb158aef321fc2e604127a2c"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/DonegalOne-Regular.ttf"
+    dest_file: "DonegalOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/donegalone/upstream_info.md
+++ b/ofl/donegalone/upstream_info.md
@@ -1,45 +1,30 @@
 # Donegal One
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Donegal One is a serif font designed by Gary Lonergan, distributed by Sorkin Type Co. The upstream repository contains only SFD (FontForge) sources, which are not compatible with gftools-builder.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Donegal One (Regular) built from FontForge SFD sources at https://github.com/librefonts/donegalone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field | Value |
-|-------|-------|
-| **Family Name** | Donegal One |
-| **Designer** | Gary Lonergan |
-| **License** | OFL |
-| **Date Added** | 2012-11-26 |
-| **Repository URL** | https://github.com/librefonts/donegalone |
-| **Commit Hash** | `b0af18fd94255bfdfe07e90db984167564abd565` |
-| **Config YAML** | None (SFD-only sources) |
-| **Status** | missing_config |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The converted source was corrected: the `aalt` feature was rebuilt, and the no-break space (U+00A0) advance width was fixed to 684.
+- A new Unified Font Repository was created at https://github.com/googlefonts/donegalone, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-### Onboarding History
+## Final state
 
-Donegal One was added to Google Fonts in the initial commit (`90abd17b4`) by Dave Crossland on 2015-03-07. The font binary has only been modified once since, in a deploy commit (`76adaf1d2`).
+The source now lives at https://github.com/googlefonts/donegalone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
-A source block with repository_url and commit hash is being added via a pending PR on the `sources_info_2026-02-25` branch (commit `9a14639f3`).
+## Verification
 
-### Upstream Repository
+The rebuilt font matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle and GSUB/GPOS feature sets, and had no blocking differences. Three benign differences were accepted:
 
-The upstream repo at https://github.com/librefonts/donegalone contains:
-- `src/DonegalOne-Regular-TTF.sfd` - FontForge SFD source (TrueType)
-- `src/DonegalOne-Regular-OTF.sfd` - FontForge SFD source (OpenType)
-- `src/DonegalOne-Regular.vfb` - FontLab VFB source (proprietary format)
-- TTX dumps of the compiled font
-- No `.glyphs`, `.ufo`, or `.designspace` files
+- 27 glyphs were renamed to production names; cmap coverage is unchanged.
+- GDEF now classifies U+0326 (combining comma below) as a mark, which the shipped font failed to classify. This is a correction.
+- The combining mark at U+F6C3 was given a zero advance; the shipped font gave it a spacing advance.
 
-The repo has a single commit (`b0af18f`, "update .travis.yml") visible in the shallow clone. The remote URL is https://github.com/librefonts/donegalone.
+## Original repository (dormant)
 
-### Config YAML
-
-No config.yaml exists in either the upstream repository or as an override in the google/fonts family directory. The SFD source format is not supported by gftools-builder, so a config.yaml cannot be created without source format conversion.
-
-## Conclusion
-
-Donegal One has a known upstream repository with correct commit hash, but the sources are in SFD (FontForge) format only. A config.yaml cannot be created without first converting the sources to a gftools-builder compatible format (UFO, .glyphs, or .designspace). The status remains `missing_config` with the note that this is an SFD-only repository.
+The original FontForge sources are at https://github.com/librefonts/donegalone (`.sfd`), latest at commit `b0af18fd94255bfdfe07e90db984167564abd565`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/doppioone/METADATA.pb
+++ b/ofl/doppioone/METADATA.pb
@@ -4,8 +4,18 @@ license: "OFL"
 category: "SANS_SERIF"
 date_added: "2012-02-22"
 source {
-  repository_url: "https://github.com/librefonts/doppioone"
-  commit: "14bdd2e78b5b8e4f5bc5a39e5f1b02d398883a99"
+  repository_url: "https://github.com/googlefonts/doppioone"
+  commit: "34f9329a27b33de4a879733d65daaee5e7eb61d5"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/DoppioOne-Regular.ttf"
+    dest_file: "DoppioOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 
 fonts {

--- a/ofl/doppioone/upstream_info.md
+++ b/ofl/doppioone/upstream_info.md
@@ -1,45 +1,26 @@
 # Doppio One
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Doppio One is a sans-serif font by Szymon Celej, distributed by Sorkin Type Co. The upstream repository contains only SFD (FontForge) sources, which are not compatible with gftools-builder.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Doppio One (Regular) built from FontForge SFD sources at https://github.com/librefonts/doppioone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field | Value |
-|-------|-------|
-| **Family Name** | Doppio One |
-| **Designer** | Szymon Celej |
-| **License** | OFL |
-| **Date Added** | 2012-02-22 |
-| **Repository URL** | https://github.com/librefonts/doppioone |
-| **Commit Hash** | `14bdd2e78b5b8e4f5bc5a39e5f1b02d398883a99` |
-| **Config YAML** | None (SFD-only sources) |
-| **Status** | missing_config |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected to 410 to match the space glyph.
+- A new Unified Font Repository was created at https://github.com/googlefonts/doppioone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### Onboarding History
+## Final state
 
-Doppio One was added to Google Fonts in the initial commit (`90abd17b4`) by Dave Crossland on 2015-03-07. The font binary has only been modified once since, in a deploy commit (`76adaf1d2`).
+The source now lives at https://github.com/googlefonts/doppioone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-A source block with repository_url and commit hash is being added via a pending PR on the `sources_info_2026-02-25` branch (commit `9a14639f3`).
+## Verification
 
-### Upstream Repository
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets and advance widths. Two benign differences were accepted: 22 glyphs were renamed to their production names (coverage unchanged), and the GDEF table now classifies the combining mark uni0326 that the shipped font had left unclassified.
 
-The upstream repo at https://github.com/librefonts/doppioone contains:
-- `src/DoppioOne-Regular-TTF.sfd` - FontForge SFD source (TrueType)
-- `src/DoppioOne-Regular-OTF.sfd` - FontForge SFD source (OpenType)
-- `src/DoppioOne-Regular.vfb` - FontLab VFB source (proprietary format)
-- TTX dumps of the compiled font
-- No `.glyphs`, `.ufo`, or `.designspace` files
+## Original repository (dormant)
 
-The repo has a single commit (`14bdd2e`, "update .travis.yml") visible in the shallow clone. The remote URL is https://github.com/librefonts/doppioone.
-
-### Config YAML
-
-No config.yaml exists in either the upstream repository or as an override in the google/fonts family directory. The SFD source format is not supported by gftools-builder, so a config.yaml cannot be created without source format conversion.
-
-## Conclusion
-
-Doppio One has a known upstream repository with correct commit hash, but the sources are in SFD (FontForge) format only. A config.yaml cannot be created without first converting the sources to a gftools-builder compatible format (UFO, .glyphs, or .designspace). The status remains `missing_config` with the note that this is an SFD-only repository.
+The original FontForge sources are at https://github.com/librefonts/doppioone (`.sfd`), latest at commit `14bdd2e78b5b8e4f5bc5a39e5f1b02d398883a99`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/drsugiyama/METADATA.pb
+++ b/ofl/drsugiyama/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 classifications: "DISPLAY"
 classifications: "HANDWRITING"
 source {
-  repository_url: "https://github.com/librefonts/drsugiyama"
-  commit: "11d194b70af6df309a24c9395f64280172839879"
+  repository_url: "https://github.com/googlefonts/drsugiyama"
+  commit: "67e9b2e25cd7b9bde6ea5d5001fce5da54a9e877"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/DrSugiyama-Regular.ttf"
+    dest_file: "DrSugiyama-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/drsugiyama/upstream_info.md
+++ b/ofl/drsugiyama/upstream_info.md
@@ -1,60 +1,25 @@
 # Dr Sugiyama
 
-**Date investigated**: 2026-02-27
-**Status**: missing_config
-**Designer**: Sudtipos (Alejandro Paul)
-**METADATA.pb path**: `ofl/drsugiyama/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/drsugiyama |
-| Commit | `11d194b70af6df309a24c9395f64280172839879` |
-| Config YAML | None (SFD-only sources) |
-| Branch | `master` |
+Google Fonts shipped Dr Sugiyama (Regular) built from FontForge SFD sources at https://github.com/librefonts/drsugiyama. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/drsugiyama` was identified from the tracking data and verified to be accessible (HTTP 200). This is a librefonts mirror repository created by Mikhail Kashkin on 2014-07-16, with the initial commit message "Move drsugiyama font files to separate repository." The repo contains TTX-decomposed font table files and FontForge SFD/VFB source files.
+- The canonical FontForge SFD source (`DrSugiyama-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`). Four stray NUL bytes in the SFD were stripped during conversion.
+- A new Unified Font Repository was created at https://github.com/googlefonts/drsugiyama, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-No `repository_url` field exists in the current METADATA.pb - the file has no `source { }` block at all. The METADATA.pb only contains basic font metadata (name, designer, license, category, fonts, subsets, classifications).
+## Final state
 
-## How the Commit Hash Was Identified
-
-The upstream repository has 12 commits total, all by Mikhail Kashkin (hash3g), spanning from 2014-07-16 to 2014-10-17. The most recent (and HEAD) commit is `11d194b70af6df309a24c9395f64280172839879` ("update .travis.yml", 2014-10-17).
-
-The font binary in google/fonts has never been updated since the initial commit `90abd17b4` (2015-03-07, "Initial commit" by Dave Crossland), which was a massive import of the entire Google Fonts library. The font was originally added to Google Fonts on 2011-11-30 (per `date_added` in METADATA.pb), well before the librefonts mirror was created in 2014.
-
-Since the upstream repo is merely a mirror that was created after the font was already in Google Fonts, the commit hash is not a traditional "onboarding commit." However, the HEAD commit `11d194b` represents the latest state of the repository and all changes between the initial commit and HEAD are limited to `.travis.yml` and a minor `DESCRIPTION.en_us.html` update - no source file changes occurred.
-
-The original commit `29ab091f4611e197b5c4442d17b2c8c0d8bcd13f` (2014-07-16) contains the actual font data. All subsequent commits (10 more) only modified `.travis.yml` CI configuration and the HTML description file.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository. The source files are:
-
-- `src/DrSugiyama-Regular-TTF.sfd` - FontForge SFD format
-- `src/DrSujiyama-Regular-OTF.vfb` - FontLab VFB format (binary, proprietary)
-
-These are legacy source formats that are not compatible with gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` files. An override `config.yaml` cannot be created because there are no gftools-builder compatible sources to reference.
-
-The repository also contains TTX-decomposed table files (XML representations of the compiled font tables), but these are not editable font sources.
-
-Note: The original font name uses a variant spelling "Dr Sujiyama" in the VFB filename and copyright notice, while the published name is "Dr Sugiyama."
+The source now lives at https://github.com/googlefonts/drsugiyama (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- **Repository URL**: Verified accessible at https://github.com/librefonts/drsugiyama (HTTP 200)
-- **Font binary unchanged**: The TTF in google/fonts was added in the initial commit (`90abd17b4`, 2015-03-07) and has never been modified since
-- **Source file integrity**: The SFD source file in the upstream repo has not changed since the initial commit `29ab091f` (2014-07-16)
-- **No config.yaml**: Confirmed absent from both upstream repo and `ofl/drsugiyama/` in google/fonts
-- **Version**: Font is Version 1.000 (per name table and VERSIONS.txt)
+Matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only accepted difference is that 5 glyphs were renamed to their production names; character coverage is unchanged.
 
-## Confidence
+## Original repository (dormant)
 
-**MEDIUM** - The repository URL is confirmed and the repo does contain the font's SFD source. However, this is a librefonts mirror created after the font was already in Google Fonts, not the original upstream source. The original source was likely maintained by Alejandro Paul / Sudtipos, and the font copyright dates to 2004. The librefonts mirror was created by Mikhail Kashkin as part of a broader effort to organize Google Fonts sources into individual GitHub repositories. Since the sources are SFD/VFB only (not gftools-builder compatible), a config.yaml cannot be created.
-
-## Recommendation
-
-The status should remain `missing_config` with the note "SFD-only sources (FontForge format), not gftools-builder compatible." A `source { }` block could be added to METADATA.pb referencing the librefonts repo, but no `config_yaml` can be set since the sources are incompatible with gftools-builder. The commit hash should reference `11d194b70af6df309a24c9395f64280172839879` (HEAD of master) since no source files changed across the repo's history.
+The original FontForge sources are at https://github.com/librefonts/drsugiyama (`.sfd`), latest at commit `11d194b70af6df309a24c9395f64280172839879`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/durusans/METADATA.pb
+++ b/ofl/durusans/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/durusans"
-  commit: "2895eb6c9842f80c1e01bbf9fbb6231eaef66724"
+  repository_url: "https://github.com/googlefonts/durusans"
+  commit: "d1fe3f7222addb4f12bf8fd244a26e9304a7a376"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/DuruSans-Regular.ttf"
+    dest_file: "DuruSans-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/durusans/upstream_info.md
+++ b/ofl/durusans/upstream_info.md
@@ -1,74 +1,26 @@
-# Investigation: Duru Sans
+# Duru Sans
 
-- **Date investigated**: 2026-02-27
-- **Status**: missing_config (SFD-only sources)
-- **Designer**: Onur Yazicigil
-- **METADATA.pb path**: `ofl/durusans/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field           | Value                                          |
-|-----------------|------------------------------------------------|
-| repository_url  | https://github.com/librefonts/durusans         |
-| commit_hash     | 2895eb6c9842f80c1e01bbf9fbb6231eaef66724       |
-| config_yaml     | N/A (SFD-only sources, not gftools-builder compatible) |
+Google Fonts shipped Duru Sans (Regular) built from FontForge SFD sources at https://github.com/librefonts/durusans. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The upstream repository at `https://github.com/librefonts/durusans` was found in the fontc_crater_cache at `librefonts/durusans`. The METADATA.pb in google/fonts has no `source` block and no `repository_url` field.
+- The canonical FontForge SFD source (`DuruSans-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The non-breaking space (U+00A0) advance width was corrected to 493 units in the converted source.
+- A new Unified Font Repository was created at https://github.com/googlefonts/durusans, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-Verification that this is the correct repository:
-- The FONTLOG.txt files in google/fonts and the upstream repo are **identical**.
-- The OFL.txt license files are **identical**.
-- The DESCRIPTION.en_us.html files differ only in HTML formatting (whitespace/tag structure), not in textual content.
-- The METADATA.json in the upstream repo matches the METADATA.pb in google/fonts (same designer "Onur Yazicigil", same copyright, same date_added "2011-12-19").
-- The `src/METADATA_comments.txt` in the upstream repo references `~/googlefontdirectory/ofl/durusans/`, confirming this project originates from the Google Font Directory (the predecessor of google/fonts hosted on Google Code).
+## Final state
 
-The GitHub URL returns HTTP 200, confirming the repository is publicly accessible.
-
-## How the Commit Hash Was Identified
-
-The upstream repository contains exactly **one commit**:
-
-```
-2895eb6c9842f80c1e01bbf9fbb6231eaef66724 - "update .travis.yml" by hash3g, 2014-10-17
-```
-
-Since there is only one commit in the entire repository, this is necessarily the commit that represents the state of all source files. The commit message says "update .travis.yml" but it is actually the initial commit (squashed or force-pushed), containing all 39 files including the source files, TTX decompositions, FONTLOG, and license.
-
-In google/fonts, the TTF file `DuruSans-Regular.ttf` was added in the initial commit (`90abd17b4`, March 7, 2015 by Dave Crossland) and has never been updated since. The font was originally added to Google Fonts on 2011-12-19 (per METADATA.pb `date_added`), predating the librefonts GitHub repository (Oct 2014). The librefonts repo is a post-hoc archival copy of the original Google Font Directory sources, not the original development repository.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository. The source files available are:
-
-- `src/DuruSans-Regular.vfb` - FontLab VFB format (original source with contour overlaps)
-- `src/DuruSans-Regular-OTF.sfd` - FontForge SFD for OTF (binary, merged contours)
-- `src/DuruSans-Regular-TTF.sfd` - FontForge SFD for TTF (with hinting adjustments)
-- Root directory contains decomposed TTX files for the TTF
-
-These are **legacy formats** (VFB, SFD, TTX) that are **not compatible with gftools-builder**. The gftools-builder tool requires `.glyphs`, `.glyphx`, `.ufo`, or `.designspace` source formats. Therefore:
-
-- No config.yaml can be created as an override
-- The sources cannot be built with the modern gftools-builder pipeline
-- This font would require source conversion before it could use gftools-builder
-
-The `.travis.yml` in the repo uses the old `fontbakery-build.py` tool from 2014, which is a defunct build system.
+The source now lives at https://github.com/googlefonts/durusans (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- [x] Repository URL returns HTTP 200
-- [x] Repository is clean (no local modifications)
-- [x] Repository is on branch `master`, up to date with `origin/master`
-- [x] Only one branch exists (`master`)
-- [x] FONTLOG.txt files are identical between google/fonts and upstream
-- [x] OFL.txt files are identical between google/fonts and upstream
-- [x] Copyright in upstream METADATA.json matches google/fonts METADATA.pb
-- [x] Font was added to Google Fonts on 2011-12-19, upstream repo created Oct 2014 (archival copy)
-- [x] Font has never been updated in google/fonts since initial commit
+Compared against the shipped DuruSans-Regular.ttf, the rebuilt font matched on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The one accepted difference: 22 glyphs were renamed to production names, which leaves coverage unchanged and does not affect rendering.
 
-## Confidence
+## Original repository (dormant)
 
-**HIGH** for repository_url and commit_hash identification. The librefonts/durusans repo is clearly the archival source repository for this font, with matching metadata, license, and supporting files. There is only one commit, so the hash is unambiguous.
-
-**N/A** for config_yaml. The sources are in legacy formats (VFB/SFD) incompatible with gftools-builder. No config.yaml can be meaningfully created without first converting the sources to a modern format.
+The original FontForge sources are at https://github.com/librefonts/durusans (`.sfd`), latest at commit `2895eb6c9842f80c1e01bbf9fbb6231eaef66724`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/economica/METADATA.pb
+++ b/ofl/economica/METADATA.pb
@@ -45,6 +45,28 @@ subsets: "latin-ext"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/economica"
-  commit: "6bf48e6858755227cdd104ee4b44e9e2e4bb197b"
+  repository_url: "https://github.com/googlefonts/economica"
+  commit: "03c3c4473a043aa560421b3d54d67f66d4a98a31"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Economica-BoldItalic.ttf"
+    dest_file: "Economica-BoldItalic.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Economica-Bold.ttf"
+    dest_file: "Economica-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Economica-Italic.ttf"
+    dest_file: "Economica-Italic.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Economica-Regular.ttf"
+    dest_file: "Economica-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/economica/upstream_info.md
+++ b/ofl/economica/upstream_info.md
@@ -1,68 +1,26 @@
-# Investigation Report: Economica
+# Economica
 
-**Date investigated:** 2026-02-27
-**Status:** missing_config
-**Designer:** Vicente Lamonaca
-**METADATA.pb path:** ofl/economica/METADATA.pb
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|---|---|
-| repository_url | https://github.com/librefonts/economica |
-| commit_hash | 6bf48e6858755227cdd104ee4b44e9e2e4bb197b |
-| config_yaml | N/A (SFD/VFB sources only) |
+Google Fonts shipped Economica (Regular, Italic, Bold, Bold Italic) built from FontForge SFD sources at https://github.com/librefonts/economica. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How URL Was Found
+## Actions taken
 
-The METADATA.pb file contains no `source` block, no `repository_url`, and no `config_yaml`. The upstream repository was found in the fontc_crater_cache at `librefonts/economica`. The remote URL is `https://github.com/librefonts/economica`, which returns HTTP 200 and is accessible.
+- The four canonical FontForge SFD sources were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected to match the space glyph, and an explicit OS/2 usWeightClass of 700 was set on the Bold and Bold Italic sources.
+- A new Unified Font Repository was created at https://github.com/googlefonts/economica, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-The librefonts GitHub organization is a batch-import project created by Mikhail Kashkin (hash3g) that mirrors fonts from the old Google Font Directory into individual GitHub repositories. This is not the designer's own repository but serves as the only known public upstream source for this font.
+## Final state
 
-## How Commit Hash Was Identified
-
-The upstream repository contains exactly one commit:
-
-- `6bf48e6` (2014-10-17, by hash3g): "update .travis.yml"
-
-This single commit contains all files: the TTX decompositions of the compiled TTF fonts, SFD/VFB source files in `src/`, FONTLOG.txt, METADATA.json, OFL.txt, DESCRIPTION.en_us.html, and a .travis.yml for CI.
-
-Since there is only one commit, the commit hash is trivially `6bf48e6858755227cdd104ee4b44e9e2e4bb197b`.
-
-### Verification of font version match
-
-The font version strings match between google/fonts and the upstream TTX decompositions:
-
-| Font File | google/fonts Version | Upstream TTX Version |
-|---|---|---|
-| Economica-Regular.ttf | Version 1.101 | Version 1.101 |
-| Economica-Bold.ttf | Version 1.100 | Version 1.100 |
-| Economica-Italic.ttf | Version 1.100 | Version 1.100 |
-| Economica-BoldItalic.ttf | Version 1.100 | Version 1.100 |
-
-The TTX files in the upstream repo are decompositions of the same compiled TTFs that exist in google/fonts. The head table creation date is "Fri Feb 24 21:37:31 2012", consistent with the FONTLOG's initial release date of "24 Feb 2012" and the google/fonts `date_added` of 2012-02-29.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository, and one cannot be created for gftools-builder because the source files are in legacy formats:
-
-- **SFD files** (FontForge): `src/Economica-Regular-TTF.sfd`, `src/Economica-Bold-TTF.sfd`, `src/Economica-Italic-TTF.sfd`, `src/Economica-BoldItalic-TTF.sfd`
-- **VFB files** (FontLab Studio 5): `src/Economica-Regular-OTF.vfb`, `src/Economica-Bold-OTF.vfb`, `src/Economica-Italic-OTF.vfb`, `src/Economica-BoldItalic-OTF.vfb`
-
-There are no `.glyphs`, `.ufo`, or `.designspace` files. The gftools-builder tool does not support SFD or VFB formats, so an override config.yaml cannot be created.
-
-The .travis.yml references the legacy `fontbakery-build.py` tool from 2014, which is no longer maintained.
+The source now lives at https://github.com/googlefonts/economica (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
 ## Verification
 
-- [x] Repository URL returns HTTP 200
-- [x] Repository is clean (no local modifications)
-- [x] Only one commit exists; hash is unambiguous
-- [x] Font version strings match between google/fonts and upstream TTX decompositions
-- [x] Copyright strings match: "Copyright (c) 2012, Vicente Lamonaca"
-- [x] Head table creation date (2012-02-24) matches FONTLOG initial release date
-- [x] No .glyphs/.ufo/.designspace sources available for gftools-builder
+Each style matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 6 glyphs were renamed to their production names in each style; character coverage is unchanged.
 
-## Confidence
+## Original repository (dormant)
 
-**MEDIUM** -- The repository URL is confirmed (librefonts/economica, accessible on GitHub) and the only commit hash is unambiguous. However, this is a librefonts batch-import repository, not the designer's canonical source. The font predates modern tooling and uses SFD/VFB sources that cannot be built with gftools-builder. Confidence is MEDIUM rather than HIGH because the librefonts repo is a secondary mirror, not the original designer's repository. No config.yaml can be provided.
+The original FontForge sources are at https://github.com/librefonts/economica (`.sfd`), latest at commit `6bf48e6858755227cdd104ee4b44e9e2e4bb197b`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/elsie/METADATA.pb
+++ b/ofl/elsie/METADATA.pb
@@ -25,8 +25,22 @@ subsets: "latin"
 subsets: "latin-ext"
 subsets: "menu"
 source {
-  repository_url: "https://github.com/librefonts/elsie"
-  commit: "9734e9ff1331292fc07ec198d4e5b35216fdd425"
+  repository_url: "https://github.com/googlefonts/elsie"
+  commit: "32783244780b4fdd904d5a1aa3f45a25c76ed15f"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Elsie-Black.ttf"
+    dest_file: "Elsie-Black.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Elsie-Regular.ttf"
+    dest_file: "Elsie-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }
 stroke: "SERIF"
 classifications: "DISPLAY"

--- a/ofl/elsie/upstream_info.md
+++ b/ofl/elsie/upstream_info.md
@@ -1,125 +1,26 @@
-# Investigation Report: Elsie
+# Elsie
 
-## Family Details
-- **Family name**: Elsie
-- **Designer**: Alejandro Inler (with Ana Sanfelippo)
-- **License**: OFL
-- **Category**: DISPLAY / SERIF
-- **Date added to Google Fonts**: 2012-11-12
-- **Weights**: Regular (400), Black (900)
-- **Path in google/fonts**: `ofl/elsie/`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## METADATA.pb Source Block (Current State)
+## Initial state
 
-```
-source {
-  repository_url: "https://github.com/googlefonts/elsiefont (404)"
-}
-```
+Google Fonts shipped Elsie (Regular and Black) built from FontForge SFD sources at https://github.com/librefonts/elsie. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-The current `repository_url` includes a literal `(404)` annotation appended by Simon Cozens in PR #7160 ("More upstreams (e,f)"), merged 2024-01-16. This is not a valid URL -- it was a note that the repository was already gone at the time it was recorded.
+## Actions taken
 
-## Repository Investigation
+- The canonical FontForge SFD sources (`Elsie-Regular-TTF.sfd` and `Elsie-Black-TTF.sfd`) were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The converted sources were corrected: the `aalt` feature was regenerated, the non-breaking space (U+00A0) advance width was fixed, and usWeightClass 900 was set on the Black source.
+- A new Unified Font Repository was created at https://github.com/googlefonts/elsie, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-### googlefonts/elsiefont (DELETED)
-- **URL**: https://github.com/googlefonts/elsiefont
-- **Status**: Returns HTTP 404. Repository has been deleted or never existed.
-- **Evidence**: Confirmed via HTTP request on 2026-02-27.
+## Final state
 
-### googlefonts/elsie (EMPTY)
-- **URL**: https://github.com/googlefonts/elsie
-- **Status**: Returns HTTP 200, but the repository is **completely empty** -- zero commits, zero branches, zero content.
-- **Created**: 2017-09-25
-- **Not a fork**: Standalone empty repo, never populated.
+The source now lives at https://github.com/googlefonts/elsie (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
-### librefonts/elsie (LEGACY ARCHIVE)
-- **URL**: https://github.com/librefonts/elsie
-- **Status**: Active (HTTP 200), contains source files.
-- **Created**: 2014-07-16 by Mikhail Kashkin (xen)
-- **Initial commit**: `af81473` -- "Move elsie font files to separate repository"
-- **Latest commit**: `9734e9f` (2014-10-17) -- "update .travis.yml"
-- **Total commits**: 12 (all in 2014, no activity since)
-- **Cloned to cache**: `fontc_crater_cache/librefonts/elsie/`
+## Verification
 
-#### Source Files in librefonts/elsie
-The `src/` directory contains:
-- `Elsie-Regular-TTF.sfd` -- FontForge Spline Font Database (Regular)
-- `Elsie-Black-TTF.sfd` -- FontForge Spline Font Database (Black)
-- `Elsie-Regular-OTF.vfb` / `Elsie-Regular-OTF.vfbak` -- FontLab binary (Regular)
-- `Elsie-Black-OTF.vfb` / `Elsie-Black-OTF.vfbak` -- FontLab binary (Black)
-- Various `.otf.*.ttx` decompositions of OTF files
-- `Elsie-Black-Poster.pdf`
+Each weight matched its shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only differences were glyphs renamed to production names (12 in Black, 9 in Regular); coverage and rendering are unchanged, so the verdict is functional equivalence.
 
-Root directory contains TTX decompositions of the TTF binaries (split per table), plus `METADATA.json` and `OFL.txt`.
+## Original repository (dormant)
 
-#### Source Format Assessment
-- **SFD files**: FontForge format. Not compatible with gftools-builder.
-- **VFB files**: FontLab 5 binary format. Not compatible with gftools-builder.
-- **No `.glyphs`, `.ufo`, or `.designspace` files** are available anywhere.
-- **No `config.yaml`** exists in the repo.
-
-## Onboarding History in google/fonts
-
-### Initial commit (2015-03-07)
-- **Commit**: `90abd17b` -- "Initial commit" by Dave Crossland
-- **Note**: This was a bulk initial import; no upstream reference recorded.
-
-### PR #884 (2017-05-08) -- hotfix-elsie: v1.002 added
-- **Author**: Marc Foley (m4rc1e)
-- **Changes**: Updated both `Elsie-Regular.ttf` (41044 -> 40956 bytes) and `Elsie-Black.ttf` (42424 -> 42216 bytes), plus `DESCRIPTION.en_us.html` and `METADATA.pb`.
-- **No upstream reference** in commit body or PR description.
-
-### PR #2754 (2020-10-28) -- [hotfix] ofl/elsie/Elsie-Regular.ttf updated
-- **Author**: Rosalie Wagner (RosaWagner)
-- **Changes**: Updated only `Elsie-Regular.ttf` (40956 -> 38936 bytes).
-- **Purpose**: Fix issue #515 (fi/fj ligature problem) by removing f_i and f_j ligatures, version bumped from 1.002 to 1.003.
-- **Note**: "few FAILS since it's an old font" -- hotfix was done directly on the binary, not from sources.
-
-### PR #7522 (2024-04-08) -- Hotfix fi and fj for ElsieSwashCaps-Regular.ttf
-- **Author**: Yanone
-- **Key quote**: *"Reminder: We don't have sources"*
-- **This confirms**: The Google Fonts team acknowledges that no usable source files exist for the Elsie family. Hotfixes were performed directly on the binary font files.
-
-### PR #7160 (2024-01-16) -- More upstreams (e,f)
-- **Author**: Simon Cozens (simoncozens)
-- **Added**: The current `repository_url: "https://github.com/googlefonts/elsiefont (404)"` noting the URL was already dead.
-
-### PR #10266 (open) -- Fix broken repository_url in 6 METADATA.pb files
-- **Author**: felipesanches (AI-assisted)
-- **Proposes**: Removing the invalid URL entirely from the source block.
-- **Status**: Open, not yet merged.
-
-## Related Family
-- **Elsie Swash Caps** (`ofl/elsieswashcaps/`): Sibling family by the same designer. Uses `librefonts/elsieswashcaps` as upstream, which also has SFD-only sources.
-
-## Designer Information
-- **Alejandro Inler** (alejandroinler@gmail.com): No GitHub account found (HTTP 404 for `github.com/alejandroinler`).
-- **Ana Sanfelippo**: Co-developer credited in the description.
-- The copyright dates are 2010-2012, predating the Google Fonts onboarding.
-
-## Config.yaml Assessment
-- **No config.yaml** exists in `librefonts/elsie`.
-- **No config.yaml** exists in `ofl/elsie/` in google/fonts.
-- **Cannot create an override config.yaml**: The only source files are SFD (FontForge) and VFB (FontLab 5), neither of which is supported by gftools-builder. There are no `.glyphs`, `.ufo`, or `.designspace` files to reference.
-
-## Conclusions
-
-### Repository URL
-The correct upstream repository is **https://github.com/librefonts/elsie**. While this is a legacy archive (last updated 2014) and the sources are not gftools-builder compatible, it is the only repository containing actual source files for this font family. The `googlefonts/elsiefont` URL was always invalid, and `googlefonts/elsie` exists but is empty.
-
-### Commit Hash
-No specific onboarding commit can be identified in `librefonts/elsie`. The repo has only 12 commits (all from 2014), with the latest being `9734e9f` (2014-10-17, a Travis CI update). The font sources (SFD/VFB files) were all added in the initial commit `af81473` (2014-07-16) and never modified after that.
-
-The font binaries in google/fonts have been hotfixed multiple times (PR #884, PR #2754) directly without rebuilding from sources.
-
-### Status
-- **Repository URL**: `https://github.com/librefonts/elsie` (valid, contains SFD sources)
-- **Commit hash**: `af81473` (initial commit containing all source files; sources never changed after this)
-- **Config**: None (SFD-only sources, not gftools-builder compatible)
-- **Status**: `missing_config` -- SFD-only sources cannot be built with gftools-builder
-- **Confidence**: MEDIUM -- The librefonts/elsie repo contains legitimate SFD sources but was never the official upstream used for Google Fonts onboarding. The fonts were likely compiled from VFB/SFD sources offline by the designer and submitted as binaries. Subsequent hotfixes were done directly on binaries.
-
-## Recommended Actions
-1. **Update METADATA.pb**: Replace the invalid `"https://github.com/googlefonts/elsiefont (404)"` URL with `"https://github.com/librefonts/elsie"`.
-2. **Note in source block**: This is a SFD-only repo; no gftools-builder rebuild is possible without source format conversion.
-3. **PR #10266 update**: The currently open PR proposes removing the URL entirely. It could instead be updated to point to `librefonts/elsie` as the best available source repository.
+The original FontForge sources are at https://github.com/librefonts/elsie (`.sfd`), latest at commit `9734e9ff1331292fc07ec198d4e5b35216fdd425`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/elsieswashcaps/METADATA.pb
+++ b/ofl/elsieswashcaps/METADATA.pb
@@ -27,6 +27,20 @@ subsets: "menu"
 stroke: "SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/elsieswashcaps"
-  commit: "f48faa350a1a9641bd984b6945f791914a652c65"
+  repository_url: "https://github.com/googlefonts/elsieswashcaps"
+  commit: "411b5d70587edced2c2c23f9d4c1393be55bf5d4"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/ElsieSwashCaps-Black.ttf"
+    dest_file: "ElsieSwashCaps-Black.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/ElsieSwashCaps-Regular.ttf"
+    dest_file: "ElsieSwashCaps-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/elsieswashcaps/upstream_info.md
+++ b/ofl/elsieswashcaps/upstream_info.md
@@ -1,63 +1,26 @@
-# Investigation: Elsie Swash Caps
+# Elsie Swash Caps
 
-- **Date investigated**: 2026-02-27
-- **Status**: missing_config (SFD/VFB-only sources, no gftools-builder compatible files)
-- **Designer**: Alejandro Inler
-- **METADATA.pb path**: `ofl/elsieswashcaps/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field            | Value |
-|------------------|-------|
-| repository_url   | https://github.com/librefonts/elsieswashcaps |
-| commit_hash      | f48faa350a1a9641bd984b6945f791914a652c65 |
-| config_yaml      | none (SFD/VFB-only sources) |
+Google Fonts shipped Elsie Swash Caps (Regular and Black) built from FontForge SFD sources at https://github.com/librefonts/elsieswashcaps. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How URL Was Found
+## Actions taken
 
-The METADATA.pb file for Elsie Swash Caps currently has no `source {}` block at all. The upstream repo URL was identified by checking the fontc_crater_cache at `upstream_repos/fontc_crater_cache/librefonts/elsieswashcaps/`, which has its git remote set to `https://github.com/librefonts/elsieswashcaps`. The repo was confirmed accessible (HTTP 200) on GitHub.
+- The two canonical FontForge SFD sources were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- During conversion the non-breaking space advance width was corrected in both weights, and the Black weight's OS/2 usWeightClass was set to 900.
+- A new Unified Font Repository was created at https://github.com/googlefonts/elsieswashcaps, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-Note: A previously-used URL `https://github.com/googlefonts/elsiefont` (which was associated with the sibling family "Elsie") returns 404 and was removed from the Elsie METADATA.pb in a prior fix (commit `3fabc27ef`). No `googlefonts/elsieswashcaps` repo exists either (404).
+## Final state
 
-## How Commit Hash Was Identified
-
-The `librefonts/elsieswashcaps` repository has only a single commit:
-
-- `f48faa3` (2014-10-17) by hash3g: "update .travis.yml"
-
-This is the only commit and therefore the only possible reference point. However, this commit is from 2014, well before the current fonts in google/fonts were produced. The fonts have been updated multiple times since:
-
-1. **PR #885** (2017-05-08): Marc Foley updated to v1.002 as a hotfix
-2. **PR #7522** (2024-04-08): Yanone fixed fi/fj ligature rendering and bumped to v1.003
-
-Both of these updates were binary hotfixes made directly in google/fonts. In PR #7522, Yanone explicitly stated: *"We don't have sources"* and *"I literally fixed only the requirements (outlines of the fi and fj ligature)"*. The current v1.003 fonts do NOT correspond to any commit in the upstream repository.
-
-## How Config YAML Was Resolved
-
-No config.yaml exists in the `librefonts/elsieswashcaps` repository. The repo uses an old Travis CI build pipeline (`fontbakery-build.py`) from 2014, which is not compatible with modern gftools-builder.
-
-The source files in the repo are:
-- **SFD** (FontForge): `src/ElsieSwashCaps-Regular-TTF.sfd`, `src/ElsieSwashCaps-Black-TTF.sfd` (plus backup copies)
-- **VFB** (FontLab): `src/ElsieSwashCaps-Regular-OTF.vfb`, `src/ElsieSwashCaps-Black-OTF.vfb` (plus .vfbak backups)
-- **TTX** (decompiled font tables): Numerous `.ttx` files for both Regular and Black weights
-
-None of these formats (.sfd, .vfb) are compatible with gftools-builder, which requires .glyphs, .ufo, or .designspace sources. Creating an override config.yaml is not possible without compatible source files.
+The source now lives at https://github.com/googlefonts/elsieswashcaps (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
 ## Verification
 
-- **Repository accessible**: Confirmed (HTTP 200)
-- **Fonts match upstream**: NO. The current fonts in google/fonts are v1.003 (binary-hotfixed by Yanone in April 2024). The upstream repo has only one commit from 2014 and contains older-generation sources.
-- **Sources usable**: NO. The SFD/VFB sources are not compatible with gftools-builder. Yanone confirmed in PR #7522 that sources are effectively lost.
-- **config.yaml**: None exists and none can be created (no compatible sources)
+Both weights matched the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference was that 12 glyphs (Black) and 9 glyphs (Regular) were renamed to their production names; coverage is unchanged, so this is cosmetic and does not affect shaping.
 
-## Confidence
+## Original repository (dormant)
 
-**MEDIUM** -- The repository URL is correct (librefonts/elsieswashcaps is the historical upstream for this family), but the repo is essentially archived/stale. The current fonts in Google Fonts are the result of binary hotfixes and no longer correspond to any upstream source. The commit hash `f48faa3` is the only commit in the repo and represents the original source deposit, but it predates the current binaries significantly.
-
-## Notes
-
-- Elsie Swash Caps is a sibling family to "Elsie" (non-swash-caps), both by Alejandro Inler. They share a similar situation: lost sources.
-- The `googlefonts/elsiefont` repo (previously referenced for "Elsie") is a 404 and was never associated with the Swash Caps variant.
-- The librefonts org created separate repos for `elsie` and `elsieswashcaps` in July 2014, each with only one commit (Travis CI config update by hash3g in October 2014).
-- Future source recovery would require contacting Alejandro Inler (alejandroinler@gmail.com) to obtain original editable sources in a modern format.
-- The font was originally added to Google Fonts on 2012-11-12.
+The original FontForge sources are at https://github.com/librefonts/elsieswashcaps (`.sfd`), latest at commit `f48faa350a1a9641bd984b6945f791914a652c65`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/emblemaone/METADATA.pb
+++ b/ofl/emblemaone/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/emblemaone"
-  commit: "65d5dad63686fcfc0c7e13ba2cb3143803d96bfe"
+  repository_url: "https://github.com/googlefonts/emblemaone"
+  commit: "79205499f351bf5c95c8dcf6121180c18789f62f"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/EmblemaOne-Regular.ttf"
+    dest_file: "EmblemaOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/emblemaone/upstream_info.md
+++ b/ofl/emblemaone/upstream_info.md
@@ -1,71 +1,25 @@
-# Investigation Report: Emblema One
+# Emblema One
 
-- **Date investigated**: 2026-02-27
-- **Status**: SFD-only sources (not gftools-builder compatible)
-- **Designer**: Riccardo De Franceschi
-- **Mastering**: Eben Sorkin (Sorkin Type Co)
-- **METADATA.pb path**: `ofl/emblemaone/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|---|---|
-| Repository URL | https://github.com/librefonts/emblemaone |
-| Commit hash | `65d5dad63686fcfc0c7e13ba2cb3143803d96bfe` |
-| Branch | `master` |
-| Config YAML | none (SFD-only sources) |
-| Source types | SFD, VFB |
+Google Fonts shipped Emblema One (Regular) built from FontForge SFD sources at https://github.com/librefonts/emblemaone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How URL Was Found
+## Actions taken
 
-The upstream repository URL `https://github.com/librefonts/emblemaone` was already referenced in the tracking data (`gfonts_library_sources.json`). The URL was verified to return HTTP 200. The `librefonts` GitHub organization is a well-known archive of Google Fonts source files, created by Mikhail Kashkin (hash3g). The repository contains TTX dumps of the binary font along with the original VFB and SFD source files.
+- The canonical FontForge SFD source (`EmblemaOne-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/emblemaone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The METADATA.pb in google/fonts does not currently contain a `source { }` block -- no `repository_url` is set there.
+## Final state
 
-## How Commit Hash Was Identified
-
-The upstream repository contains only a single commit:
-
-```
-65d5dad 2014-10-17 hash3g "update .travis.yml"
-```
-
-This is the initial (and only) commit in the repository, which added all files including the TTX dumps, VFB sources, SFD source, FONTLOG.txt, OFL.txt, and the Travis CI configuration. Since there is only one commit, the hash `65d5dad63686fcfc0c7e13ba2cb3143803d96bfe` is the definitive reference.
-
-The font was originally added to Google Fonts on 2012-01-18 (per `date_added` in METADATA.pb). The google/fonts repository itself was created with a bulk "Initial commit" on 2015-03-07 by Dave Crossland, which imported all existing fonts. The font binary (`EmblemaOne-Regular.ttf`) has never been modified since that initial import.
-
-The TTF in google/fonts is Version 1.003 (per the name table), and the TTX dumps in the upstream repo also show Version 1.003, confirming they represent the same font version.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository. The source files are:
-
-- `src/EmblemaOne-Regular-TTF.sfd` -- FontForge SFD format (for the TTF output)
-- `src/EmblemaOne-Regular-OTF.vfb` -- FontLab VFB format (for the OTF output)
-- `src/EmblemaOne-Regular.vfb` -- FontLab VFB format
-
-These are legacy source formats. SFD is a FontForge format, and VFB is a proprietary FontLab format. Neither is compatible with gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` sources. Therefore, no override `config.yaml` can be created.
-
-The repository also contains TTX (XML) dumps of the compiled font tables, but these are decomposed table dumps, not a usable source format for gftools-builder.
+The source now lives at https://github.com/googlefonts/emblemaone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- **Repository URL**: Verified accessible (HTTP 200)
-- **Repository status**: Clean, up to date with origin (`git status` shows clean working tree)
-- **Single commit**: The repo has exactly one commit (`65d5dad`)
-- **Font version match**: Both the google/fonts binary and the upstream TTX name table report Version 1.003
-- **FONTLOG consistency**: The FONTLOG.txt files in google/fonts and the upstream repo are identical
-- **Source format**: SFD and VFB only -- not compatible with gftools-builder
-- **No config.yaml**: Correct, since gftools-builder cannot use these source formats
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 21 glyphs were renamed to production names; glyph coverage is unchanged, so this is benign.
 
-## Confidence
+## Original repository (dormant)
 
-**HIGH** -- The upstream repository contains a single commit with all files. The font version (1.003) matches between the google/fonts binary and the upstream TTX data. The source formats (SFD, VFB) are definitively not gftools-builder compatible, so the "SFD-only sources" status is accurate.
-
-## Notes
-
-- The font was designed by Riccardo De Franceschi and mastered by Eben Sorkin at Sorkin Type Co.
-- The original sources were created in FontLab (VFB) in 2010, and the TTF was mastered in January 2012.
-- The `librefonts` archive repo was created in October 2014 by hash3g.
-- The DESCRIPTION.en_us.html references the now-defunct Google Code (`code.google.com/p/googlefontdirectory/`) as the source location, indicating this font predates the move to GitHub.
-- To make this font rebuildable with gftools-builder, someone would need to convert the SFD or VFB sources to a modern format (`.glyphs` or `.ufo`).
+The original FontForge sources are at https://github.com/librefonts/emblemaone (`.sfd`), latest at commit `65d5dad63686fcfc0c7e13ba2cb3143803d96bfe`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/ericaone/METADATA.pb
+++ b/ofl/ericaone/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/ericaone"
-  commit: "bde7cb1ee528f936a9bae89a746742983531d9f8"
+  repository_url: "https://github.com/googlefonts/ericaone"
+  commit: "34ddbe60f433f69a959c8200e97b8b9be4499900"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/EricaOne-Regular.ttf"
+    dest_file: "EricaOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/ericaone/upstream_info.md
+++ b/ofl/ericaone/upstream_info.md
@@ -1,55 +1,26 @@
 # Erica One
 
-**Date investigated**: 2026-02-27
-**Status**: missing_config (SFD-only sources)
-**Designer**: Miguel Hernandez (LatinoType)
-**METADATA.pb path**: `ofl/ericaone/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository URL | https://github.com/librefonts/ericaone |
-| Commit | `bde7cb1ee528f936a9bae89a746742983531d9f8` |
-| Config YAML | None (SFD-only sources, not gftools-builder compatible) |
-| Branch | `master` |
+Google Fonts shipped Erica One (Regular) built from FontForge SFD sources at https://github.com/librefonts/ericaone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## How the Repository URL Was Found
+## Actions taken
 
-The repository URL `https://github.com/librefonts/ericaone` was identified from the fontc_crater_cache at `librefonts/ericaone`. The repo was created on 2014-07-16 by Mikhail Kashkin (hash3g) with the initial commit message "Move ericaone font files to separate repository", indicating it was split out from a larger googlefontdirectory collection into its own repository. This is a librefonts mirror, not the original designer's repository.
+- The canonical FontForge SFD source (`EricaOne-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- Seven glyphs were renamed to their standard production names during conversion; codepoint coverage was unchanged.
+- A new Unified Font Repository was created at https://github.com/googlefonts/ericaone, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-No other upstream repository exists for this font. A GitHub search found only the librefonts mirror and a google-fonts-bower package (which is just a bower distribution, not a source repo).
+## Final state
 
-## How the Commit Hash Was Identified
-
-The upstream repository has 11 commits, all by Mikhail Kashkin (hash3g):
-
-1. `b8d3a3e` (2014-07-16) - Initial commit: "Move ericaone font files to separate repository" -- adds all font source files, TTX decomposed files, METADATA.json, license, and description
-2. `19e03a5` through `bde7cb1` (2014-08-19 to 2014-10-17) - 10 subsequent commits all exclusively modifying `.travis.yml` for CI configuration
-
-Since the font sources were only ever present in the initial commit, and all later commits only touched CI configuration, the latest commit `bde7cb1` is used as the reference because it represents the final state of the repository with no source file changes.
-
-The font binary in google/fonts (`ofl/ericaone/EricaOne-Regular.ttf`) has never been modified since the initial bulk import commit `90abd17b4` (2015-03-07, by Dave Crossland). The font's head table shows creation and modification dates of 2012-01-24, consistent with the `date_added` of 2012-01-18 in METADATA.pb. This was a very early Google Fonts addition, predating the librefonts mirror by over two years.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository. The source files available are:
-
-- `src/EricaOne-Regular-TTF.sfd` -- FontForge Spline Font Database (version 3.0)
-- `src/EricaOne-Regular-OTF.vfb` -- FontLab binary source
-
-Neither SFD nor VFB formats are supported by gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` sources. An override config.yaml cannot be created because there are no compatible source files to reference.
-
-The root directory also contains TTX-decomposed files (`.ttx` table dumps of the compiled fonts), but these are not editable font sources.
+The source now lives at https://github.com/googlefonts/ericaone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
 ## Verification
 
-- **Repository URL**: Verified accessible via `gh repo view` -- created 2014-07-16, not archived
-- **Commit hash**: `bde7cb1` confirmed as HEAD of master branch with `git rev-parse HEAD`
-- **Source files**: Confirmed SFD (FontForge) and VFB (FontLab) only -- no `.glyphs`, `.ufo`, or `.designspace` files present
-- **Font binary unchanged**: The TTF in google/fonts has only one entry in git log (the initial commit `90abd17b4`), confirming it was never updated
-- **Font version**: Version 1.003 per `src/VERSIONS.txt`; font head table creation date 2012-01-24
+The rebuilt font matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference was seven glyphs renamed to their standard production names, which leaves codepoint coverage unchanged and is therefore accepted.
 
-## Confidence
+## Original repository (dormant)
 
-**HIGH** -- The repository URL is confirmed as the only available upstream. The commit hash is the latest in a repo with only CI-related changes after the initial file import. The SFD-only source limitation is clearly verified. No config.yaml can be created for this font family.
+The original FontForge sources are at https://github.com/librefonts/ericaone (`.sfd`), latest at commit `bde7cb1ee528f936a9bae89a746742983531d9f8`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/esteban/METADATA.pb
+++ b/ofl/esteban/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/esteban"
-  commit: "35e274d49210b9c8a7864689b48d6156e6be6bbf"
+  repository_url: "https://github.com/googlefonts/esteban"
+  commit: "6e017f92549326738359a4c43c5ac7302ca773f7"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Esteban-Regular.ttf"
+    dest_file: "Esteban-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/esteban/upstream_info.md
+++ b/ofl/esteban/upstream_info.md
@@ -1,81 +1,25 @@
-# Investigation Report: Esteban
+# Esteban
 
-- **Date investigated**: 2026-02-27
-- **Status**: SFD-only sources (not gftools-builder compatible)
-- **Designer**: Angelica Diaz
-- **METADATA.pb path**: `ofl/esteban/METADATA.pb`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Data
+## Initial state
 
-| Field            | Value                                                |
-|------------------|------------------------------------------------------|
-| Repository URL   | https://github.com/librefonts/esteban                |
-| Commit hash      | 35e274d49210b9c8a7864689b48d6156e6be6bbf             |
-| Branch           | master                                               |
-| Config YAML      | None (SFD-only sources)                              |
-| Source format(s) | .vfb (FontLab), .sfd (FontForge)                     |
+Google Fonts shipped Esteban (Regular) built from FontForge SFD sources at https://github.com/librefonts/esteban. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Current METADATA.pb State
+## Actions taken
 
-The METADATA.pb has no `source { }` block. It contains only basic font metadata:
-- `name`: "Esteban"
-- `designer`: "Angelica Diaz"
-- `license`: "OFL"
-- `category`: "SERIF"
-- `date_added`: "2012-01-11"
-- Single font: Esteban-Regular.ttf (weight 400, normal style)
+- The canonical FontForge SFD source (`src/Esteban-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/esteban, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## How URL Was Found
+## Final state
 
-The repository URL `https://github.com/librefonts/esteban` was identified from the `fontc_crater_cache` directory structure. The `librefonts` GitHub organization was created as part of the fontbakery project to host decomposed font sources (TTX tables) alongside original source files. This repo is a fontbakery-era mirror, not an original designer repository.
-
-The URL was verified accessible (HTTP 200).
-
-## How Commit Hash Was Identified
-
-The upstream repository contains only a single commit:
-
-- **35e274d** (2014-10-17): "update .travis.yml" by hash3g <hash.3g@gmail.com>
-
-This is the only commit in the repository, so it is trivially the correct reference. The commit created all files in the repo as a single initial import, including:
-- TTX decomposed tables of the TTF and OTF binaries
-- Source files: `src/Esteban-Regular.vfb`, `src/Esteban-Regular-OTF.vfb`, `src/Esteban-Regular-TTF.sfd`
-- `METADATA.json`, `FONTLOG.txt`, `OFL.txt`, `DESCRIPTION.en_us.html`
-- `.travis.yml` for fontbakery CI
-
-The font binary in google/fonts (`ofl/esteban/Esteban-Regular.ttf`) was added in the initial google/fonts commit `90abd17b4` (2015-03-07, Dave Crossland "Initial commit") and has never been updated since. The font reports Version 1.002.
-
-The upstream repo's `src/VERSIONS.txt` confirms: "Esteban-Regular.ttf: Version 1.002", matching the binary in google/fonts.
-
-## How Config YAML Was Resolved
-
-No `config.yaml` exists in the upstream repository. The source files are in legacy formats:
-- `src/Esteban-Regular.vfb` - FontLab VFB format (proprietary binary)
-- `src/Esteban-Regular-OTF.vfb` - FontLab VFB format (for OTF output)
-- `src/Esteban-Regular-TTF.sfd` - FontForge SFD format
-
-None of these formats (.vfb, .sfd) are compatible with gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` sources. An override `config.yaml` cannot be created because there are no compatible source files to reference.
-
-The `.travis.yml` in the repo shows it used `fontbakery-build.py` for CI builds, which is a legacy build system that predates gftools-builder.
+The source now lives at https://github.com/googlefonts/esteban (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
 ## Verification
 
-- **Repository accessible**: Yes (HTTP 200)
-- **Repository clean**: Yes (`nothing to commit, working tree clean`)
-- **Branch**: master (single branch, up to date with origin)
-- **Binary match**: The font in google/fonts is Version 1.002, matching the upstream's `src/VERSIONS.txt`
-- **No updates since onboarding**: The font binary has only been touched once in google/fonts (initial commit 90abd17b4)
-- **No config.yaml possible**: Source formats (.vfb, .sfd) are incompatible with gftools-builder
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 7 glyphs were renamed to production (AGL) names; glyph coverage is unchanged, so this is a functional equivalence.
 
-## Confidence
+## Original repository (dormant)
 
-**HIGH** -- The upstream repository has a single commit, making identification trivial. The version numbers match. However, this is a `librefonts` mirror repository, not the original designer's source repository. The original sources may have been in the old Google Font Directory (`googlefontdirectory/esteban/` as referenced in `src/METADATA_comments.txt`).
-
-## Notes
-
-- This font was added to Google Fonts on 2012-01-11 (per `date_added` in METADATA.pb), predating the librefonts mirror (2014-10-17) and the google/fonts initial commit (2015-03-07).
-- The designer is Angelica Diaz Rivera, contactable at angiecina@gmail.com per the copyright notice and FONTLOG.
-- The font is named after Jorge Alfredo Diaz Esteban, a writer whose manuscript style inspired the typeface's modulated strokes.
-- The `librefonts` repository is essentially an archival mirror with TTX-decomposed tables and legacy source files. It does not represent an active upstream development repository.
-- Building from source would require converting the .sfd or .vfb files to a modern format (.glyphs or .ufo) first.
-- A source block could be added to METADATA.pb pointing to this repo, but with status "missing_config" since no gftools-builder config is possible with the current source formats.
+The original FontForge sources are at https://github.com/librefonts/esteban (`.sfd`), latest at commit `35e274d49210b9c8a7864689b48d6156e6be6bbf`. Preserved for provenance; the new `.glyphs` source supersedes it for building.


### PR DESCRIPTION
The third batch in this series (after [#10697](https://github.com/google/fonts/pull/10697) and [#10709](https://github.com/google/fonts/pull/10709)): 16 families whose upstream was a FontForge `.sfd` project with no source that builds on the current Google Fonts Rust pipeline. Each `.sfd` was converted to Glyphs (`.glyphs`), placed in a new Unified Font Repository under the `googlefonts` org, and made to build with gftools-builder3 + fontc. The rebuilt fonts were verified functionally equivalent to the shipped binaries.

Each family is one commit: it repoints the `source { }` block in METADATA.pb at the new repository (repository_url + merge commit + `config_yaml: sources/config.yaml` + the shipped file list) and rewrites `upstream_info.md`. The original `librefonts/*` `.sfd` repositories are preserved and cited in each report under "Original repository (dormant)".

**This PR changes source metadata only** -- it does not re-ship rebuilt binaries. The referenced repositories are the source of record for the next production build; that build's output would go through the usual QA.

### Verification

Each rebuild was graded against the shipped binary by codepoint (never by glyph name): cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, and the GSUB/GPOS feature inventory all match. Remaining differences are benign modernizations (production-name renames with coverage unchanged, legacy `kern` rebuilt as a GPOS `kern` feature, U+00A0 advance corrected, GDEF/combining-mark fixes). Details per family are in each `upstream_info.md`.

### Families and source repositories

| family | source repository | commit |
|---|---|---|
| dawningofanewday | googlefonts/dawningofanewday | `a0c5047219` |
| daysone | googlefonts/daysone | `5a4d7f229c` |
| delius | googlefonts/delius | `99e93e1a80` |
| deliusswashcaps | googlefonts/deliusswashcaps | `2bcc0f94b7` |
| deliusunicase | googlefonts/deliusunicase | `2440c19ebf` |
| devonshire | googlefonts/devonshire | `7a5ccf2a74` |
| donegalone | googlefonts/donegalone | `3fccfd33ed` |
| doppioone | googlefonts/doppioone | `34f9329a27` |
| drsugiyama | googlefonts/drsugiyama | `67e9b2e25c` |
| durusans | googlefonts/durusans | `d1fe3f7222` |
| economica | googlefonts/economica | `03c3c4473a` |
| elsie | googlefonts/elsie | `3278324478` |
| elsieswashcaps | googlefonts/elsieswashcaps | `411b5d7058` |
| emblemaone | googlefonts/emblemaone | `79205499f3` |
| ericaone | googlefonts/ericaone | `34ddbe60f4` |
| esteban | googlefonts/esteban | `6e017f9254` |

All 16 source-repo modernization PRs have merged into their `googlefonts/*` repositories; the commits referenced above are those repositories' current `master` tips.
