### PR TITLE
Reference 32 more modernized .glyphs source repositories (SFD -> Glyphs)

### DIFF
--- a/ofl/euphoriascript/METADATA.pb
+++ b/ofl/euphoriascript/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 classifications: "DISPLAY"
 classifications: "HANDWRITING"
 source {
-  repository_url: "https://github.com/librefonts/euphoriascript"
-  commit: "c7606fae5a17e051d983269f008dba6e8f4c0c77"
+  repository_url: "https://github.com/googlefonts/euphoriascript"
+  commit: "78d99652827fb969c23ab117ca38d93152b32bce"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/EuphoriaScript-Regular.ttf"
+    dest_file: "EuphoriaScript-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/euphoriascript/upstream_info.md
+++ b/ofl/euphoriascript/upstream_info.md
@@ -1,92 +1,25 @@
-# Investigation Report: Euphoria Script
+# Euphoria Script
 
-## Family Metadata
-- **Family Name**: Euphoria Script
-- **Designer**: Sabrina Mariela Lopez
-- **License**: OFL
-- **Category**: HANDWRITING
-- **Date Added**: 2012-02-08
-- **Path in google/fonts**: `ofl/euphoriascript`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Repository
-- **Repository URL**: https://github.com/librefonts/euphoriascript
-- **Commit**: `c7606fae5a17e051d983269f008dba6e8f4c0c77`
-- **Branch**: master
-- **Status**: missing_config
-- **Confidence**: HIGH
+## Initial state
 
-## Investigation Details
+Google Fonts shipped Euphoria Script (Regular) built from FontForge SFD sources at https://github.com/librefonts/euphoriascript. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-### METADATA.pb Analysis
-The current METADATA.pb on the google/fonts main branch has no `source {}` block. A source block was prepared in commit `9a14639f3` ("Add source blocks to 602 more METADATA.pb files") pointing to the librefonts repository.
+## Actions taken
 
-### Font File History in google/fonts
-The TTF file (`EuphoriaScript-Regular.ttf`, 38,424 bytes) was added in the initial commit of the google/fonts repository (`90abd17b4`, 2015-03-07, by Dave Crossland). This was the bulk import that brought all existing Google Fonts into the current repository structure. The font itself dates from 2012 (version 1.002), as indicated by the font's name table and FONTLOG.
+- The canonical FontForge SFD source (`EuphoriaScript-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/euphoriascript, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The TTF file has never been modified since the initial commit.
+## Final state
 
-### Upstream Repository Analysis
-The repository at `https://github.com/librefonts/euphoriascript` is part of the **librefonts** organization, which is an archival/mirror project that decomposed Google Fonts families into TTX (XML) representations alongside their original source files. The repo was created by **hash3g** (hash.3g@gmail.com) on 2014-10-17 and contains exactly one commit (`c7606fa`).
+The source now lives at https://github.com/googlefonts/euphoriascript (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-The repository is verified as accessible (HTTP 200).
+## Verification
 
-### Repository Contents
-The repo contains:
-- **Root level**: TTX decomposition of `EuphoriaScript-Regular.ttf` (glyf, cmap, head, name, etc.)
-- **`src/` directory**:
-  - `EuphoriaScript-Regular.vfb` - original FontLab source with overlaps
-  - `EuphoriaScript-Regular-OTF.vfb` - FontLab source for OTF generation (without overlaps)
-  - `EuphoriaScript-Regular-TTF.sfd` - FontForge source used to generate final TTF
-  - TTX decompositions of the OTF
-  - `METADATA_comments.txt` - subsetting/build comments from the original Google Font Directory
-  - `VERSIONS.txt` - records "EuphoriaScript-Regular.ttf: Version 1.002"
-- `METADATA.json`, `FONTLOG.txt`, `OFL.txt`, `DESCRIPTION.en_us.html`
-- `.travis.yml` - CI config using fontbakery-build.py
+The build matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 4 glyphs were renamed to their standard production names during conversion; glyph coverage is unchanged, so this is accepted.
 
-### Source File Formats
-The original sources are:
-- **VFB** (FontLab format) - proprietary binary, not compatible with gftools-builder
-- **SFD** (FontForge format) - open format, but not compatible with gftools-builder
+## Original repository (dormant)
 
-There are no `.glyphs`, `.ufo`, or `.designspace` files. The sources are entirely legacy formats.
-
-### Build Configuration
-- **No `config.yaml`** exists in the upstream repo
-- **No `config.yaml` override** exists in the google/fonts family directory
-- The `.travis.yml` references `fontbakery-build.py`, an older build system from 2014
-- The `METADATA_comments.txt` shows the original Google Font Directory subsetting workflow using `subset.py`
-
-### Designer Information
-- **Sabrina Mariela Lopez** (TypeSenses)
-- Contact: typesenses@live.com.ar
-- Website: www.typesenses.com (referenced in font metadata)
-- No known personal GitHub repository for this font
-
-### About the librefonts Organization
-The librefonts GitHub organization is **not** the original designer's repository. It is an archival project that extracted Google Fonts families into individual repos with TTX decompositions. The single commit by hash3g (a Google Fonts infrastructure contributor) confirms this is an automated extraction, not an active development repository.
-
-### Font Details
-- **Version**: 1.002
-- **Created**: Mon Feb 6 13:07:54 2012 (per head table)
-- **Units per Em**: 1250
-- **Copyright**: Copyright (c) 2012 Sabrina Mariela Lopez (typesenses@live.com.ar), with Reserved Font Name "Euphoria Script"
-
-## Conclusion
-
-Euphoria Script has a known upstream repository at `https://github.com/librefonts/euphoriascript` with a single commit (`c7606fa`). This is an archival repo, not the original designer's repository. The sources are legacy formats (VFB and SFD) that are not compatible with gftools-builder, so no `config.yaml` can be created. The font has not been updated since its original onboarding in 2012.
-
-### Recommended METADATA.pb Source Block
-```
-source {
-  repository_url: "https://github.com/librefonts/euphoriascript"
-  commit: "c7606fae5a17e051d983269f008dba6e8f4c0c77"
-}
-```
-
-No `config_yaml` field is applicable since the sources are SFD/VFB only.
-
-### Status Summary
-- **Repository URL**: Verified (HTTP 200)
-- **Commit Hash**: `c7606fae5a17e051d983269f008dba6e8f4c0c77` (only commit in repo)
-- **Config**: None (SFD-only sources, not gftools-builder compatible)
-- **Overall Status**: missing_config (inherent limitation - legacy sources only)
+The original FontForge sources are at https://github.com/librefonts/euphoriascript (`.sfd`), latest at commit `c7606fae5a17e051d983269f008dba6e8f4c0c77`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/ewert/METADATA.pb
+++ b/ofl/ewert/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 stroke: "SERIF"
 classifications: "DISPLAY"
 source {
-  commit: "21fa9ed2031b8f7f1bec75cb3f91ad495e3b2370"
-  repository_url: "https://github.com/librefonts/ewert"
+  repository_url: "https://github.com/googlefonts/ewert"
+  commit: "1fdc40c5b4f330020515d69ca4e3d1fd18e1df64"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Ewert-Regular.ttf"
+    dest_file: "Ewert-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/ewert/upstream_info.md
+++ b/ofl/ewert/upstream_info.md
@@ -1,91 +1,25 @@
-# Ewert - Investigation Report
+# Ewert
 
-## Family Details
-- **Family name**: Ewert
-- **Designer**: Johan Kallas, Mihkel Virkus
-- **License**: OFL
-- **Category**: DISPLAY
-- **Date added**: 2012-02-08
-- **Path in google/fonts**: `ofl/ewert`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Repository
-- **Repository URL**: https://github.com/librefonts/ewert
-- **Status**: Accessible (HTTP 200)
-- **Branch**: master
+## Initial state
 
-## Repository Analysis
+Google Fonts shipped Ewert (Regular) built from FontForge SFD sources at https://github.com/librefonts/ewert. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-### Commit History
-The repository contains a single commit:
+## Actions taken
 
-| Commit | Date | Author | Message |
-|--------|------|--------|---------|
-| `21fa9ed` | 2014-10-17 | hash3g | update .travis.yml |
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/ewert, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-This is a single-commit repository created by the `librefonts` GitHub organization (maintained by hash3g). The librefonts org migrated individual font families from the monolithic Google Font Directory into separate per-family repositories, each with CI via Travis CI and fontbakery.
+## Final state
 
-### Source Files
-The repository contains:
-- `src/Ewert-Regular-TTF.sfd` -- FontForge SFD source (558,360 bytes)
-- `src/Ewert-Regular-OTF.vfb` -- FontLab VFB binary source (119,693 bytes)
-- Various TTX dumps of the compiled TTF and OTF files
-- `METADATA.json`, `FONTLOG.txt`, `OFL.txt`, `DESCRIPTION.en_us.html`
-- `.travis.yml` for CI with fontbakery
+The source now lives at https://github.com/googlefonts/ewert (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
-The primary source format is **SFD (FontForge)**, which is not compatible with gftools-builder. There are no `.glyphs`, `.ufo`, or `.designspace` files.
+## Verification
 
-### Config File
-- **No config.yaml** in the upstream repository
-- **No config.yaml** in the google/fonts family directory
-- Not applicable: SFD sources are not compatible with gftools-builder
+Matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. Eight glyphs were renamed to their production names; cmap coverage is unchanged, so this difference is benign.
 
-## Google Fonts History
+## Original repository (dormant)
 
-### Binary File History
-The TTF file (`Ewert-Regular.ttf`, 70,752 bytes) was added in the initial commit of the google/fonts repository:
-- Commit `90abd17b` (2015-03-07) by Dave Crossland -- "Initial commit"
-- The font has never been updated since being added to the repository.
-
-### Font Metadata (from binary)
-- **Version**: 1.001
-- **Copyright**: Copyright (c) 2011, Johan Kallas, Copyright (c) 2011 Mihkel Virkus
-- **Unique ID**: JohanKallas,MihkelVirkus: Ewert: 2012
-- **Created/Modified**: Fri Feb 3 21:13:17 2012
-
-The font was originally created in February 2012 and released as version 1.001.
-
-### METADATA.pb Changes
-1. `90abd17b` (2015-03-07) -- Initial commit (added with the entire google/fonts repo)
-2. `480630de` -- Tentative update to METADATA.pb textprotos
-3. `27f377ab` -- Update copyright field
-4. `883939708` -- Remove METADATA.json files
-5. `06331b24` (2021-03-22) -- Ewert: Multiple designers fixed (#3228) by Rosalie Wagner
-6. Various language support and classification batch updates
-7. `df925b959` (2026-02-27) -- Ewert: add source block to METADATA.pb (also added upstream_info.md)
-
-## Commit Hash Verification
-
-Since the librefonts/ewert repository has only a single commit (`21fa9ed`), and the TTX dumps in the repository match the font metadata in the google/fonts binary (Version 1.001, same copyright, same name table entries), the commit hash `21fa9ed2031b8f7f1bec75cb3f91ad495e3b2370` is the correct reference.
-
-The upstream repo was created on 2014-10-17, while the font was added to Google Fonts on 2012-02-08 (pre-dating the librefonts repo). This confirms the librefonts repo is a migration of the original sources, not the original development repository. The original sources from the designers (Johan Kallas and Mihkel Virkus) are not available in a separate public repository.
-
-## Recommended Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/ewert"
-  commit: "21fa9ed2031b8f7f1bec75cb3f91ad495e3b2370"
-}
-```
-
-No `config_yaml` field is needed because the sources are SFD-only (FontForge format), which is not compatible with gftools-builder.
-
-## Status
-- **Status**: complete (SFD-only sources)
-- **Confidence**: HIGH
-- **Config**: none (SFD-only sources)
-
-## Notes
-- The librefonts organization was a community effort by hash3g to split the monolithic Google Font Directory into individual per-family repositories with CI integration.
-- The SFD and VFB sources are legacy formats. If this font were to be rebuilt, the sources would need to be converted to a gftools-compatible format (.glyphs, .ufo, or .designspace).
-- The font has not been updated since its original onboarding in 2012.
+The original FontForge sources are at https://github.com/librefonts/ewert (`.sfd`), latest at commit `21fa9ed2031b8f7f1bec75cb3f91ad495e3b2370`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/felipa/METADATA.pb
+++ b/ofl/felipa/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 stroke: "SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/felipa"
-  commit: "3489dd2445fc633f3b32485420d9c56998fad093"
+  repository_url: "https://github.com/googlefonts/felipa"
+  commit: "1ba44f83532b9074cc71a2c13c526dea5118bb50"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Felipa-Regular.ttf"
+    dest_file: "Felipa-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/felipa/upstream_info.md
+++ b/ofl/felipa/upstream_info.md
@@ -1,81 +1,26 @@
-# Investigation Report: Felipa
+# Felipa
 
-## Family Details
-- **Family name**: Felipa
-- **Designer**: Fontstage (Javier Alcaraz)
-- **License**: OFL
-- **Category**: Handwriting / Display
-- **Date added to Google Fonts**: 2012-02-08
-- **Google Fonts path**: `ofl/felipa`
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source of Truth in google/fonts
-- **Binary file**: `Felipa-Regular.ttf` (40,000 bytes)
-- **Font version**: Version 1.001
-- **Font created date**: 2012-02-03
-- **SHA-256**: `d3f07e2669e046acc1030139a4b08046d7eca87c0b477a8cc99ac1c46af84edc`
-- **Initial commit in google/fonts**: `90abd17b4f97671435798b6147b698aa9087612f` (2015-03-07, by Dave Crossland) -- this was the initial import of the entire library into the current google/fonts repo structure
-- **Binary never modified**: The TTF has not been updated since the initial commit
+## Initial state
 
-## Upstream Repository
-- **Repository URL**: https://github.com/librefonts/felipa
-- **Status**: Accessible (HTTP 200)
-- **Commit**: `3489dd2445fc633f3b32485420d9c56998fad093` (only commit in the repo)
-- **Commit date**: 2014-10-17
-- **Commit author**: hash3g (hash.3g@gmail.com)
-- **Commit message**: "update .travis.yml"
-- **Branch**: `master`
+Google Fonts shipped Felipa (Regular) built from FontForge SFD sources at https://github.com/librefonts/felipa. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-### Repository Nature
-This is a typical **librefonts archive repository**, created by hash3g in October 2014 to preserve sources from the Google Font Directory. The repository has a single commit and contains:
+## Actions taken
 
-- **Root directory**: TTX files (XML decomposition of the compiled TrueType font tables), plus DESCRIPTION, FONTLOG, OFL.txt, METADATA.json
-- **src/ directory**: Original source files
-  - `Felipa-Regular-TTF.sfd` (FontForge SFD format, 276 KB)
-  - `Felipa-Regular.vfb` (FontLab VFB format, 143 KB -- binary, proprietary)
-  - OTF TTX decompositions
-  - `METADATA_comments.txt` (subsetting commands from the old Google Font Directory workflow)
-  - `VERSIONS.txt` (records "Version 1.001")
-- **No compiled font binaries** (.ttf or .otf) in the repo -- only TTX decompositions
-- **`.travis.yml`**: Old CI configuration using fontbakery-build.py (now defunct)
+- The canonical FontForge SFD source (`src/Felipa-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The non-breaking space (U+00A0) advance width was corrected to 200 to match the space glyph.
+- A new Unified Font Repository was created at https://github.com/googlefonts/felipa, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### Source File Assessment
-- **SFD file** (`Felipa-Regular-TTF.sfd`): FontForge SplineFont Database format. This is a TTF-mastered SFD, not directly usable with gftools-builder.
-- **VFB file** (`Felipa-Regular.vfb`): FontLab Studio binary format. Proprietary and not usable with modern open-source toolchains.
-- **No `.glyphs`, `.ufo`, or `.designspace` sources**: The font predates modern open-source font development workflows.
-- **No `config.yaml`**: Not present and not applicable -- there are no gftools-builder compatible sources.
+## Final state
 
-## FONTLOG Evidence
-The FONTLOG in the repository lists:
-- Source files: `Felipa-Regular-OTF.vfb` (Mastered OTF source) and `Felipa-Regular-TTF.sfd` (Mastered TTF source)
-- Designer: Javier Alcaraz (info@fontstage.com, www.fontstage.com)
-- Initial release: 3 February 2012, v1.001
+The source now lives at https://github.com/googlefonts/felipa (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-## Commit Hash Verification
-Since the upstream repo has only a single commit (`3489dd2`), this is the only possible reference. The commit is dated 2014-10-17, which is after the font was added to Google Fonts (2012-02-08), consistent with librefonts repos being created as post-hoc archives. The font sources in the repo match the font metadata (same version, same copyright, same designer info).
+## Verification
 
-## Current METADATA.pb State
-The current METADATA.pb on the `main` branch of google/fonts does **not** have a source block. A source block was added on branch `sources_info_2026-02-25` (commit `9a14639f3`) with:
-```
-source {
-  repository_url: "https://github.com/librefonts/felipa"
-  commit: "3489dd2445fc633f3b32485420d9c56998fad093"
-}
-```
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 12 glyphs were renamed to their standard production names; the set of encoded characters is unchanged, so this is cosmetic and acceptable.
 
-## Recommendation
+## Original repository (dormant)
 
-### Source Block
-```
-source {
-  repository_url: "https://github.com/librefonts/felipa"
-  commit: "3489dd2445fc633f3b32485420d9c56998fad093"
-}
-```
-
-- **No `config_yaml` field** is needed -- the sources are SFD/VFB only, not compatible with gftools-builder.
-- **No override `config.yaml`** is needed -- there are no buildable sources (.glyphs/.ufo/.designspace) to configure.
-
-### Status
-- **Status**: `complete` (SFD-only sources)
-- **Confidence**: HIGH
-- **Rationale**: Single-commit archive repo with only SFD/VFB sources. The repo URL is valid, the commit hash is the only commit, and the source files match the font metadata. No config.yaml is possible or needed.
+The original FontForge sources are at https://github.com/librefonts/felipa (`.sfd`), latest at commit `3489dd2445fc633f3b32485420d9c56998fad093`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/fenix/METADATA.pb
+++ b/ofl/fenix/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/fenix"
-  commit: "b5107c124ba8762eeaccd00b73a7302897d4367e"
+  repository_url: "https://github.com/googlefonts/fenix"
+  commit: "cfae6dd0422933ef47db060c6710166fb5ed30d1"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Fenix-Regular.ttf"
+    dest_file: "Fenix-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/fenix/upstream_info.md
+++ b/ofl/fenix/upstream_info.md
@@ -1,105 +1,26 @@
-# Investigation Report: Fenix
+# Fenix
 
-## Family Details
-- **Family name**: Fenix
-- **Designer**: Fernando Diaz
-- **License**: OFL
-- **Category**: Serif
-- **Date added to Google Fonts**: 2012-09-24
-- **Fonts**: Fenix-Regular.ttf (400 normal)
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Upstream Repository
-- **URL**: https://github.com/librefonts/fenix
-- **Status**: Accessible (HTTP 200)
-- **Owner**: librefonts (organization)
-- **Default branch**: master
-- **Created**: 2014-07-16
-- **Last pushed**: 2014-10-17
-- **Contributors**: vitalyvolkov, xen
+## Initial state
 
-## Commit Analysis
-- **Total commits**: 1
-- **Only commit**: `b5107c124ba8762eeaccd00b73a7302897d4367e` (2014-10-17, by hash3g)
-- **Commit message**: "update .travis.yml"
-- **Confidence**: HIGH -- there is only one commit in the entire repository, so this is unambiguously the correct reference.
+Google Fonts shipped Fenix (Regular) built from FontForge SFD sources at https://github.com/librefonts/fenix. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Source Files in Upstream Repository
+## Actions taken
 
-### Root directory (TTX decomposed from TTF binary):
-- `Fenix-Regular.ttf.*.ttx` (multiple table-split TTX files, ttLibVersion 2.4)
-- `DESCRIPTION.en_us.html`
-- `FONTLOG.txt`
-- `METADATA.json`
-- `OFL.txt`
-- `.travis.yml` (legacy Travis CI config using fontbakery-build.py)
+- The canonical FontForge SFD source (`Fenix-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected to 220 to match the space glyph.
+- A new Unified Font Repository was created at https://github.com/googlefonts/fenix, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### src/ directory (original design sources):
-- `Fenix-Regular-TTF.sfd` (FontForge SFD format, 282 KB)
-- `Fenix-Regular-OTF.vfb` (FontLab VFB format, 120 KB)
-- `Fenix-Regular.vfb` (FontLab VFB format, 178 KB)
-- `Fenix-Regular.otf.*.ttx` (OTF table-split TTX files)
-- `METADATA_comments.txt` (contains build/subset commands)
-- `VERSIONS.txt` (contents: "Fenix-Regular.ttf: 004.301")
+## Final state
 
-### Source type assessment:
-- **SFD-only sources** (FontForge format) plus VBF (FontLab format)
-- No `.glyphs`, `.ufo`, or `.designspace` files
-- Not compatible with gftools-builder
-- No `config.yaml` present or possible
+The source now lives at https://github.com/googlefonts/fenix (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
-## Binary Verification
+## Verification
 
-The font binary in google/fonts (`ofl/fenix/Fenix-Regular.ttf`, 45,144 bytes) matches the upstream TTX decomposition:
-- **Version string** (nameID 5): "004.301" -- matches both the binary and the upstream TTX
-- **Font creation date** (head table): Mon Oct 1 14:45:46 2012
-- **Font modification date** (head table): Mon Oct 1 14:45:46 2012
-- **checkSumAdjustment**: 0xd9d8ad71 (from upstream TTX)
-- **fontRevision**: 1.0
+Matched the shipped binary on every dimension checked: cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 5 glyphs were renamed to their AGL production names; coverage and rendering are unchanged, so the verdict is functional equivalence.
 
-The SFD file header confirms the same version: "Version: 004.301".
+## Original repository (dormant)
 
-## Google Fonts Repository History
-
-The font file history in google/fonts shows only two commits touching `ofl/fenix/`:
-1. `90abd17b4f` (2015-03-07) -- "Initial commit" by Dave Crossland. This was the bulk import of the entire Google Fonts library into the git repository. The font itself was added to Google Fonts on 2012-09-24, predating the git repo.
-2. `76adaf1d29` (2021-11-01) -- "deploy: c7e2740188205a85..." -- A deploy commit that deleted files (part of a repo restructure). The files were restored/maintained through the branch structure.
-
-No PRs or commits indicate any updates to the Fenix binary since original onboarding.
-
-## Repository Context
-
-The `librefonts` organization on GitHub appears to be a community archival effort to host libre/open-source font projects with their sources and TTX decompositions. The single commit was authored by "hash3g" (hash.3g@gmail.com), and the listed contributors are vitalyvolkov and xen. The repo was created on 2014-07-16, nearly two years after the font was added to Google Fonts.
-
-The METADATA_comments.txt file in `src/` contains the original subsetting and font-optimizer commands used during Google Fonts onboarding, confirming this is the authoritative source archive for this font.
-
-## Designer Information
-
-- **Designer**: Fernando Diaz (Fernando Diaz)
-- **Website**: www.ferfolio.com (currently suspended/inactive)
-- **Email**: fer@ferfolio.com (from METADATA.pb copyright), fenix@ferfolio.com (from FONTLOG)
-- **Copyright**: "Copyright (c) 2012, Fernando Diaz (www.ferfolio.com fer@ferfolio.com) with Reserved Font Name 'Fenix'"
-
-## Existing Source Block
-
-A source block was added to METADATA.pb in commit `9a14639f3c` (2026-02-25) as part of a batch addition of 602 source blocks:
-
-```
-source {
-  repository_url: "https://github.com/librefonts/fenix"
-  commit: "b5107c124ba8762eeaccd00b73a7302897d4367e"
-}
-```
-
-This source block is correct. The commit hash references the only commit in the repository.
-
-Note: This source block has not yet been merged into google/fonts main -- it was added in a local working branch.
-
-## Status and Recommendation
-
-- **Repository URL**: Confirmed correct (`https://github.com/librefonts/fenix`)
-- **Commit hash**: Confirmed correct (`b5107c124ba8762eeaccd00b73a7302897d4367e`, the only commit)
-- **Config**: None possible -- sources are SFD/VBF only, not compatible with gftools-builder
-- **Status**: `complete` (for source metadata purposes; no config.yaml needed or possible)
-- **Confidence**: HIGH
-
-No override `config.yaml` is needed or possible since the sources are in legacy formats (FontForge SFD and FontLab VBF) that are not supported by gftools-builder. The source block with repository_url and commit hash is sufficient.
+The original FontForge sources are at https://github.com/librefonts/fenix (`.sfd`), latest at commit `b5107c124ba8762eeaccd00b73a7302897d4367e`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/fjordone/METADATA.pb
+++ b/ofl/fjordone/METADATA.pb
@@ -15,6 +15,16 @@ fonts {
 subsets: "menu"
 subsets: "latin"
 source {
-  repository_url: "https://github.com/librefonts/fjordone"
-  commit: "90b0be2c47a5acd683621f38ce4f046f741abafb"
+  repository_url: "https://github.com/googlefonts/fjordone"
+  commit: "a6c1784e33666b26db68a0170055b9f41086240e"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/FjordOne-Regular.ttf"
+    dest_file: "FjordOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/fjordone/upstream_info.md
+++ b/ofl/fjordone/upstream_info.md
@@ -1,83 +1,23 @@
-# Investigation Report: Fjord One
+# Fjord One
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| **Family Name** | Fjord One |
-| **Designer** | Viktoriya Grabowska |
-| **License** | OFL |
-| **Date Added** | 2011-11-02 |
-| **Category** | Serif |
-| **Status** | complete (SFD-only sources) |
-| **Confidence** | HIGH |
+## Initial state
 
-## Upstream Repository
+The family shipped from the dormant librefonts repository, whose only sources were FontForge `.sfd` files under `src/`. METADATA.pb recorded that repository and commit but carried no `config_yaml`, and the sources could not be built by the current Rust pipeline.
 
-| Field | Value |
-|-------|-------|
-| **Repository URL** | https://github.com/librefonts/fjordone |
-| **Commit** | `90b0be2c47a5acd683621f38ce4f046f741abafb` |
-| **Branch** | master |
-| **Config** | none (SFD-only sources) |
+## Actions taken
 
-## Source Block (current METADATA.pb)
+The repository was forked to the Google Fonts org and rebuilt on the Unified Font Repository template. The single FontForge source `src/FjordOne-Regular-TTD.sfd` was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), and a build configuration was added. During conversion the non-breaking space (U+00A0) advance width was corrected to 537 to match the space glyph. The superseded `.sfd` sources and legacy build cruft were then retired.
 
-The current METADATA.pb (in our local clone, pending merge) has:
+## Final state
 
-```
-source {
-  repository_url: "https://github.com/librefonts/fjordone"
-  commit: "90b0be2c47a5acd683621f38ce4f046f741abafb"
-}
-```
+The repository builds `FjordOne-Regular.ttf` from the `.glyphs` source with gftools-builder3 and fontc. METADATA.pb points at the modernized repository, the post-conversion commit and the build configuration.
 
-This was added in commit `9a14639f3` ("Add source blocks to 602 more METADATA.pb files", 2026-02-25).
+## Verification
 
-## Investigation Details
+The freshly built TTF was compared against the shipped `FjordOne-Regular.ttf`: glyph coverage, outlines, metrics and layout matched. The verdict is FUNCTIONAL. Two benign differences were accepted: 9 glyphs were renamed to their production names (coverage unchanged), and GDEF now classifies one real combining mark (uni0326) that the shipped font had failed to mark.
 
-### Repository Verification
+## Original repository (dormant)
 
-The upstream repository at https://github.com/librefonts/fjordone is valid and accessible. It is cached locally at `upstream_repos/fontc_crater_cache/librefonts/fjordone/`.
-
-The repository is a **librefonts archive** repo, typical of early Google Fonts families that predate modern gftools infrastructure. It contains:
-
-- **Source files**: `src/FjordOne-Regular-TTD.sfd` (FontForge SFD, 467 KB), `src/FjordOne-Regular.vfb` (FontLab VFB, 115 KB)
-- **TTX decompositions**: Multiple `.ttx` files for both TTF and OTF binaries in the repo root
-- **Metadata**: `METADATA.json`, `FONTLOG.txt`, `OFL.txt`, `DESCRIPTION.en_us.html`
-- **No config.yaml**: SFD/VFB sources are not compatible with gftools-builder
-- **No pre-built binaries in repo**: The TTF/OTF are only present as TTX decompositions
-
-### Commit Hash Verification
-
-The repository has only a **single commit**: `90b0be2c47a5acd683621f38ce4f046f741abafb` (2014-10-17, by hash3g, "update .travis.yml"). This is the HEAD of the master branch and the only commit available.
-
-Since the librefonts repos were created as archives of the original Google Code font directory sources, and there is only one commit, this commit represents the complete state of all archived source files. The referenced commit is the only possible choice.
-
-### Google Fonts History
-
-1. **Initial commit** (`90abd17b4`, 2015-03-07): Fjord One was included in the initial import of the google/fonts repository. The binary `FjordOne-Regular.ttf` (54,156 bytes) was added here.
-2. **Deploy update** (`76adaf1d2`, 2021-11-01): A large deploy commit by m4rc1e that restructured the repository. This commit deleted and re-added many files including Fjord One's DESCRIPTION.en_us.html and FONTLOG.txt, but the binary font file itself was not modified -- it remains unchanged since the initial import.
-
-The font binary has been untouched since it was first added to google/fonts. The FONTLOG records:
-- Version 1.002 (2011-10-28): "Mastered Font from Fontlab VBF to TTF" by Eben Sorkin
-- Version 1.001 (2010-10-27): "Completed first complete version of Fjord in Fontlab (VBF format)" by Viktoriya Grabowska
-
-### Config.yaml Status
-
-No config.yaml is possible for this family. The source files are:
-- `FjordOne-Regular-TTD.sfd` -- FontForge SFD format
-- `FjordOne-Regular.vfb` -- FontLab VFB format (binary, not directly usable)
-
-Neither format is supported by gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` sources. No override config.yaml can be created.
-
-### Copyright and Attribution
-
-The copyright in google/fonts METADATA.pb and the upstream OFL.txt both state:
-> "Copyright (c) 2011, Sorkin Type Co (www.sorkintype.com) with Reserved Font Names 'Fjord' and 'Fjord One'"
-
-The font was designed by Viktoriya Grabowska and mastered by Eben Sorkin at Sorkin Type Co.
-
-## Conclusion
-
-Fjord One has a source block with a verified repository URL and the only available commit hash. The upstream repo is a librefonts archive containing only SFD/VFB sources, which are not compatible with gftools-builder. No config.yaml is possible. The status is as complete as it can be for a font with SFD-only sources.
+The original upstream lived at https://github.com/librefonts/fjordone, latest commit `90b0be2c47a5acd683621f38ce4f046f741abafb` on branch `master`. It contained only FontForge `.sfd` sources and had received no commits after the Google Fonts onboarding.

--- a/ofl/flamenco/METADATA.pb
+++ b/ofl/flamenco/METADATA.pb
@@ -24,6 +24,20 @@ fonts {
 subsets: "latin"
 subsets: "menu"
 source {
-  repository_url: "https://github.com/librefonts/flamenco"
-  commit: "908f93e92b13062e172153d04b96a9301ca1c7c5"
+  repository_url: "https://github.com/googlefonts/flamenco"
+  commit: "457c24c5400c78afac2d6cb6c24e1fec4d3cfbb6"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Flamenco-Light.ttf"
+    dest_file: "Flamenco-Light.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Flamenco-Regular.ttf"
+    dest_file: "Flamenco-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/flamenco/upstream_info.md
+++ b/ofl/flamenco/upstream_info.md
@@ -1,100 +1,26 @@
-# Investigation Report: Flamenco
+# Flamenco
 
-## Family Details
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-- **Family name**: Flamenco
-- **Designer**: LatinoType (Luciano Vergara)
-- **Category**: Display
-- **Date added to Google Fonts**: 2011-12-19
-- **License**: OFL
-- **Weights**: Light (300), Regular (400)
-- **Current version in Google Fonts**: 1.003
-- **Google Fonts path**: ofl/flamenco
+## Initial state
 
-## Upstream Repository
+Google Fonts shipped Flamenco (Light and Regular) built from FontForge SFD sources at https://github.com/librefonts/flamenco. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-- **URL**: https://github.com/librefonts/flamenco
-- **Status**: Active (not archived), publicly accessible
-- **Default branch**: master
-- **Total commits**: 1 (single commit: `908f93e`)
-- **Last push**: 2014-10-17
+## Actions taken
 
-## Source Files Analysis
+- The canonical FontForge SFD sources (`Flamenco-Light-TTF.sfd` and `Flamenco-Regular-TTF.sfd`) were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- In conversion the non-breaking space advance width was corrected and OS/2 usWeightClass was set to 300 on the Light source.
+- A new Unified Font Repository was created at https://github.com/googlefonts/flamenco, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-The upstream repository contains only legacy source formats:
+## Final state
 
-- `src/Flamenco-Light-TTF.sfd` (FontForge SFD)
-- `src/Flamenco-Regular-TTF.sfd` (FontForge SFD)
-- `src/Flamenco-Light-OTF.vfb` (FontLab VFB)
-- `src/Flamenco-Regular-OTF.vfb` (FontLab VFB)
+The source now lives at https://github.com/googlefonts/flamenco (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
-No `.glyphs`, `.glyphx`, `.ufo`, or `.designspace` files exist. No `config.yaml` is present. These sources are **not compatible with gftools-builder**.
+## Verification
 
-The repo also contains TTX dumps of the font tables (in both the root directory and `src/`) and a `.travis.yml` for legacy fontbakery CI.
+Both weights matched the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 5 glyphs were renamed to their production names in each weight, which leaves cmap coverage unchanged and is therefore accepted (verdict: FUNCTIONAL).
 
-## Version History
+## Original repository (dormant)
 
-| Version | Location | Notes |
-|---------|----------|-------|
-| 1.002 | Upstream repo (SFD/VFB sources, TTX dumps) | Only version in the repo |
-| 1.003 | google/fonts (current binaries) | Updated via PR #887 (May 2017) |
-
-## Commit Hash Verification
-
-The upstream repo has only a single commit:
-
-- **Commit**: `908f93e92b13062e172153d04b96a9301ca1c7c5`
-- **Date**: 2014-10-17
-- **Author**: hash3g (hash.3g@gmail.com)
-- **Message**: "update .travis.yml"
-
-This is an initial import commit that added all files at once (72 files). Since there is only one commit in the entire repo, this is trivially the correct reference point.
-
-## Google Fonts History
-
-1. **Initial commit** (`90abd17b4`, 2015-03-07): Font first added to google/fonts repo.
-2. **PR #887** (`f1fe299e0`, 2017-05-08): Marc Foley updated fonts to v1.003 ("hotfix-flamenco: v1.003 added"). This updated both .ttf files and adjusted METADATA.pb. The PR body was empty -- no link to upstream sources or details about what was fixed.
-3. **Copyright fixup** (`ac5149724`, 2017-05-08): Dave Crossland fixed a double-space in copyright strings in METADATA.pb.
-4. Various METADATA.pb-only changes (language support, formatting, etc.)
-
-The v1.003 binaries in google/fonts do **not** correspond to any commit in the upstream repo, which only contains v1.002 sources. The v1.003 update was done by Marc Foley directly without updating the upstream repo.
-
-## METADATA.pb Source Block
-
-Current METADATA.pb on upstream/main has **no source block**.
-
-A source block was added on the local branch `sources_info_2026-02-25`:
-
-```
-source {
-  repository_url: "https://github.com/librefonts/flamenco"
-  commit: "908f93e92b13062e172153d04b96a9301ca1c7c5"
-}
-```
-
-## Config.yaml Assessment
-
-**No config.yaml can be created.** The upstream repo has only SFD (FontForge) and VFB (FontLab) sources. These formats are not supported by gftools-builder, so no override config.yaml is applicable.
-
-## Findings
-
-- The upstream repo `librefonts/flamenco` is the correct source repository for this font family.
-- The repo has a single commit (`908f93e`) which is the only possible reference point.
-- The current fonts in google/fonts (v1.003) were updated beyond what the upstream repo contains (v1.002). The v1.003 hotfix by Marc Foley was done without updating the upstream repo.
-- Sources are SFD/VFB only -- not gftools-builder compatible. No config.yaml is needed or possible.
-
-## Recommended Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/flamenco"
-  commit: "908f93e92b13062e172153d04b96a9301ca1c7c5"
-}
-```
-
-## Status
-
-- **Status**: no_config (SFD-only sources)
-- **Confidence**: HIGH
-- The repository URL and commit hash are verified. The single-commit repo makes hash verification trivial.
-- No config.yaml is applicable due to SFD/VFB-only sources.
+The original FontForge sources are at https://github.com/librefonts/flamenco (`.sfd`), latest at commit `908f93e92b13062e172153d04b96a9301ca1c7c5`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/fresca/METADATA.pb
+++ b/ofl/fresca/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/fresca"
-  commit: "ca8ad60bad380c425ebe357ee8a3a71770a849b4"
+  repository_url: "https://github.com/googlefonts/fresca"
+  commit: "6f0f0d00ca1fc37032e87cb12c365a1a31bea443"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Fresca-Regular.ttf"
+    dest_file: "Fresca-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/fresca/upstream_info.md
+++ b/ofl/fresca/upstream_info.md
@@ -1,70 +1,26 @@
-# Investigation Report: Fresca
+# Fresca
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Fresca is a sans-serif display font designed by Ivan Moreno of Fontstage, added to Google Fonts on 2011-12-07. The font has never been updated since its initial inclusion in the google/fonts repository. The only known upstream repository is `librefonts/fresca`, which is a mirror containing TTX decompositions and legacy source files (VFB and SFD formats). There are no gftools-builder compatible sources (.glyphs, .ufo, .designspace), so no config.yaml can be created.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Fresca (Regular) built from FontForge SFD sources at https://github.com/librefonts/fresca. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field             | Value                                              |
-|-------------------|----------------------------------------------------|
-| Family Name       | Fresca                                             |
-| Designer          | Fontstage (Ivan Moreno)                            |
-| Repository URL    | https://github.com/librefonts/fresca               |
-| Commit Hash       | ca8ad60bad380c425ebe357ee8a3a71770a849b4           |
-| Branch            | master                                             |
-| Config YAML       | None (no gftools-builder compatible sources)       |
-| Status            | no_config_possible                                 |
-| Confidence        | HIGH                                               |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source (`src/Fresca-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The converted source was corrected: the non-breaking space (U+00A0) advance width was fixed to match the space glyph (253).
+- A new Unified Font Repository was created at https://github.com/googlefonts/fresca, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### METADATA.pb Analysis
+## Final state
 
-The current METADATA.pb has no source block. The font was added on 2011-12-07, predating the source metadata system.
+The source now lives at https://github.com/googlefonts/fresca (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-### google/fonts Commit History
+## Verification
 
-The font binary `Fresca-Regular.ttf` was added in the initial commit (`90abd17b4`) on 2015-03-07 (when the repo was created on GitHub) and has never been modified since. The only other commits touching the fresca directory are metadata updates (METADATA.json removal, METADATA.pb updates for language support, stroke/classifications).
+The rebuilt Fresca-Regular was compared against the shipped binary and matched on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle and the GSUB/GPOS feature sets. The verdict is FUNCTIONAL, with these accepted differences: the FontForge legacy glyph `nonmarkingreturn` was dropped; 14 glyphs were renamed to production names with coverage unchanged; the new GDEF correctly classifies two combining marks (U+0307, U+0326) that the shipped font failed to mark; and one combining mark (U+0307) had its advance zeroed, where the shipped font had given it a spacing advance.
 
-### Upstream Repository
+## Original repository (dormant)
 
-The only upstream repository found is `librefonts/fresca` (https://github.com/librefonts/fresca). This is a librefonts mirror with a single commit (`ca8ad60`, dated 2014-10-17, by hash3g, message: "update .travis.yml").
-
-The repository contains:
-- **Source files**: `src/Fresca-Regular-OTF.vfb` (FontLab format) and `src/Fresca-Regular-TTF.sfd` (FontForge format)
-- **TTX decompositions**: Multiple `.ttx` files decomposed from the binary
-- **Standard metadata**: FONTLOG.txt, OFL.txt, DESCRIPTION.en_us.html, METADATA.json
-
-The source files are in legacy formats (VFB, SFD) that are not compatible with gftools-builder. No `.glyphs`, `.ufo`, or `.designspace` files exist.
-
-### Designer Information
-
-The FONTLOG identifies Ivan Moreno (info@fontstage.com, www.fontstage.com) as the type designer. No other GitHub repositories from Fontstage were found.
-
-### Search for Alternative Upstream Repos
-
-- No repository found under googlefonts organization
-- No repository found under any other GitHub organization
-- GitHub search for "fresca font" returned no relevant results
-- The librefonts mirror is the only known repository
-
-## Conclusion
-
-Fresca has a known upstream repository (`librefonts/fresca`) but it only contains legacy VFB/SFD sources, not gftools-builder compatible formats. No config.yaml can be created. The source block should document the repository URL and commit for reference purposes, noting the absence of buildable sources.
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/fresca"
-  commit: "ca8ad60bad380c425ebe357ee8a3a71770a849b4"
-  files {
-    source_file: "OFL.txt"
-    dest_file: "OFL.txt"
-  }
-  branch: "master"
-}
-```
-
-**Note**: No `config_yaml` field because the repository only contains VFB/SFD sources, which are not gftools-builder compatible. The font binary in google/fonts predates the librefonts mirror and was likely compiled manually from the VFB source.
+The original FontForge sources are at https://github.com/librefonts/fresca (`.sfd`), latest at commit `ca8ad60bad380c425ebe357ee8a3a71770a849b4`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/fugazone/METADATA.pb
+++ b/ofl/fugazone/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/fugazone"
-  commit: "d6fef0584e47767dc53d0144d0d41de77088184b"
+  repository_url: "https://github.com/googlefonts/fugazone"
+  commit: "cc513bad4e98bf35e593423ddcbe6a71ec532143"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/FugazOne-Regular.ttf"
+    dest_file: "FugazOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/fugazone/upstream_info.md
+++ b/ofl/fugazone/upstream_info.md
@@ -1,58 +1,25 @@
-# Investigation Report: Fugaz One
+# Fugaz One
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Fugaz One is a display typeface designed by LatinoType, added to Google Fonts on 2011-12-19. The upstream repository is at `https://github.com/librefonts/fugazone`, which contains only SFD and VFB source files. No gftools-builder compatible sources exist, so no config.yaml is possible. The repo has a single commit.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Fugaz One (Regular) built from FontForge SFD sources at https://github.com/librefonts/fugazone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field             | Value |
-|-------------------|-------|
-| Family Name       | Fugaz One |
-| Designer          | LatinoType |
-| Repository URL    | https://github.com/librefonts/fugazone |
-| Commit Hash       | d6fef0584e47767dc53d0144d0d41de77088184b |
-| Config YAML       | N/A (SFD-only sources) |
-| Status            | **no_config_possible** |
-| Confidence        | HIGH |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source (`FugazOne-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`). Four glyphs were renamed to their production names during conversion; glyph coverage was unchanged.
+- A new Unified Font Repository was created at https://github.com/googlefonts/fugazone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### Google Fonts History
+## Final state
 
-The font was part of the initial commit to the google/fonts repository (commit `90abd17b4`, dated 2015-03-07, by Dave Crossland). The font was originally added to Google Fonts on 2011-12-19 per METADATA.pb.
+The source now lives at https://github.com/googlefonts/fugazone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
-No source block exists in the current METADATA.pb on the main branch. A source block was added in commit `9a14639f3` ("Add source blocks to 602 more METADATA.pb files") but this commit appears to be on a local branch, not yet merged to the upstream google/fonts main.
+## Verification
 
-### Upstream Repository
+Matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 4 glyphs were renamed to their production names, which leaves coverage and rendering unchanged.
 
-- **URL**: https://github.com/librefonts/fugazone
-- **Cached at**: `upstream_repos/fontc_crater_cache/librefonts/fugazone`
-- **Single commit**: `d6fef05` (2014-10-17) - "update .travis.yml"
-- The repo was created as a migration/archive of the original font sources
+## Original repository (dormant)
 
-### Source Files
-
-The repository contains:
-- `src/FugazOne-Regular-TTF.sfd` - Spline Font Database (FontForge format)
-- `src/FugazOne-Regular-OTF.vfb` - FontLab VFB binary format
-- TTX decomposed font tables in root and `src/` directories
-
-No `.glyphs`, `.ufo`, or `.designspace` files exist. The sources are in legacy formats (SFD, VFB) that are not compatible with gftools-builder.
-
-### Config YAML
-
-No config.yaml exists in the upstream repository, and none can be created because the sources are in SFD/VFB format only, which gftools-builder does not support.
-
-## Conclusion
-
-The source metadata is straightforward. The repository URL and commit hash are verified. No config.yaml is possible due to SFD-only sources.
-
-### Recommended METADATA.pb source block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/fugazone"
-  commit: "d6fef0584e47767dc53d0144d0d41de77088184b"
-}
-```
+The original FontForge sources are at https://github.com/librefonts/fugazone (`.sfd`), latest at commit `d6fef0584e47767dc53d0144d0d41de77088184b`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/gafata/METADATA.pb
+++ b/ofl/gafata/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/gafata"
-  commit: "dcd42b72333486b9704c2d3736e3c26b0346cb67"
+  repository_url: "https://github.com/googlefonts/gafata"
+  commit: "145c6761d3cf3aa1522f0bcec92b5378f67e4139"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Gafata-Regular.ttf"
+    dest_file: "Gafata-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/gafata/upstream_info.md
+++ b/ofl/gafata/upstream_info.md
@@ -1,88 +1,24 @@
-# Investigation Report: Gafata
+# Gafata
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Gafata is a Latin sans-serif font designed by Lautaro Hourcade, present in Google Fonts since the initial commit (2015-03-07). The upstream repository is `https://github.com/librefonts/gafata`, which contains only legacy source formats: FontForge SFD (`.sfd`) and FontLab VFB (`.vfb`). There is no `config.yaml` and no gftools-builder-compatible sources (.glyphs, .ufo, .designspace). The repository has only a single commit and was likely created as a mirror of the original Google Code hosting.
+## Initial state
 
-## Key Findings
+The family shipped from FontForge `.sfd` sources with no gftools-builder configuration. METADATA.pb pointed at the librefonts repository but recorded no config_yaml, so the family could not be rebuilt by the current pipeline.
 
-| Field              | Value                                                      |
-|--------------------|------------------------------------------------------------|
-| Family Name        | Gafata                                                     |
-| Designer           | Lautaro Hourcade                                           |
-| License            | OFL                                                        |
-| Date Added         | 2012-10-31                                                 |
-| Repository URL     | https://github.com/librefonts/gafata                       |
-| Commit Hash        | dcd42b72333486b9704c2d3736e3c26b0346cb67                   |
-| Config YAML        | None (SFD-only sources)                                    |
-| Source Type         | FontForge SFD, FontLab VFB                                |
-| Status             | no_config_possible                                         |
-| Confidence         | HIGH                                                       |
+## Actions taken
 
-## Investigation Details
+The `src/Gafata-Regular-TTF.sfd` source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), producing `sources/Gafata-Regular.glyphs`. During conversion the `aalt` feature was repaired and the no-break space (U+00A0) advance width was corrected to 228. The repository adopted the Unified Font Repository template and a gftools-builder configuration was added; the superseded FontForge sources and legacy build cruft were retired.
 
-### Onboarding History
+## Final state
 
-Gafata was present in the google/fonts repository since the initial commit `90abd17b4` (2015-03-07) by Dave Crossland. The font itself was originally released on 2012-10-31. Subsequent commits only modified metadata (METADATA.pb, languages, stroke/classification).
+The repository builds Gafata-Regular.ttf from the `.glyphs` source via gftools-builder3 and fontc.
 
-### Upstream Repository
+## Verification
 
-The upstream repository at `https://github.com/librefonts/gafata` is accessible and verified. It was created under the `librefonts` organization, which hosts mirrors of fonts originally from Google Code.
+The freshly built Gafata-Regular.ttf was compared against the shipped binary. The verdict was FUNCTIONAL: glyph coverage, metrics and layout matched, with the only difference being 5 glyphs renamed to their production names (coverage unchanged), which is an expected consequence of the Glyphs conversion.
 
-The repository contains a single commit:
-- `dcd42b7` (2014-10-17) by hash3g: "update .travis.yml"
+## Original repository (dormant)
 
-This commit is the initial (and only) commit in the repository, adding all files at once including the Travis CI configuration.
-
-### Repository Contents
-
-The repository has the following structure:
-- Root level: TTX decomposed font tables (`.ttx` files for various tables like `_c_m_a_p`, `_g_l_y_f`, etc.)
-- `src/Gafata-Regular-OTF.vfb` - FontLab VFB source (117 KB)
-- `src/Gafata-Regular-TTF.sfd` - FontForge SFD source (221 KB)
-- `src/Gafata-Regular-before_ttfautohint.ttf.*` - Pre-autohint TTX decompositions
-- `src/Gafata-Regular.otf.*` - OTF TTX decompositions
-- `FONTLOG.txt` - Font changelog and history
-- `METADATA.json` - Legacy metadata format
-- `.travis.yml` - CI configuration
-
-### Source File Assessment
-
-The only editable source files are:
-1. **Gafata-Regular-TTF.sfd** (FontForge format) - TrueType outlines with hinting
-2. **Gafata-Regular-OTF.vfb** (FontLab format) - Merged contours for OTF
-
-Neither format is compatible with gftools-builder. The VFB format is proprietary (FontLab 5) and the SFD format is FontForge-specific. There are no `.glyphs`, `.ufo`, or `.designspace` files.
-
-The FONTLOG confirms: "There are 2 Source files: 1. Gafata-Regular-OTF.vfb... 2. Gafata-Regular-TTF.sfd..."
-
-### Config.yaml Assessment
-
-No `config.yaml` exists in the upstream repository. Creating an override config.yaml is not possible because gftools-builder cannot process SFD or VFB source files. The sources would need to be converted to a modern format (.glyphs, .ufo, or .designspace) before a config.yaml could be useful.
-
-### Branch Information
-
-The repository has only one branch: `master` (default).
-
-### Historical Context
-
-The FONTLOG documents:
-- Initial release: October 30, 2012 (v4.001) by Lautaro Hourcade
-- Last update: March 1, 2013 (v4.002) - updated metrics, fixed Z metrics bug
-- Original source was hosted on Google Code (now defunct): `http://code.google.com/p/googlefontdirectory/`
-
-## Conclusion
-
-Gafata has a known upstream repository at `librefonts/gafata` with a single commit (`dcd42b7`). However, the sources are in legacy formats (SFD/VFB) that are not compatible with gftools-builder. No config.yaml can be created without first converting the sources to a modern format. The status is `no_config_possible`.
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/gafata"
-  commit: "dcd42b72333486b9704c2d3736e3c26b0346cb67"
-  branch: "master"
-}
-```
-
-Note: No `config_yaml` field is included because the upstream repo only has SFD/VFB sources that are incompatible with gftools-builder.
+Original repository: https://github.com/librefonts/gafata
+Latest commit: dcd42b72333486b9704c2d3736e3c26b0346cb67 (branch master)

--- a/ofl/galdeano/METADATA.pb
+++ b/ofl/galdeano/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/galdeano"
-  commit: "0325c647c669479930cc9126131a78ca5b942db9"
+  repository_url: "https://github.com/googlefonts/galdeano"
+  commit: "41268aaf05c1ab2716d0b4a8114aa6b7beff8e31"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Galdeano-Regular.ttf"
+    dest_file: "Galdeano-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/galdeano/upstream_info.md
+++ b/ofl/galdeano/upstream_info.md
@@ -1,71 +1,25 @@
-# Investigation Report: Galdeano
+# Galdeano
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Galdeano is a humanist sans-serif typeface designed by Dario Manuel Muhafara. It was part of the initial commit to the google/fonts repository on 2015-03-07. The upstream repository is `librefonts/galdeano`, a single-commit archive repo created by Alexei Vanyashin (hash3g) on 2014-10-17. The repo contains only legacy source formats (VFB and SFD) with no gftools-builder compatible sources.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Galdeano (Regular) built from FontForge SFD sources at https://github.com/librefonts/galdeano. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field             | Value                                                    |
-|-------------------|----------------------------------------------------------|
-| Family Name       | Galdeano                                                 |
-| Repository URL    | https://github.com/librefonts/galdeano                   |
-| Commit Hash       | 0325c647c669479930cc9126131a78ca5b942db9                 |
-| Config YAML       | None (SFD/VFB sources only)                              |
-| Source Type        | SFD + VFB (legacy formats)                               |
-| Status            | no_config_possible                                       |
-| Confidence        | HIGH                                                     |
-| Date Added        | 2011-12-07                                               |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source (`Galdeano-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/galdeano, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-### METADATA.pb Review
+## Final state
 
-The current METADATA.pb has no `source { }` block. The font is listed under the OFL license with designer "Dario Manuel Muhafara". Copyright references http://www.tipo.net.ar.
+The source now lives at https://github.com/googlefonts/galdeano (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
-### Git History in google/fonts
+## Verification
 
-- **90abd17b4** (2015-03-07): "Initial commit" by Dave Crossland - The font was included in the massive initial commit that added all fonts to the google/fonts repository.
-- **76adaf1d2**: Deploy commit (no font changes).
+The rebuilt font matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. Two benign differences were accepted: the FontForge legacy glyphs `.null` and `nonmarkingreturn` were dropped (they carry no cmap entry, so coverage is unchanged), and 7 glyphs were renamed to their production names with coverage unchanged.
 
-The font binary (Galdeano-Regular.ttf) has never been modified since the initial commit. All subsequent commits touching the directory were metadata-only changes (METADATA.pb updates, language support, etc.).
+## Original repository (dormant)
 
-### Upstream Repository
-
-The repo `librefonts/galdeano` was created on 2014-07-16 and last pushed on 2014-10-17. It contains a single commit:
-
-- **0325c64** (2014-10-17): "update .travis.yml" by hash3g (Alexei Vanyashin) - This is a squashed initial commit that includes all files: TTX decompositions, source files, metadata, and Travis CI configuration.
-
-The `librefonts` organization is a collection of archived font repos, typically migrated from the old Google Font Directory.
-
-### Source Files
-
-The repo contains legacy source formats only:
-- `src/Galdeano-Regular.vfb` - Original FontLab source
-- `src/Galdeano-Regular-OTF.vfb` - OTF-specific FontLab source
-- `src/Galdeano-Regular-TTF.sfd` - FontForge SFD source (TrueType outlines)
-
-Additionally, the repo has extensive TTX decompositions of both the TTF and OTF files at the root level and in `src/`.
-
-The `src/VERSIONS.txt` confirms: "Galdeano-Regular.ttf: Version 1.001"
-
-The `src/METADATA_comments.txt` contains the original subsetting/processing commands from the Google Font Directory workflow.
-
-### Config YAML Assessment
-
-No `config.yaml` exists. The only source formats are VFB (proprietary FontLab) and SFD (FontForge). Neither is compatible with gftools-builder. Creating an override config.yaml is not possible without converting the sources to a modern format first.
-
-## Conclusion
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/galdeano"
-  commit: "0325c647c669479930cc9126131a78ca5b942db9"
-}
-```
-
-**Status**: no_config_possible
-
-**Notes**: This is a legacy font from the original Google Font Directory era. The `librefonts/galdeano` repo is an archive containing VFB and SFD sources that are not compatible with gftools-builder. The single commit in the repo predates the google/fonts initial commit. No config.yaml can be created without first converting the sources to a modern format (UFO, .glyphs, or .designspace).
+The original FontForge sources are at https://github.com/librefonts/galdeano (`.sfd`), latest at commit `0325c647c669479930cc9126131a78ca5b942db9`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/geostar/METADATA.pb
+++ b/ofl/geostar/METADATA.pb
@@ -17,6 +17,16 @@ subsets: "latin"
 stroke: "SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/geostar"
-  commit: "ca481fdb49204442916697e3d7b1cf6fda792b77"
+  repository_url: "https://github.com/googlefonts/geostar"
+  commit: "cd70b3170a6db347032f02d4f773e2f0ecff25a3"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Geostar-Regular.ttf"
+    dest_file: "Geostar-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/geostar/upstream_info.md
+++ b/ofl/geostar/upstream_info.md
@@ -1,70 +1,25 @@
-# Investigation: Geostar
+# Geostar
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Geostar is a display serif font designed by Joe Prince (Admix Designs), added to Google Fonts on 2011-08-10. The font was part of the initial bulk import of the google/fonts repository. The upstream repository is https://github.com/librefonts/geostar, a single-commit archive containing TTX decompositions and legacy source files (SFD, VFB). No gftools-builder compatible sources exist, so no config.yaml is possible. The METADATA.pb currently has no source block.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Geostar (Regular) built from FontForge SFD sources at https://github.com/librefonts/geostar (`src/Geostar-Regular-TTF.sfd`). METADATA.pb carried a bare source block with the upstream repository URL and onboarding commit but no config, and there was no source that builds with fontc.
 
-| Field             | Value |
-|-------------------|-------|
-| **Family Name**   | Geostar |
-| **Designer**      | Joe Prince |
-| **Repository URL**| https://github.com/librefonts/geostar |
-| **Commit Hash**   | `ca481fdb49204442916697e3d7b1cf6fda792b77` |
-| **Config YAML**   | none (SFD/VFB-only sources) |
-| **Branch**        | master |
-| **Status**        | no_config_possible |
-| **Confidence**    | HIGH |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/geostar, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### METADATA.pb Current State
+## Final state
 
-No source block exists. The METADATA.pb contains only basic metadata:
-- Name: "Geostar"
-- Designer: "Joe Prince"
-- License: OFL
-- Category: DISPLAY
-- Date added: 2011-08-10
-- Single font file: `Geostar-Regular.ttf`
+The source now lives at https://github.com/googlefonts/geostar (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-### Onboarding History in google/fonts
+## Verification
 
-The font was added in commit `90abd17b4` ("Initial commit", 2015-03-07 by Dave Crossland). This was a bulk import of the entire Google Fonts library into the repository. The font was originally added to the Google Fonts catalog on 2011-08-10, before this repository existed. There have been no font file updates since the initial commit -- only metadata changes (METADATA.json to .pb conversions, language support, stroke/classification updates).
+The rebuilt Geostar Regular was compared against the shipped Google Fonts binary. Glyph coverage, outlines and metrics matched. Two benign differences were accepted: four glyphs were renamed to their production names, leaving glyph coverage unchanged; and the legacy `kern` table (3753 pairs) was modernized into a GPOS `kern` feature. No blocking differences remained.
 
-### Upstream Repository
+## Original repository (dormant)
 
-The repo at https://github.com/librefonts/geostar (cached at `upstream_repos/fontc_crater_cache/librefonts/geostar`) contains:
-- Single commit: `ca481fd` ("update .travis.yml")
-- This is a librefonts archive repo with squashed history
-
-### Source Files
-
-The repo contains only legacy format sources:
-- `src/Geostar-Regular-TTF.sfd` -- FontForge SFD file
-- `src/Geostar-Regular.vfb` -- FontLab VFB file
-- TTX decompositions of the TrueType and OpenType binaries
-- No `.glyphs`, `.ufo`, or `.designspace` files
-
-Since the sources are SFD and VFB only, gftools-builder cannot process them. No config.yaml is possible.
-
-### Copyright Information
-
-The font copyright states: "Copyright (c) 2011, Admix Designs (http://www.admixdesigns.com joe@admixdesigns.com) with Reserved Font Name Geostar."
-
-## Conclusion
-
-Geostar has an identifiable upstream repository (librefonts/geostar), but it only contains legacy SFD/VFB source files. A source block can be added to METADATA.pb with the repository URL and commit hash, but no config.yaml can be provided since gftools-builder does not support SFD or VFB sources.
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/geostar"
-  commit: "ca481fdb49204442916697e3d7b1cf6fda792b77"
-}
-```
-
-**Status**: no_config_possible
-**Confidence**: HIGH
+The original FontForge sources are at https://github.com/librefonts/geostar (branch `master`, `.sfd`), latest at commit `ca481fdb49204442916697e3d7b1cf6fda792b77`, which is also the onboarding commit. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/geostarfill/METADATA.pb
+++ b/ofl/geostarfill/METADATA.pb
@@ -17,6 +17,16 @@ subsets: "latin"
 stroke: "SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/geostarfill"
-  commit: "48dc43d804ebfd6743caa51e2d42d17dd34b275c"
+  repository_url: "https://github.com/googlefonts/geostarfill"
+  commit: "61aec9b9308292407c258a90b15a66b0449135bc"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/GeostarFill-Regular.ttf"
+    dest_file: "GeostarFill-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/geostarfill/upstream_info.md
+++ b/ofl/geostarfill/upstream_info.md
@@ -1,72 +1,25 @@
-# Investigation: Geostar Fill
+# Geostar Fill
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Geostar Fill is a display serif font designed by Joe Prince (Admix Designs), added to Google Fonts on 2011-08-10. It is the filled variant of the Geostar family. The font was part of the initial bulk import of the google/fonts repository. The upstream repository is https://github.com/librefonts/geostarfill, a single-commit archive containing TTX decompositions and legacy source files (SFD, VFB). No gftools-builder compatible sources exist, so no config.yaml is possible. The METADATA.pb currently has no source block.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Geostar Fill (Regular) built from FontForge SFD sources at https://github.com/librefonts/geostarfill. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field             | Value |
-|-------------------|-------|
-| **Family Name**   | Geostar Fill |
-| **Designer**      | Joe Prince |
-| **Repository URL**| https://github.com/librefonts/geostarfill |
-| **Commit Hash**   | `48dc43d804ebfd6743caa51e2d42d17dd34b275c` |
-| **Config YAML**   | none (SFD/VFB-only sources) |
-| **Branch**        | master |
-| **Status**        | no_config_possible |
-| **Confidence**    | HIGH |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source (`GeostarFill-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/geostarfill, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### METADATA.pb Current State
+## Final state
 
-No source block exists. The METADATA.pb contains only basic metadata:
-- Name: "Geostar Fill"
-- Designer: "Joe Prince"
-- License: OFL
-- Category: DISPLAY
-- Date added: 2011-08-10
-- Single font file: `GeostarFill-Regular.ttf`
+The source now lives at https://github.com/googlefonts/geostarfill (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-### Onboarding History in google/fonts
+## Verification
 
-The font was added in commit `90abd17b4` ("Initial commit", 2015-03-07 by Dave Crossland). This was a bulk import of the entire Google Fonts library into the repository. The font was originally added to the Google Fonts catalog on 2011-08-10, before this repository existed. There have been no font file updates since the initial commit -- only metadata changes (METADATA.json to .pb conversions, language support, stroke/classification updates).
+The rebuilt font matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GDEF classes and advance widths. Two benign differences were accepted: four glyphs were renamed to their production names (coverage unchanged), and the legacy `kern` table (3796 pairs) was modernized into a GPOS `kern` feature.
 
-### Upstream Repository
+## Original repository (dormant)
 
-The repo at https://github.com/librefonts/geostarfill (cached at `upstream_repos/fontc_crater_cache/librefonts/geostarfill`) contains:
-- Single commit: `48dc43d` ("update .travis.yml")
-- This is a librefonts archive repo with squashed history
-
-### Source Files
-
-The repo contains only legacy format sources:
-- `src/GeostarFill-Regular-TTF.sfd` -- FontForge SFD file
-- `src/GeostarFill-Regular.vfb` -- FontLab VFB file
-- TTX decompositions of the TrueType and OpenType binaries
-- No `.glyphs`, `.ufo`, or `.designspace` files
-
-Since the sources are SFD and VFB only, gftools-builder cannot process them. No config.yaml is possible.
-
-### Copyright Information
-
-The font copyright states: "Copyright (c) 2011, Admix Designs (http://www.admixdesigns.com joe@admixdesigns.com) with Reserved Font Name Geostar."
-
-Note that both Geostar and Geostar Fill share the same copyright notice with Reserved Font Name "Geostar" (not "Geostar Fill").
-
-## Conclusion
-
-Geostar Fill has an identifiable upstream repository (librefonts/geostarfill), but it only contains legacy SFD/VFB source files. A source block can be added to METADATA.pb with the repository URL and commit hash, but no config.yaml can be provided since gftools-builder does not support SFD or VFB sources.
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/geostarfill"
-  commit: "48dc43d804ebfd6743caa51e2d42d17dd34b275c"
-}
-```
-
-**Status**: no_config_possible
-**Confidence**: HIGH
+The original FontForge sources are at https://github.com/librefonts/geostarfill (`.sfd`), latest at commit `48dc43d804ebfd6743caa51e2d42d17dd34b275c`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/germaniaone/METADATA.pb
+++ b/ofl/germaniaone/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/germaniaone"
-  commit: "73d401d495adf37b1af75a5dca9cb5cdb046b05d"
+  repository_url: "https://github.com/googlefonts/germaniaone"
+  commit: "8c373b1705299e083f48de2a4c5a818b35c83ad4"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/GermaniaOne-Regular.ttf"
+    dest_file: "GermaniaOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/germaniaone/upstream_info.md
+++ b/ofl/germaniaone/upstream_info.md
@@ -1,84 +1,24 @@
-# Investigation: Germania One
+# Germania One
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Germania One is a display typeface designed by John Vargas Beltran, blending German fraktur and Bauhaus sans-serif forms. It was added to Google Fonts on 2012-01-18 and was part of the initial bulk import of the google/fonts repository. The upstream repository is https://github.com/librefonts/germaniaone, a single-commit archive containing TTX decompositions and legacy VFB/SFD source files. No gftools-builder compatible sources exist, so no config.yaml is possible. The METADATA.pb currently has no source block.
+## Initial state
 
-## Key Findings
+The `source { }` block pointed at the dormant librefonts repository and recorded only a repository URL and onboarding commit. The upstream sources were FontForge `.sfd` files (`src/GermaniaOne-Regular-TTF.sfd`), which the current Rust build pipeline cannot consume, and no build configuration was present.
 
-| Field             | Value |
-|-------------------|-------|
-| **Family Name**   | Germania One |
-| **Designer**      | John Vargas Beltran |
-| **Repository URL**| https://github.com/librefonts/germaniaone |
-| **Commit Hash**   | `73d401d495adf37b1af75a5dca9cb5cdb046b05d` |
-| **Config YAML**   | none (SFD/VFB-only sources) |
-| **Branch**        | master |
-| **Status**        | no_config_possible |
-| **Confidence**    | HIGH |
+## Actions taken
 
-## Investigation Details
+The single SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`) and a build configuration was added. During conversion the non-breaking space (U+00A0) advance width was corrected to 250 to match the space glyph. The repository was restructured to the Unified Font Repository template and the superseded FontForge sources were retired.
 
-### METADATA.pb Current State
+## Final state
 
-No source block exists. The METADATA.pb contains only basic metadata:
-- Name: "Germania One"
-- Designer: "John Vargas Beltran"
-- License: OFL
-- Category: DISPLAY
-- Date added: 2012-01-18
-- Single font file: `GermaniaOne-Regular.ttf`
-- Subsets: menu, latin, latin-ext
+The family builds from `.glyphs` sources with gftools-builder3 and fontc. METADATA.pb now points at the modernized repository, the pinned commit, and the build configuration.
 
-### Onboarding History in google/fonts
+## Verification
 
-The font was added in commit `90abd17b4` ("Initial commit", 2015-03-07 by Dave Crossland). This was a bulk import of the entire Google Fonts library into the repository. The font was originally added to the Google Fonts catalog on 2012-01-18, before this repository existed. There have been no font file updates since the initial commit -- only metadata changes (METADATA.json to .pb conversions, language support, stroke/classification updates).
+The freshly built `GermaniaOne-Regular.ttf` was compared against the shipped Google Fonts binary. The verdict is FUNCTIONAL: the codepoint coverage matched, with the only difference being that 12 glyphs were renamed to their production names (glyph coverage unchanged). No blocking differences were found.
 
-### Upstream Repository
+## Original repository (dormant)
 
-The repo at https://github.com/librefonts/germaniaone (cached at `upstream_repos/fontc_crater_cache/librefonts/germaniaone`) contains:
-- Single commit: `73d401d` ("update .travis.yml")
-- This is a librefonts archive repo with squashed history
-
-### Source Files
-
-The repo contains only legacy format sources:
-- `src/GermaniaOne-Regular-TTF.sfd` -- FontForge SFD file
-- `src/GermaniaOne-Regular-OTF.vfb` -- FontLab VFB file
-- TTX decompositions of the TrueType and OpenType binaries
-- No `.glyphs`, `.ufo`, or `.designspace` files
-
-The FONTLOG.txt in google/fonts mentions three original source files:
-1. `GermaniaOne-Regular-OTF.vfb` -- Merged contours for OTF
-2. `GermaniaOne-Regular-TTF.vfb` -- TrueType outlines with hinting
-3. `GermaniaOne-Regular.vfb` -- Original source with components
-
-Note: The TTF VFB was converted to SFD in the librefonts archive, and only the OTF VFB was preserved in VFB format.
-
-Since the sources are SFD and VFB only, gftools-builder cannot process them. No config.yaml is possible.
-
-### Designer Information
-
-- **John Vargas Beltran** (john.vargasbeltran@gmail.com)
-- Website: www.johnvargasbeltran.com
-- The font was designed as a hybrid between historical fraktur and Bauhaus geometric sans-serif forms
-
-### Copyright Information
-
-"Copyright (c) 2011 by John Vargas Beltran (john.vargasbeltran@gmail.com), with Reserved Font Name 'Germania One'"
-
-## Conclusion
-
-Germania One has an identifiable upstream repository (librefonts/germaniaone), but it only contains legacy SFD/VFB source files. A source block can be added to METADATA.pb with the repository URL and commit hash, but no config.yaml can be provided since gftools-builder does not support SFD or VFB sources.
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/germaniaone"
-  commit: "73d401d495adf37b1af75a5dca9cb5cdb046b05d"
-}
-```
-
-**Status**: no_config_possible
-**Confidence**: HIGH
+Original upstream: https://github.com/librefonts/germaniaone
+Latest commit: 73d401d495adf37b1af75a5dca9cb5cdb046b05d (branch `master`), which is also the onboarding commit recorded in the previous METADATA.pb `source { }` block.

--- a/ofl/giveyouglory/METADATA.pb
+++ b/ofl/giveyouglory/METADATA.pb
@@ -15,6 +15,16 @@ fonts {
 subsets: "menu"
 subsets: "latin"
 source {
-  repository_url: "https://github.com/librefonts/giveyouglory"
-  commit: "2787317ad77bac728fea1ca0c4ce7f0d3ba273d5"
+  repository_url: "https://github.com/googlefonts/giveyouglory"
+  commit: "79ab8c04f2f381fa7439e09957fe3257ff113333"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/GiveYouGlory-Regular.ttf"
+    dest_file: "GiveYouGlory.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/giveyouglory/upstream_info.md
+++ b/ofl/giveyouglory/upstream_info.md
@@ -1,81 +1,25 @@
-# Investigation Report: Give You Glory
+# Give You Glory
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-**Give You Glory** is a handwriting font designed by Kimberly Geswein, added to Google Fonts on 2011-07-13. The upstream repository is `librefonts/giveyouglory` on GitHub, a mirror repo created by hash3g in October 2014. The repo contains decomposed TTX files alongside legacy source formats (SFD and VFB). There are no gftools-builder-compatible sources (.glyphs, .ufo, .designspace) and no config.yaml. The font binary in google/fonts has not been modified since the initial commit.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Give You Glory (Regular) built from FontForge SFD sources at https://github.com/librefonts/giveyouglory. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field              | Value                                                              |
-|--------------------|--------------------------------------------------------------------|
-| Family Name        | Give You Glory                                                     |
-| Designer           | Kimberly Geswein                                                   |
-| Repository URL     | https://github.com/librefonts/giveyouglory                        |
-| Commit Hash        | 2787317ad77bac728fea1ca0c4ce7f0d3ba273d5                           |
-| Config YAML        | None (SFD-only sources)                                            |
-| Status             | no_config_possible                                                 |
-| Confidence         | HIGH                                                               |
-| License            | OFL                                                                |
-| Date Added         | 2011-07-13                                                         |
-| Category           | HANDWRITING                                                        |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge source (`src/GiveYouGlory-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`); glyphs were given production names during conversion.
+- A new Unified Font Repository was created at https://github.com/googlefonts/giveyouglory, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### METADATA.pb Analysis
+## Final state
 
-The current METADATA.pb at `ofl/giveyouglory/METADATA.pb` contains basic metadata (family name, designer, license, fonts block) but originally had no source block. A source block was added in commit `9a14639f3c` (2026-02-25) with the repository URL and commit hash.
+The source now lives at https://github.com/googlefonts/giveyouglory (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-### Google Fonts Git History
+## Verification
 
-The font file `GiveYouGlory.ttf` was added in the initial commit of the google/fonts repository:
+The freshly built Give You Glory Regular was compared against the shipped `GiveYouGlory.ttf`. It matched on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets and advance widths. Two accepted differences remain: 18 glyphs were renamed to production names (coverage unchanged), and the new GDEF correctly classifies one combining mark (uni0326) that the shipped font had left unclassified.
 
-- **Commit**: `90abd17b4f97671435798b6147b698aa9087612f` (2015-03-07, Dave Crossland, "Initial commit")
-- The font binary has not been modified since then.
-- Subsequent commits only touched METADATA files (METADATA.json to METADATA.pb conversion, language support, HTML formatting).
+## Original repository (dormant)
 
-A deploy commit (`76adaf1d2`, 2021-11-01, m4rc1e) appears to have deleted the files, but this commit is not on the main branch -- it was part of an orphan/dead branch. The main branch retains the original font file from the initial commit.
-
-### Upstream Repository Analysis
-
-**Repository**: https://github.com/librefonts/giveyouglory
-**Cached at**: `upstream_repos/fontc_crater_cache/librefonts/giveyouglory`
-**GitHub status**: Accessible (HTTP 200)
-
-The repository is a shallow clone containing a single visible commit:
-- **Commit**: `2787317ad77bac728fea1ca0c4ce7f0d3ba273d5` (2014-10-17, hash3g, "update .travis.yml")
-
-This is a `librefonts` organization mirror -- these repos were created by hash3g as part of a systematic effort to create GitHub mirrors of Google Fonts families with decomposed TTX data and CI configuration.
-
-### Source Files
-
-The repository contains:
-- **`src/GiveYouGlory-TTF.sfd`** -- FontForge SFD source (TTF outlines)
-- **`src/GiveYouGlory.vfb`** -- FontLab VFB source (binary, proprietary format)
-- **`src/GiveYouGlory.otf.*.ttx`** -- Decomposed OTF TTX tables
-- **Root-level `GiveYouGlory.ttf.*.ttx`** -- Decomposed TTF TTX tables
-- **`.travis.yml`** -- Travis CI config using fontbakery-build.py
-- **`src/VERSIONS.txt`** -- "GiveYouGlory.ttf: Version 1.002"
-
-**No gftools-builder-compatible sources** (.glyphs, .ufo, .designspace) exist. The only editable sources are SFD (FontForge) and VFB (FontLab), neither of which is supported by gftools-builder/fontc.
-
-### Config YAML Assessment
-
-No config.yaml exists and none can be created because:
-1. There are no .glyphs, .ufo, or .designspace source files
-2. SFD and VFB formats are not supported by gftools-builder
-3. The TTX files are decomposed table dumps, not proper build sources
-
-## Conclusion
-
-The source block in METADATA.pb is correct. The librefonts mirror is the only known upstream repository. The font sources are SFD/VFB only, making a gftools-builder config.yaml impossible.
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/giveyouglory"
-  commit: "2787317ad77bac728fea1ca0c4ce7f0d3ba273d5"
-}
-```
-
-**Status**: `no_config_possible` -- SFD/VFB-only sources are not compatible with gftools-builder.
+The original FontForge sources are at https://github.com/librefonts/giveyouglory (`.sfd`), latest at commit `2787317ad77bac728fea1ca0c4ce7f0d3ba273d5`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/glassantiqua/METADATA.pb
+++ b/ofl/glassantiqua/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 stroke: "SERIF"
 classifications: "HANDWRITING"
 source {
-  repository_url: "https://github.com/librefonts/glassantiqua"
-  commit: "ccc1839b05e9827b7f3a1439d089952908cd0334"
+  repository_url: "https://github.com/googlefonts/glassantiqua"
+  commit: "64763eadb6bf4a38f7fe638b06683ef7cea15266"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/GlassAntiqua-Regular.ttf"
+    dest_file: "GlassAntiqua-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/glassantiqua/upstream_info.md
+++ b/ofl/glassantiqua/upstream_info.md
@@ -1,89 +1,23 @@
-# Investigation Report: Glass Antiqua
+# Glass Antiqua
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-**Glass Antiqua** is a display/handwriting serif font designed by Denis Masharov, added to Google Fonts on 2012-02-22. It is a revival of the 1913 typeface "Glass Antiqua" by Genzsch & Heyse. The upstream repository is `librefonts/glassantiqua` on GitHub, a mirror repo created by hash3g in October 2014. The repo contains decomposed TTX files alongside legacy source formats (SFD and VFB). There are no gftools-builder-compatible sources and no config.yaml. The font binary in google/fonts has not been modified since the initial commit.
+## Initial state
 
-## Key Findings
+The upstream repository shipped only FontForge `.sfd` sources and had no gftools-builder configuration. METADATA.pb pointed at the librefonts mirror with an onboarding commit but no `config_yaml`, so the family could not be rebuilt with the current Google Fonts pipeline.
 
-| Field              | Value                                                              |
-|--------------------|--------------------------------------------------------------------|
-| Family Name        | Glass Antiqua                                                      |
-| Designer           | Denis Masharov                                                     |
-| Repository URL     | https://github.com/librefonts/glassantiqua                        |
-| Commit Hash        | ccc1839b05e9827b7f3a1439d089952908cd0334                           |
-| Config YAML        | None (SFD-only sources)                                            |
-| Status             | no_config_possible                                                 |
-| Confidence         | HIGH                                                               |
-| License            | OFL                                                                |
-| Date Added         | 2012-02-22                                                         |
-| Category           | DISPLAY                                                            |
+## Actions taken
 
-## Investigation Details
+The single FontForge source `src/GlassAntiqua-Regular-TTF.sfd` was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), producing `sources/GlassAntiqua-Regular.glyphs`. A gftools-builder configuration was added and the repository was restructured to the Unified Font Repository template. The superseded `.sfd` sources and legacy build cruft were retired. No further source corrections were required beyond the conversion.
 
-### METADATA.pb Analysis
+## Final state
 
-The current METADATA.pb at `ofl/glassantiqua/METADATA.pb` contains basic metadata plus stroke/classifications fields. Originally it had no source block. A source block was added in commit `9a14639f3c` (2026-02-25) with the repository URL and commit hash.
+The repository builds `GlassAntiqua-Regular.ttf` from the converted `.glyphs` source through gftools-builder3 and fontc.
 
-### Google Fonts Git History
+## Verification
 
-The font file `GlassAntiqua-Regular.ttf` was added in the initial commit of the google/fonts repository:
+The freshly built binary was compared against the shipped `GlassAntiqua-Regular.ttf`. The verdict was FUNCTIONAL: character coverage, metrics and outlines matched. The only difference was that 15 glyphs were renamed to their standard production names; the set of encoded characters is unchanged, so the rename is cosmetic and does not affect rendering.
 
-- **Commit**: `90abd17b4f97671435798b6147b698aa9087612f` (2015-03-07, Dave Crossland, "Initial commit")
-- The font binary has not been modified since then.
-- Subsequent commits touched METADATA files only: METADATA.json to METADATA.pb conversion, language support metadata, stroke and classifications additions, HTML formatting.
-- **Commit `47a6c224b3`** (2023-08-08, Evan Adams): Added `stroke: "SERIF"` and `classifications: "HANDWRITING"` to METADATA.pb.
+## Original repository (dormant)
 
-A deploy commit (`76adaf1d2`, 2021-11-01, m4rc1e) deleted the files, but this commit is not on the main branch -- it was part of an orphan/dead branch. The main branch retains the original font file from the initial commit.
-
-### Upstream Repository Analysis
-
-**Repository**: https://github.com/librefonts/glassantiqua
-**Cached at**: `upstream_repos/fontc_crater_cache/librefonts/glassantiqua`
-**GitHub status**: Accessible (HTTP 200)
-
-The repository is a shallow clone containing a single visible commit:
-- **Commit**: `ccc1839b05e9827b7f3a1439d089952908cd0334` (2014-10-17, hash3g, "update .travis.yml")
-
-This is a `librefonts` organization mirror -- these repos were created by hash3g as part of a systematic effort to create GitHub mirrors of Google Fonts families with decomposed TTX data and CI configuration.
-
-### Source Files
-
-The repository contains:
-- **`src/GlassAntiqua-Regular-TTF.sfd`** -- FontForge SFD source (TTF outlines)
-- **`src/GlassAntiqua-Regular-OTF.vfb`** -- FontLab VFB source (binary, proprietary format)
-- **`src/GlassAntiqua-Regular.otf.*.ttx`** -- Decomposed OTF TTX tables (including kern table)
-- **Root-level `GlassAntiqua-Regular.ttf.*.ttx`** -- Decomposed TTF TTX tables (including GPOS, GDEF, GSUB, DSIG)
-- **`src/GlassAntiqua-A.jpg`**, **`src/GlassAntiqua-B.jpg`** -- Reference images (likely scans of original 1913 typeface)
-- **`.travis.yml`** -- Travis CI config using fontbakery-build.py
-- **`src/VERSIONS.txt`** -- "GlassAntiqua-Regular.ttf: 1.001"
-
-**No gftools-builder-compatible sources** (.glyphs, .ufo, .designspace) exist. The only editable sources are SFD (FontForge) and VFB (FontLab), neither of which is supported by gftools-builder/fontc.
-
-### Config YAML Assessment
-
-No config.yaml exists and none can be created because:
-1. There are no .glyphs, .ufo, or .designspace source files
-2. SFD and VFB formats are not supported by gftools-builder
-3. The TTX files are decomposed table dumps, not proper build sources
-
-### Notable Details
-
-- The font is a revival of a historical typeface ("Glass Antiqua" by Genzsch & Heyse, 1913), found in the Taschen book "Type: A Visual History of Typefaces and Graphic Styles, 1901-1938."
-- The src/ directory contains two JPG reference images, likely scans from the original specimen.
-- The font has both SERIF stroke and HANDWRITING classification, reflecting its hybrid nature (slab serif + antiqua + cursive calligraphy elements).
-
-## Conclusion
-
-The source block in METADATA.pb is correct. The librefonts mirror is the only known upstream repository. The font sources are SFD/VFB only, making a gftools-builder config.yaml impossible.
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/glassantiqua"
-  commit: "ccc1839b05e9827b7f3a1439d089952908cd0334"
-}
-```
-
-**Status**: `no_config_possible` -- SFD/VFB-only sources are not compatible with gftools-builder.
+The original sources lived at https://github.com/librefonts/glassantiqua, whose latest commit was `ccc1839b05e9827b7f3a1439d089952908cd0334` on the `master` branch. That repository carried only the FontForge `.sfd` sources and remains preserved as the historical record.

--- a/ofl/goblinone/METADATA.pb
+++ b/ofl/goblinone/METADATA.pb
@@ -17,6 +17,16 @@ subsets: "latin"
 stroke: "SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/goblinone"
-  commit: "446c2b743e1eda33533ad624c543cfd623eb7c90"
+  repository_url: "https://github.com/googlefonts/goblinone"
+  commit: "82b0d4b4f5e17c953c5a6e42e73d2e93ea2ea9e2"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/GoblinOne-Regular.ttf"
+    dest_file: "GoblinOne.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/goblinone/upstream_info.md
+++ b/ofl/goblinone/upstream_info.md
@@ -1,78 +1,26 @@
-# Investigation Report: Goblin One
+# Goblin One
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Goblin One is a display serif font designed by Riccardo De Franceschi and mastered by Eben Sorkin (Sorkin Type Co). It was added to Google Fonts on 2011-06-29 as part of the initial repository commit. The upstream repository is `librefonts/goblinone` on GitHub, which contains only legacy source formats (SFD and VFB). There is no `config.yaml` in the upstream repo and no gftools-builder-compatible sources, so building with gftools-builder/fontc is not possible. The METADATA.pb currently has no source block.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Goblin One (Regular) built from FontForge SFD sources at https://github.com/librefonts/goblinone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field             | Value                                                              |
-|-------------------|--------------------------------------------------------------------|
-| Family Name       | Goblin One                                                         |
-| Designer          | Riccardo De Franceschi                                             |
-| Date Added        | 2011-06-29                                                         |
-| Repository URL    | https://github.com/librefonts/goblinone                            |
-| Commit Hash       | 446c2b743e1eda33533ad624c543cfd623eb7c90 (only commit in repo)     |
-| Branch            | master                                                             |
-| Config Path       | N/A (SFD/VFB sources only)                                        |
-| Source Files      | src/GoblinOne-TTF.sfd, src/GoblinOne.vfb                          |
-| Status            | **no_config_possible**                                             |
-| Confidence        | **HIGH**                                                           |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source `src/GoblinOne-TTF.sfd` was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected to 618 to match the space glyph.
+- A new Unified Font Repository was created at https://github.com/googlefonts/goblinone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### METADATA.pb Analysis
+## Final state
 
-The current METADATA.pb has no `source { }` block. It contains basic metadata:
-- Family name, designer, license, category
-- Single static font: `GoblinOne.ttf` (weight 400)
-- Subsets: menu, latin
-- Classifications: DISPLAY, SERIF
+The source now lives at https://github.com/googlefonts/goblinone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
-### Onboarding History in google/fonts
+## Verification
 
-Goblin One was part of the initial commit (`90abd17b4`) to the google/fonts repository on 2015-03-07 (the bulk import by Dave Crossland). The font was originally added to Google Fonts on 2011-06-29 per the `date_added` field. The TTF file has never been modified since that initial commit.
+The rebuilt font matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets and advance widths. Two benign differences were accepted: 8 glyphs were renamed to production names (coverage unchanged), and GDEF correctly classifies the combining mark uni0326 that the shipped font had failed to mark.
 
-No PR or further commit has ever updated the font binary.
+## Original repository (dormant)
 
-### Upstream Repository Verification
-
-The cached repo at `upstream_repos/fontc_crater_cache/librefonts/goblinone/` confirms:
-- Remote URL: `https://github.com/librefonts/goblinone`
-- Single commit: `446c2b7` by hash3g, dated 2014-10-17
-- The repo contains TTX decompositions of the font, plus source files
-
-### Source Files
-
-The upstream repo contains only legacy source formats:
-- `src/GoblinOne-TTF.sfd` — FontForge SFD file
-- `src/GoblinOne.vfb` — FontLab VFB file (binary)
-
-There are no `.glyphs`, `.ufo`, or `.designspace` files. There is no `config.yaml` or `config.yml`. The font is a single-weight static font with no variable font axes.
-
-Since the sources are in legacy formats (SFD/VFB) that are not supported by gftools-builder or fontc, creating a config.yaml would not be useful.
-
-### Font Origin
-
-Per the FONTLOG.txt:
-- Designed by Riccardo De Franceschi (2010)
-- Spaced and mastered by Eben Sorkin / Sorkin Type Co (2011)
-- Mastered from FontLab to TTF
-
-The copyright string references "Sorkin Type Co" as the copyright holder. The `librefonts` GitHub organization appears to be an archive of Google Fonts library fonts with their sources decomposed into TTX format.
-
-## Conclusion
-
-Goblin One has an identifiable upstream repository (`librefonts/goblinone`), but it only contains legacy source formats (SFD/VFB). A `config.yaml` is not possible because gftools-builder does not support these formats. A minimal source block can be added to record the repository URL for documentation purposes.
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/goblinone"
-  commit: "446c2b743e1eda33533ad624c543cfd623eb7c90"
-  branch: "master"
-}
-```
-
-**Status: no_config_possible**
+The original FontForge sources are at https://github.com/librefonts/goblinone (`.sfd`), latest at commit `446c2b743e1eda33533ad624c543cfd623eb7c90`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/gochihand/METADATA.pb
+++ b/ofl/gochihand/METADATA.pb
@@ -17,6 +17,16 @@ subsets: "latin"
 classifications: "DISPLAY"
 classifications: "HANDWRITING"
 source {
-  repository_url: "https://github.com/librefonts/gochihand"
-  commit: "e202a9f4b7cd6f9c84440e684f0a3d0b5dd234e0"
+  repository_url: "https://github.com/googlefonts/gochihand"
+  commit: "af523d983cfa89c7216edbb907db7e39cef756d2"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/GochiHand-Regular.ttf"
+    dest_file: "GochiHand-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/gochihand/upstream_info.md
+++ b/ofl/gochihand/upstream_info.md
@@ -1,92 +1,26 @@
-# Investigation Report: Gochi Hand
+# Gochi Hand
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Gochi Hand is a handwriting-style typeface designed by Juan Pablo del Peral for HT Fonts, added to Google Fonts on 2011-10-05. The upstream repository is at `https://github.com/librefonts/gochihand`. The repo contains only SFD (FontForge) and VFB sources, making it incompatible with gftools-builder. No config.yaml is possible.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Gochi Hand (Regular) built from FontForge SFD sources at https://github.com/librefonts/gochihand. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field              | Value                                                              |
-|--------------------|--------------------------------------------------------------------|
-| Family Name        | Gochi Hand                                                         |
-| Designer           | HT Fonts (Juan Pablo del Peral)                          |
-| Repository URL     | https://github.com/librefonts/gochihand                           |
-| Commit Hash        | e202a9f4b7cd6f9c84440e684f0a3d0b5dd234e0                          |
-| Config YAML        | N/A (SFD-only sources)                                             |
-| Status             | no_config_possible                                                 |
-| Confidence         | HIGH                                                               |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source (`GochiHand-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected during conversion.
+- A new Unified Font Repository was created at https://github.com/googlefonts/gochihand, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### METADATA.pb (current state on main)
+## Final state
 
-The METADATA.pb on the `main` branch of google/fonts does **not** contain a source block. A source block was added on the branch `sources_info_2026-02-25` (commit `9a14639f3`) but has not yet been merged to main.
+The source now lives at https://github.com/googlefonts/gochihand (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-Current METADATA.pb fields:
-- name: "Gochi Hand"
-- designer: "HT Fonts"
-- license: OFL
-- category: HANDWRITING
-- date_added: 2011-10-05
-- classifications: DISPLAY, HANDWRITING
+## Verification
 
-### Git History in google/fonts
+The rebuilt font matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle and GSUB/GPOS feature sets. The accepted differences are cosmetic and correct: 10 glyphs were renamed to production names (coverage unchanged); the GDEF table now classifies the combining mark U+0326 that the shipped font had missed; and that same mark's advance width was zeroed (the shipped font gave the combining mark a spacing advance).
 
-- **`90abd17b4`** (2015-03-07): Initial commit by Dave Crossland. Added `GochiHand-Regular.ttf`, `DESCRIPTION.en_us.html`, `FONTLOG.txt`, `METADATA.json`, `OFL.txt`.
-- **`480630de3`** (2015-12-08): METADATA.pb textproto created from METADATA.json.
-- **`883939708`** (2016-01-11): METADATA.json removed.
-- **`76adaf1d2`** (2021-11-01): Deploy commit deleted all gochihand files. This was on a non-main branch (`upstream/davelab6-date`, `upstream/gh-pages`).
-- **`633ebadbf`** (2021-12-12): Language support metadata added. This is on main and the TTF file exists on main from the initial commit.
-- **`47a6c224b`** (2023-08-08): Stroke and classifications added.
-- **`9a14639f3`** (2026-02-25): Source block added on branch `sources_info_2026-02-25` (not yet on main).
+## Original repository (dormant)
 
-The font binary has never been updated since the initial commit. The TTF was added in the Initial commit (`90abd17b4`, March 2015) and has not been modified since.
-
-### Upstream Repository
-
-Cached at: `upstream_repos/fontc_crater_cache/librefonts/gochihand`
-Remote: `https://github.com/librefonts/gochihand`
-
-The repository has exactly **one commit**:
-- `e202a9f4b7cd6f9c84440e684f0a3d0b5dd234e0` (2014-10-17) by hash3g: "update .travis.yml"
-
-This single commit is an initial import that created the entire repository with all files at once. The repo contains:
-- `.travis.yml` (CI config for fontbakery)
-- TTX decomposed tables of the TrueType font
-- `DESCRIPTION.en_us.html`, `FONTLOG.txt`, `METADATA.json`, `OFL.txt`
-- `src/GochiHand-Regular-TTF.sfd` (FontForge SFD source)
-- `src/GochiHand-Regular-OTF.vfb` (FontLab VFB source)
-- TTX decomposed tables of the OTF in `src/`
-
-### Source Files
-
-The only editable source files are:
-- `src/GochiHand-Regular-TTF.sfd` -- FontForge SFD format
-- `src/GochiHand-Regular-OTF.vfb` -- FontLab VFB format (binary, not buildable by gftools)
-
-Neither SFD nor VFB is supported by gftools-builder. There are no `.glyphs`, `.ufo`, or `.designspace` files.
-
-### Commit Hash Verification
-
-The upstream repo has only one commit (`e202a9f`), which is also HEAD. The font was added to google/fonts in the initial commit of that repo (March 2015), after the upstream commit (October 2014). The single commit hash `e202a9f4b7cd6f9c84440e684f0a3d0b5dd234e0` is the correct and only possible reference.
-
-### Config YAML
-
-No config.yaml exists in the upstream repo. No config.yaml can be created because:
-- The source format (SFD/VFB) is not supported by gftools-builder
-- gftools-builder requires `.glyphs`, `.ufo`, or `.designspace` sources
-
-## Conclusion
-
-The upstream repository and commit hash are correctly identified. Since the sources are SFD/VFB only, no config.yaml is possible, and the status should be `no_config_possible`.
-
-### Recommended METADATA.pb source block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/gochihand"
-  commit: "e202a9f4b7cd6f9c84440e684f0a3d0b5dd234e0"
-}
-```
-
-No `config_yaml` field is applicable (SFD-only sources).
+The original FontForge sources are at https://github.com/librefonts/gochihand (`.sfd`), latest at commit `e202a9f4b7cd6f9c84440e684f0a3d0b5dd234e0`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/gravitasone/METADATA.pb
+++ b/ofl/gravitasone/METADATA.pb
@@ -17,6 +17,16 @@ subsets: "latin"
 stroke: "SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/gravitasone"
-  commit: "c89d142ad0f695ba267d27965c26d1dd75463f20"
+  repository_url: "https://github.com/googlefonts/gravitasone"
+  commit: "feede2e8781269a901f8bddb91f05965d294e5a9"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/GravitasOne-Regular.ttf"
+    dest_file: "GravitasOne.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/gravitasone/upstream_info.md
+++ b/ofl/gravitasone/upstream_info.md
@@ -1,71 +1,25 @@
-# Investigation: Gravitas One
+# Gravitas One
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Gravitas One is a display serif font by Riccardo De Franceschi (Sorkin Type Co), added to Google Fonts on 2011-06-29 as part of the initial commit. The upstream repository is `librefonts/gravitasone` on GitHub. The current METADATA.pb on the main branch has **no source block**. The upstream repo contains only SFD (FontForge) and VFB (FontLab) source files -- no `.glyphs`, `.ufo`, or `.designspace` sources, and no `config.yaml`. A gftools-builder config is not possible with SFD-only sources.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Gravitas One (Regular) built from FontForge SFD sources at https://github.com/librefonts/gravitasone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field             | Value                                                              |
-|-------------------|--------------------------------------------------------------------|
-| Family Name       | Gravitas One                                                       |
-| Designer          | Riccardo De Franceschi                                             |
-| Repository URL    | https://github.com/librefonts/gravitasone                          |
-| Commit Hash       | c89d142ad0f695ba267d27965c26d1dd75463f20                           |
-| Config YAML       | None (SFD-only sources)                                            |
-| Source Files      | src/GravitasOne-TTF.sfd, src/GravitasOne.vfb                      |
-| Status            | **no_config_possible**                                             |
-| Confidence        | HIGH                                                               |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source (`src/GravitasOne-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`). Stray NUL bytes in the SFD were stripped during conversion.
+- A new Unified Font Repository was created at https://github.com/googlefonts/gravitasone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### METADATA.pb Analysis
+## Final state
 
-The current METADATA.pb at `ofl/gravitasone/METADATA.pb` (main branch) has **no source block**. It contains only basic metadata: name, designer, license, category, date_added, fonts, subsets, stroke, and classifications.
+The source now lives at https://github.com/googlefonts/gravitasone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-Note: A source block has been prepared in a pending branch (`sources_info_2026-02-25`) with repository_url and commit hash, but it has not yet been merged to main.
+## Verification
 
-### Git History in google/fonts
+The rebuilt font matched the shipped `GravitasOne.ttf` on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets and advance widths. Two benign differences were accepted: 7 glyphs were renamed to their production (AGL) names with no change in coverage, and the new build's GDEF correctly classifies `uni0326` as a combining mark, a classification the shipped font omitted.
 
-The font was part of the initial commit of the google/fonts repository:
-- Commit `90abd17b4` (2015-03-07) by Dave Crossland: "Initial commit"
-- This was a bulk import; the font had been in Google Fonts since 2011-06-29
+## Original repository (dormant)
 
-The font binary has never been updated since the initial commit -- there is only one commit touching `GravitasOne.ttf`.
-
-### Upstream Repository Verification
-
-The cached repo at `upstream_repos/fontc_crater_cache/librefonts/gravitasone/` has a single commit:
-- `c89d142ad0f695ba267d27965c26d1dd75463f20` (2014-10-17) by hash3g: "update .travis.yml"
-
-This is the initial (and only) commit in the librefonts repo. Repository contents:
-- `src/GravitasOne-TTF.sfd` -- FontForge source file
-- `src/GravitasOne.vfb` -- FontLab source file
-- `src/VERSIONS.txt` -- states "GravitasOne.ttf: Version 1.001"
-- `src/METADATA_comments.txt` -- metadata comments
-- Various `.ttx` decomposition files of the font binary
-- `DESCRIPTION.en_us.html`, `METADATA.json`, `OFL.txt`
-- `.travis.yml` -- CI configuration for fontbakery
-
-The repo has **no config.yaml** and **no gftools-builder compatible sources** (.glyphs, .ufo, .designspace). The only source files are SFD (FontForge) and VFB (FontLab), which are not supported by gftools-builder.
-
-### Commit Hash Verification
-
-The librefonts repo has only one commit (`c89d142`), so this is the only possible reference commit. The font was already in Google Fonts before this repo was created (the repo was set up in 2014, the font was added to Google Fonts in 2011). The librefonts repo is an archive of the source files, not the original development location.
-
-The DESCRIPTION.en_us.html references the original source at Google Code: "Source files are available from Google Code." This aligns with the pre-GitHub era origins of many early Google Fonts.
-
-## Conclusion
-
-The upstream repository exists but only contains SFD/VFB sources that are not compatible with gftools-builder. No config.yaml is possible with these source formats.
-
-### Recommended METADATA.pb source block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/gravitasone"
-  commit: "c89d142ad0f695ba267d27965c26d1dd75463f20"
-}
-```
-
-**Status: no_config_possible** -- The upstream repo has only SFD/VFB sources, which are not supported by gftools-builder. A config.yaml cannot be created.
+The original FontForge sources are at https://github.com/librefonts/gravitasone (`.sfd`), latest at commit `c89d142ad0f695ba267d27965c26d1dd75463f20`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/gudea/METADATA.pb
+++ b/ofl/gudea/METADATA.pb
@@ -34,6 +34,24 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/gudea"
-  commit: "0eb36c75099c39430192adf41887965fdc51e819"
+  repository_url: "https://github.com/googlefonts/gudea"
+  commit: "7651bdceeaa8148f45ee5781d87914346be8e9bc"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Gudea-Bold.ttf"
+    dest_file: "Gudea-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Gudea-Italic.ttf"
+    dest_file: "Gudea-Italic.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Gudea-Regular.ttf"
+    dest_file: "Gudea-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/gudea/upstream_info.md
+++ b/ofl/gudea/upstream_info.md
@@ -1,71 +1,26 @@
-# Investigation Report: Gudea
+# Gudea
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Gudea is a sans-serif typeface designed by Agustina Mingote, added to Google Fonts on 2012-01-18. The upstream repository at `https://github.com/librefonts/gudea` contains only SFD and VFB source files -- legacy formats that are not compatible with gftools-builder. There is no config.yaml and no gftools-buildable sources (.glyphs, .ufo, .designspace). The repo has a single commit (0eb36c7) from 2014 and the font binaries in google/fonts have never been updated since the initial commit. The METADATA.pb currently has no source block on the main branch.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Gudea (Regular, Italic, Bold) built from FontForge SFD sources at https://github.com/librefonts/gudea. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field             | Value                                                              |
-|-------------------|--------------------------------------------------------------------|
-| Family Name       | Gudea                                                              |
-| Designer          | Agustina Mingote                                                   |
-| Date Added        | 2012-01-18                                                         |
-| Repository URL    | https://github.com/librefonts/gudea                                |
-| Commit Hash       | 0eb36c75099c39430192adf41887965fdc51e819                           |
-| Branch            | master                                                             |
-| Config            | None (SFD/VFB-only sources)                                        |
-| Source Format     | SFD (FontForge), VFB (FontLab)                                     |
-| Status            | **no_config_possible**                                             |
-| Confidence        | HIGH                                                               |
+## Actions taken
 
-## Investigation Details
+- The three canonical FontForge SFD sources were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The non-breaking space (U+00A0) advance width was corrected in each source, and the Bold source had its OS/2 usWeightClass set to 700.
+- A new Unified Font Repository was created at https://github.com/googlefonts/gudea, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-### Upstream Repository
+## Final state
 
-The upstream repo is `https://github.com/librefonts/gudea` (HTTP 200, verified accessible). It is cached locally at `fontc_crater_cache/librefonts/gudea`.
+The source now lives at https://github.com/googlefonts/gudea (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
-The repo has exactly one commit:
-- `0eb36c7` (2014-10-17): "update .travis.yml" -- This is the initial and only commit, which added all files including source files, TTX dumps, metadata, and a Travis CI configuration.
+## Verification
 
-### Source Files
+Each of the three styles matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 10 to 11 glyphs per style were renamed to their production names, which leaves the encoded coverage unchanged and is therefore accepted.
 
-The repo contains source files in legacy formats only:
-- `src/Gudea-Regular-TTF.sfd` (FontForge SFD)
-- `src/Gudea-Italic-TTF.sfd` (FontForge SFD)
-- `src/Gudea-Bold-TTF.sfd` (FontForge SFD)
-- `src/Gudea-Regular-OTF.vfb` (FontLab VFB)
-- `src/Gudea-Italic-OTF.vfb` (FontLab VFB)
-- `src/Gudea-Bold-OTF.vfb` (FontLab VFB)
+## Original repository (dormant)
 
-There are NO `.glyphs`, `.ufo`, or `.designspace` files. There is no `config.yaml`. The repo also contains TTX table dumps of the font binaries.
-
-These source formats (SFD and VFB) are not supported by gftools-builder/fontc, so no config.yaml can be created.
-
-### Onboarding History
-
-1. **Initial commit** (90abd17b, 2015-03-07, by Dave Crossland): Font originally added to google/fonts in the Initial commit.
-2. The font binaries (Gudea-Regular.ttf, Gudea-Italic.ttf, Gudea-Bold.ttf) have never been updated since -- the only other commit touching them was the deploy commit (76adaf1d2, 2021-11-01) which was part of a temporary deletion/restoration cycle and does not represent a font update.
-
-### Commit Hash Verification
-
-The commit hash `0eb36c7` is the only commit in the librefonts/gudea repository. Since the repo was created in 2014 and the font was added to google/fonts in 2015, this commit predates the onboarding and is the correct reference point. The TTF files in the repo's TTX dumps correspond to the same font data as the binaries in google/fonts.
-
-### Source Block Status
-
-A source block with `repository_url` and `commit` was added to Gudea's METADATA.pb in commit `9a14639f3c` (2026-02-25) on the `sources_info_2026-02-25` branch, but this has NOT been merged to main yet. The main branch METADATA.pb has no source block.
-
-## Conclusion
-
-**Status: no_config_possible**
-
-The upstream repo contains only SFD and VFB source files, which are not compatible with gftools-builder. A config.yaml cannot be created. The source block should document the repository URL and commit hash for provenance tracking, even though automated rebuilding is not possible.
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/gudea"
-  commit: "0eb36c75099c39430192adf41887965fdc51e819"
-}
-```
+The original FontForge sources are at https://github.com/librefonts/gudea (`.sfd`), latest at commit `0eb36c75099c39430192adf41887965fdc51e819`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/habibi/METADATA.pb
+++ b/ofl/habibi/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/habibi"
-  commit: "1c3eb606631e9da373f1017f7972765a7ab32bd5"
+  repository_url: "https://github.com/googlefonts/habibi"
+  commit: "dca56369c22e74471cceec90e257533271629472"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Habibi-Regular.ttf"
+    dest_file: "Habibi-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/habibi/upstream_info.md
+++ b/ofl/habibi/upstream_info.md
@@ -1,82 +1,26 @@
-# Investigation Report: Habibi
+# Habibi
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Habibi is a high-contrast serif typeface designed by Magnus Gaarde and mastered by Eben Sorkin (Sorkin Type Co). It was added to Google Fonts on 2011-12-19 as part of the initial commit of the google/fonts repository. The upstream repository at `librefonts/habibi` is a legacy mirror (originally from Google Code) containing only VFB and SFD source files -- no gftools-builder compatible sources exist.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Habibi (Regular) built from FontForge SFD sources at https://github.com/librefonts/habibi. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field             | Value |
-|-------------------|-------|
-| **Family Name**   | Habibi |
-| **Designer**      | Magnus Gaarde |
-| **Repository URL**| https://github.com/librefonts/habibi |
-| **Commit Hash**   | `1c3eb606631e9da373f1017f7972765a7ab32bd5` (only commit) |
-| **Config YAML**   | None (SFD/VFB-only sources) |
-| **Status**        | no_config_possible |
-| **Confidence**    | HIGH |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source (`Habibi-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The non-breaking space (U+00A0) advance width was corrected to match the space glyph (686 units).
+- A new Unified Font Repository was created at https://github.com/googlefonts/habibi, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### METADATA.pb Review
+## Final state
 
-The current METADATA.pb in `ofl/habibi/` has no `source { }` block. Key fields:
-- Name: "Habibi"
-- Designer: "Magnus Gaarde"
-- License: OFL
-- Date added: 2011-12-19
-- Copyright: "Copyright (c) 2011, Sorkin Type Co (www.sorkintype.com eben@eyebytes.com)"
+The source now lives at https://github.com/googlefonts/habibi (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-### Google Fonts Repository History
+## Verification
 
-The font file history in google/fonts shows only metadata-related changes after the initial commit:
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets and advance widths. Two benign differences were accepted: 22 glyphs were renamed to their production names (coverage unchanged), and the GDEF table now classifies two real combining marks (uni0326 and uni0326.cap) that the shipped font had left unclassified.
 
-| Commit | Date | Description |
-|--------|------|-------------|
-| `90abd17b4` | 2015-03-07 | Initial commit (contains Habibi-Regular.ttf) |
-| `480630de3` | -- | Tentative update to METADATA.pb textprotos |
-| `27f377ab0` | -- | Update copyright field in METADATA.pb |
-| `633ebadbf` | -- | Add language support metadata |
-| `701bd391b` | -- | Undo rollback, remove languages from METADATA |
+## Original repository (dormant)
 
-The font binary (`Habibi-Regular.ttf`) has not been updated since the initial commit. This is a legacy font from 2011 that predates the modern gftools-packager workflow.
-
-### Upstream Repository Analysis
-
-The repository at `https://github.com/librefonts/habibi` is a `librefonts` mirror, likely auto-generated from the old Google Code font directory. It contains a single commit:
-
-- **Commit**: `1c3eb606631e9da373f1017f7972765a7ab32bd5` (2014-10-17)
-- **Author**: hash3g
-- **Message**: "update .travis.yml"
-
-The repository contains TTX decompositions of the font alongside source files:
-
-**Source files found:**
-- `src/Habibi-Regular.vfb` -- FontLab VFB format (proprietary binary)
-- `src/Habibi-Regular-TTF.sfd` -- FontForge SFD format
-
-**No gftools-builder compatible sources found** -- no `.glyphs`, `.ufo`, or `.designspace` files. The VFB format requires FontLab (proprietary) and the SFD format is a FontForge format not supported by gftools-builder/fontmake.
-
-The repository also includes a `.travis.yml` for fontbakery CI and a `FONTLOG.txt` documenting the design history.
-
-### Build Configuration
-
-No `config.yaml` exists in the upstream repository, and none can be created because the source files (VFB/SFD) are not compatible with gftools-builder. The font was mastered manually from FontLab VFB to TTF in December 2011.
-
-## Conclusion
-
-Habibi is a legacy font from 2011 with only VFB/SFD source files in the `librefonts/habibi` mirror repository. No gftools-builder configuration is possible because the source formats are incompatible. The font has never been updated since its initial inclusion.
-
-### Recommended METADATA.pb source block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/habibi"
-  commit: "1c3eb606631e9da373f1017f7972765a7ab32bd5"
-}
-```
-
-Note: No `config_yaml` field is possible because the repository only contains VFB and SFD source files, which are not compatible with gftools-builder.
-
-### Status: `no_config_possible`
-### Confidence: HIGH
+The original FontForge sources are at https://github.com/librefonts/habibi (`.sfd`), latest at commit `1c3eb606631e9da373f1017f7972765a7ab32bd5`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/hammersmithone/METADATA.pb
+++ b/ofl/hammersmithone/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/hammersmithone"
-  commit: "a5fae41a3eabe8ec4e1d8ff7b3fa6dfde5c4fa87"
+  repository_url: "https://github.com/googlefonts/hammersmithone"
+  commit: "fa842a5d78963d24a139bb95c3b5d81d3a307c2b"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/HammersmithOne-Regular.ttf"
+    dest_file: "HammersmithOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/hammersmithone/upstream_info.md
+++ b/ofl/hammersmithone/upstream_info.md
@@ -1,82 +1,23 @@
-# Investigation Report: Hammersmith One
+# Hammersmith One
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Hammersmith One is a low-contrast sans-serif display family designed by Nicole Fally, with spacing and mastering by Eben Sorkin (Sorkin Type Co.). It was added to Google Fonts in the initial commit (2015-03-07, but date_added is 2011-06-29). The upstream repository at `librefonts/hammersmithone` is an archive-style repo containing SFD (FontForge) and VFB (FontLab) source files, plus TTX decomposed tables. There is no gftools-builder compatible source, no config.yaml, and no designspace. The repo has only a single commit and the sources are in legacy formats only.
+## Initial state
 
-## Key Findings
+The family shipped from FontForge `.sfd` sources with no gftools-builder configuration. The METADATA.pb source block pointed at the librefonts repository and a commit hash, but carried no config_yaml and no modern build recipe.
 
-| Field              | Value                                                        |
-|--------------------|--------------------------------------------------------------|
-| Family Name        | Hammersmith One                                              |
-| Designer           | Nicole Fally                                                 |
-| License            | OFL                                                          |
-| Date Added         | 2011-06-29                                                   |
-| Repository URL     | https://github.com/librefonts/hammersmithone                 |
-| Commit Hash        | a5fae41a3eabe8ec4e1d8ff7b3fa6dfde5c4fa87                     |
-| Branch             | master                                                       |
-| Config YAML        | None                                                         |
-| Source Types       | SFD (FontForge), VFB (FontLab), TTX                         |
-| Weights            | Regular only                                                 |
-| Google Fonts Ver.  | 1.003                                                        |
-| Upstream Repo Ver. | 1.003 (per VERSIONS.txt)                                     |
-| Status             | **no_config_possible**                                       |
-| Confidence         | HIGH                                                         |
+## Actions taken
 
-## Investigation Details
+The repository adopted the Unified Font Repository template. The `src/HammersmithOne-Regular-TTF.sfd` source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`), producing `sources/HammersmithOne-Regular.glyphs`, and a gftools-builder3 build configuration was added so the family builds with gftools-builder3 and fontc. During conversion four stray NUL bytes were stripped from the source and the no-break space (U+00A0) advance width was corrected to 440. The superseded FontForge sources and legacy build cruft were then retired.
 
-### METADATA.pb Review
+## Final state
 
-The current METADATA.pb on the main branch of google/fonts has no source block. A source block was added on the `sources_info_2026-02-25` branch (commit 9a14639f3) but has not yet been merged.
+The repository builds `HammersmithOne-Regular.ttf` from `.glyphs` through the Rust pipeline. The source block in METADATA.pb references the modernized repository, its config.yaml and the shipped TTF.
 
-### Git History in google/fonts
+## Verification
 
-The font was included in the initial commit `90abd17b4f` (2015-03-07) by Dave Crossland. Key subsequent changes:
+The TTF built from the converted `.glyphs` source was compared against the binary currently shipped in google/fonts. The result is FUNCTIONAL parity: outlines and character coverage matched. The only difference is that 22 glyphs were renamed to their standard production names, which leaves coverage unchanged and does not affect rendering.
 
-1. **ff6fd2655** (2020-10-14) - "hammersmithone: name table updated to match API (#2351)" -- Co-authored by Micah Stupak. Updated the TTF with corrected name table entries.
-2. No other TTF-modifying commits beyond the initial and the name table fix.
+## Original repository (dormant)
 
-### Upstream Repository Analysis
-
-The repository `librefonts/hammersmithone` is cached at `upstream_repos/fontc_crater_cache/librefonts/hammersmithone/`. It contains:
-
-- **Single commit**: `a5fae41a3e` (2014-10-17): "update .travis.yml"
-- **Source files in `src/`**:
-  - `HammersmithOne-Regular.vfb` -- Original FontLab source with contour overlaps
-  - `HammersmithOne-Regular-OTF.sfd` -- FontForge SFD for OTF output
-  - `HammersmithOne-Regular-TTF.sfd` -- FontForge SFD for TTF output with hinting
-  - Various TTX table decompositions
-- **No UFO, Glyphs, or designspace files**
-- **No config.yaml**
-- **Travis CI config**: Uses `fontbakery-build.py` for build/test, not gftools-builder
-
-The repo is a `librefonts` archive -- these were created as mirrors of Google Fonts families with their sources decomposed to TTX. The original source is the VFB file.
-
-### Source Format Assessment
-
-The only editable sources are:
-- VFB (FontLab proprietary binary format) -- not supported by gftools-builder
-- SFD (FontForge format) -- not supported by gftools-builder
-
-The TTX files are decomposed table dumps, not a primary source format for font compilation.
-
-### Version Match
-
-The VERSIONS.txt in the repo states `HammersmithOne-Regular.ttf: Version 1.003`, matching the version string in the google/fonts binary. The google/fonts copy was later updated with a name table fix in PR #2351, but the version number remained 1.003.
-
-## Conclusion
-
-The upstream repository is correctly identified. The commit hash `a5fae41a3eabe8ec4e1d8ff7b3fa6dfde5c4fa87` is the only commit in the repo. The sources are exclusively in SFD/VFB formats, which are not compatible with gftools-builder. No config.yaml is possible without converting the sources to a supported format (UFO or Glyphs).
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/hammersmithone"
-  commit: "a5fae41a3eabe8ec4e1d8ff7b3fa6dfde5c4fa87"
-}
-```
-
-### Status: no_config_possible
-
-SFD/VFB-only sources. These legacy formats are not compatible with gftools-builder, and creating a config.yaml is not possible without first converting the sources to UFO or Glyphs format.
+The original upstream repository was https://github.com/librefonts/hammersmithone, whose latest commit on the `master` branch is a5fae41a3eabe8ec4e1d8ff7b3fa6dfde5c4fa87 (the same commit recorded at onboarding). No upstream commits were made after onboarding.

--- a/ofl/handlee/METADATA.pb
+++ b/ofl/handlee/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 stroke: "SANS_SERIF"
 classifications: "HANDWRITING"
 source {
-  repository_url: "https://github.com/librefonts/handlee"
-  commit: "d937cfc17b0389d9847b8a865060b7241af7c654"
+  repository_url: "https://github.com/googlefonts/handlee"
+  commit: "f9930b13dd4ace03636c6260d73cacb5fa30a107"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Handlee-Regular.ttf"
+    dest_file: "Handlee-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/handlee/upstream_info.md
+++ b/ofl/handlee/upstream_info.md
@@ -1,81 +1,25 @@
-# Investigation Report: Handlee
+# Handlee
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-Handlee is a handwriting font designed by Joe Prince (Admix Designs), added to Google Fonts on 2011-12-13. The font was included in the initial commit of the google/fonts repository and has never been updated. The upstream repository is `librefonts/handlee` on GitHub, which contains an SFD (FontForge) source file and a VFB (FontLab) source file. Neither format is compatible with gftools-builder. No `.glyphs`, `.ufo`, or `.designspace` sources exist, making it impossible to create a config.yaml for building.
+## Initial state
 
-## Key Findings
+Google Fonts shipped Handlee (Regular) built from FontForge SFD sources at https://github.com/librefonts/handlee. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-| Field | Value |
-|---|---|
-| **Family Name** | Handlee |
-| **Designer** | Joe Prince |
-| **Date Added** | 2011-12-13 |
-| **Repository URL** | https://github.com/librefonts/handlee |
-| **Commit Hash** | d937cfc17b0389d9847b8a865060b7241af7c654 |
-| **Config YAML** | None (SFD/VFB-only sources) |
-| **Status** | no_config_possible |
-| **Confidence** | HIGH |
+## Actions taken
 
-## Investigation Details
+- The canonical FontForge SFD source (`src/Handlee-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/handlee, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-### METADATA.pb Analysis
+## Final state
 
-The current METADATA.pb has no `source { }` block. The font has a single weight (Regular) with filename `Handlee-Regular.ttf`. Classifications include HANDWRITING and stroke SANS_SERIF.
+The source now lives at https://github.com/googlefonts/handlee (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
-### Git History in google/fonts
+## Verification
 
-The font binary was added in the initial commit:
-- `90abd17b4` (2015-03-07) - "Initial commit" by Dave Crossland
+The fontc build matched the shipped Handlee-Regular.ttf on every dimension checked, with two accepted differences: two legacy FontForge helper glyphs (`.null` and `nonmarkingreturn`) were dropped, and one glyph was renamed to its production name. Both leave the Unicode cmap coverage unchanged, so rendering is unaffected.
 
-The font file has only been touched once more:
-- `76adaf1d2` (2021-11-01) - "deploy: c7e2740188205a85323c7385547f6f59b4f2245a" - gh-pages deployment, not a font update.
+## Original repository (dormant)
 
-The binary has never been updated since the initial commit.
-
-### Upstream Repository
-
-The upstream repository at `https://github.com/librefonts/handlee` (cached at `librefonts/handlee`) has only a single commit:
-- `d937cfc17b0389d9847b8a865060b7241af7c654` (2014-10-17) - "update .travis.yml"
-
-The repository contains:
-- **Font files**: TTX decompositions of the TTF file (various table-level files)
-- **Source files** in `src/`:
-  - `Handlee-Regular-TTF.sfd` - FontForge SFD source
-  - `Handlee-Regular-OTF.vfb` - FontLab VFB source
-  - Various OTF TTX decompositions
-- **No gftools-builder compatible sources**: No `.glyphs`, `.ufo`, or `.designspace` files exist
-- **No config.yaml**
-
-### Source Compatibility
-
-The source files are SFD (FontForge) and VFB (FontLab) formats. Neither is compatible with gftools-builder, which requires `.glyphs`, `.ufo`, or `.designspace` files. Creating an override config.yaml is not feasible without compatible source files.
-
-### Commit Hash Rationale
-
-The upstream repository has only one commit (`d937cfc`), so this is the only possible commit to reference. The repository predates the google/fonts initial commit.
-
-### librefonts Organization Context
-
-The `librefonts` organization on GitHub hosts decomposed (TTX) versions of many Google Fonts with their original source files. These repos typically have a single commit with Travis CI configuration for automated font building/testing. They serve as archival repositories rather than active development repos.
-
-## Conclusion
-
-Handlee has an identifiable upstream repository at `librefonts/handlee`, but it only contains SFD and VFB sources, making gftools-builder incompatible. The source block should reference the repository and commit, but no config.yaml is possible.
-
-### Recommended METADATA.pb Source Block
-
-```
-source {
-  repository_url: "https://github.com/librefonts/handlee"
-  commit: "d937cfc17b0389d9847b8a865060b7241af7c654"
-  files {
-    source_file: "OFL.txt"
-    dest_file: "OFL.txt"
-  }
-}
-```
-
-Note: The font binary in google/fonts was compiled from the original SFD/VFB sources. Since these formats are not supported by gftools-builder, no `config_yaml` field should be included.
-
-**Status**: no_config_possible (SFD/VFB-only sources, no gftools-builder compatible files)
+The original FontForge sources are at https://github.com/librefonts/handlee (`.sfd`), latest at commit `d937cfc17b0389d9847b8a865060b7241af7c654`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/inder/METADATA.pb
+++ b/ofl/inder/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  commit: "5620f4744158d400ba1286612d14d49c43597033"
-  repository_url: "https://github.com/librefonts/inder"
+  repository_url: "https://github.com/googlefonts/inder"
+  commit: "e4d4209a92fbe490892b0a6dbac6d61369f32f60"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Inder-Regular.ttf"
+    dest_file: "Inder-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/inder/upstream_info.md
+++ b/ofl/inder/upstream_info.md
@@ -1,42 +1,26 @@
-# Investigation: Inder
+# Inder
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Inder |
-| Slug | inder |
-| License Dir | ofl |
-| Repository URL | https://github.com/librefonts/inder |
-| Commit Hash | unknown |
-| Config YAML | none |
-| Status | no_config_possible |
-| Confidence | HIGH |
+## Initial state
 
-## Source Data (METADATA.pb)
+Google Fonts shipped Inder (Regular) built from FontForge SFD sources at https://github.com/librefonts/inder. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-```
-No source block
-```
+## Actions taken
 
-## Investigation
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected to match the space glyph.
+- A new Unified Font Repository was created at https://github.com/googlefonts/inder, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The METADATA.pb for Inder (at `google/fonts/ofl/inder/METADATA.pb`) contains no source block. The family was added in the initial commit to google/fonts (commit `90abd17b4`, dated 2015-03-07 by Dave Crossland), predating the modern source tracking infrastructure.
+## Final state
 
-The git log for `ofl/inder/Inder-Regular.ttf` shows only the initial commit `90abd17b4`, confirming the font has not been updated since the original onboarding.
+The source now lives at https://github.com/googlefonts/inder (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
-The upstream repository was identified as `https://github.com/librefonts/inder` (confirmed by the cached repo at `upstream_repos/fontc_crater_cache/librefonts/inder/` with remote URL `https://github.com/librefonts/inder`).
+## Verification
 
-The librefonts/inder repository structure:
-- Root level: `DESCRIPTION.en_us.html`, `FONTLOG.txt`, `Inder-Regular.ttf`, `OFL.txt`, `METADATA.json`, `src/`
-- `src/` directory contains: FontForge `.sfd` files (`Inder-Regular-TTF.sfd`, `Inder-Regular-OTF.vfb`, `Inder-Regular.vfb`) and TTX decompiled files
+The rebuilt Inder Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets and advance widths. The remaining differences are benign: 22 glyphs were renamed to production names with coverage unchanged, and GDEF now classifies two real combining marks the shipped font missed (uni0326, uni0326.cap).
 
-The HEAD commit of the upstream repo is `5620f4744158d400ba1286612d14d49c43597033` (message: "update .travis.yml").
+## Original repository (dormant)
 
-The `.sfd` (Spline Font Database) files are FontForge format. While they contain the original font source data, they are NOT compatible with gftools-builder, which only supports `.glyphs`, `.ufo`, and `.designspace` formats. Therefore, no `config.yaml` can be created for automated gftools-builder rebuilds.
-
-The font was designed by Sorkin Type (Eben Sorkin), as indicated in the copyright notice: "Copyright (c) 2010 by Sorkin Type Co (eben@eyebytes.com)".
-
-## Conclusion
-
-No source block can be completed for Inder. The upstream repository (`librefonts/inder`) only contains FontForge `.sfd` source files, which are not compatible with gftools-builder. Status: `no_config_possible`. A source block with `repository_url` only could be added to document the upstream location, but no `config_yaml` can be provided.
+The original FontForge sources are at https://github.com/librefonts/inder (`.sfd`), latest at commit `5620f4744158d400ba1286612d14d49c43597033`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/inika/METADATA.pb
+++ b/ofl/inika/METADATA.pb
@@ -25,6 +25,20 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  commit: "bccbe87bf5a91ebb43d149cd786cdabde71c8e52"
-  repository_url: "https://github.com/librefonts/inika"
+  repository_url: "https://github.com/googlefonts/inika"
+  commit: "07bb78b80a644c3e4979fbd4b6a6a6548d5a2934"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Inika-Bold.ttf"
+    dest_file: "Inika-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Inika-Regular.ttf"
+    dest_file: "Inika-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/inika/upstream_info.md
+++ b/ofl/inika/upstream_info.md
@@ -1,42 +1,26 @@
-# Investigation: Inika
+# Inika
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Inika |
-| Slug | inika |
-| License Dir | ofl |
-| Repository URL | https://github.com/librefonts/inika |
-| Commit Hash | unknown |
-| Config YAML | none |
-| Status | no_config_possible |
-| Confidence | HIGH |
+## Initial state
 
-## Source Data (METADATA.pb)
+Google Fonts shipped Inika (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/inika. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-```
-No source block
-```
+## Actions taken
 
-## Investigation
+- The two canonical FontForge SFD sources (Regular and Bold) were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The Bold source's OS/2 usWeightClass was set to 700 to match the shipped binary.
+- A new Unified Font Repository was created at https://github.com/googlefonts/inika, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-The METADATA.pb for Inika (at `google/fonts/ofl/inika/METADATA.pb`) contains no source block. The family was added in the initial commit to google/fonts (commit `90abd17b4`, dated 2015-03-07 by Dave Crossland), predating the modern source tracking infrastructure.
+## Final state
 
-The git log for `ofl/inika/Inika-Regular.ttf` shows only the initial commit `90abd17b4`, confirming the font has not been updated since the original onboarding.
+The source now lives at https://github.com/googlefonts/inika (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
-The upstream repository was identified as `https://github.com/librefonts/inika` (confirmed by the cached repo at `upstream_repos/fontc_crater_cache/librefonts/inika/` with remote URL `https://github.com/librefonts/inika`).
+## Verification
 
-The librefonts/inika repository structure:
-- Root level: `DESCRIPTION.en_us.html`, `FONTLOG.txt`, `Inika-Bold.ttf`, `Inika-Regular.ttf`, `OFL.txt`, `METADATA.json`, `src/`
-- `src/` directory contains FontForge `.sfd` files: `Inika-Regular-TTF.sfd`, `Inika-Bold-TTF.sfd`, along with `.vfb` and TTX decompiled files
+Both weights matched the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 10 glyphs per weight were renamed to production names; glyph coverage is unchanged.
 
-The HEAD commit of the upstream repo is `bccbe87bf5a91ebb43d149cd786cdabde71c8e52` (message: "update .travis.yml").
+## Original repository (dormant)
 
-The `.sfd` (Spline Font Database) files are FontForge format. While they contain the original font source data, they are NOT compatible with gftools-builder, which only supports `.glyphs`, `.ufo`, and `.designspace` formats. Therefore, no `config.yaml` can be created for automated gftools-builder rebuilds.
-
-The font was designed by Constanza Artigas (copyright 2011).
-
-## Conclusion
-
-No source block can be completed for Inika. The upstream repository (`librefonts/inika`) only contains FontForge `.sfd` source files, which are not compatible with gftools-builder. Status: `no_config_possible`. A source block with `repository_url` only could be added to document the upstream location, but no `config_yaml` can be provided.
+The original FontForge sources are at https://github.com/librefonts/inika (`.sfd`), latest at commit `bccbe87bf5a91ebb43d149cd786cdabde71c8e52`. Preserved for provenance; the new `.glyphs` sources supersede them for building.

--- a/ofl/jockeyone/METADATA.pb
+++ b/ofl/jockeyone/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/jockeyone"
-  commit: "71261c6f0c80fb7269df32e4aa396669a038030f"
+  repository_url: "https://github.com/googlefonts/jockeyone"
+  commit: "4f6087374d94a145a80a2b297f27db8b52e52dd9"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/JockeyOne-Regular.ttf"
+    dest_file: "JockeyOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/jockeyone/upstream_info.md
+++ b/ofl/jockeyone/upstream_info.md
@@ -1,40 +1,26 @@
-# Investigation: Jockey One
+# Jockey One
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Jockey One |
-| Slug | jockey-one |
-| License Dir | ofl |
-| Repository URL | https://github.com/librefonts/jockeyone |
-| Commit Hash | 71261c6f0c80fb7269df32e4aa396669a038030f |
-| Config YAML | none |
-| Status | missing_config |
-| Confidence | HIGH |
+## Initial state
 
-## Source Data (METADATA.pb)
+Google Fonts shipped Jockey One (Regular) built from FontForge SFD sources at https://github.com/librefonts/jockeyone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-No source block
+## Actions taken
 
-## Investigation
+- The canonical FontForge SFD source (`src/JockeyOne-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The no-break space (U+00A0) advance width was corrected to 160 in the converted source.
+- A new Unified Font Repository was created at https://github.com/googlefonts/jockeyone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The `ofl/jockeyone/` directory in google/fonts contains `DESCRIPTION.en_us.html`, `JockeyOne-Regular.ttf`, `METADATA.pb`, and `OFL.txt`. The METADATA.pb has only basic metadata — no `source { }` block.
+## Final state
 
-The git log shows the font has been in google/fonts since the initial commit (`90abd17b4`, 2015-03-07). No font file updates have been pushed since then.
+The source now lives at https://github.com/googlefonts/jockeyone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-The copyright reads: "Copyright (c) 2011, TypeTogether (www.type-together.com), with Reserved Font Names 'Jockey' and 'Jockey One'."
+## Verification
 
-The tracking JSON (`data/gfonts_library_sources.json`) records the upstream repository as `https://github.com/librefonts/jockeyone` at commit `71261c6f0c80fb7269df32e4aa396669a038030f` (subject: "update .travis.yml"). This is the librefonts GitHub organization's mirror repository. Notes indicate: "SFD-only sources (FontForge format), not gftools-builder compatible".
+The rebuilt Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle and GSUB/GPOS feature sets. Three benign differences were accepted: the FontForge-only helper glyph `nonmarkingreturn` was dropped; 13 glyphs were renamed to their production names with no change in coverage; and GDEF now classifies two real combining marks (uni0326 and uni0326.cap) that the shipped font had left unclassified.
 
-The upstream repository is cached at `upstream_repos/fontc_crater_cache/librefonts/jockeyone`. The local clone has only one commit (shallow clone). The repository contains:
-- `JockeyOne-Regular.ttf` (binary font)
-- `src/JockeyOne-Regular-TTF.sfd` (FontForge source, SFD format)
-- `src/JockeyOne-Regular.vfb` (FontLab Studio source)
-- TTX decompositions of the fonts
+## Original repository (dormant)
 
-The source format is `.sfd` (FontForge) and `.vfb` (FontLab Studio), which are NOT compatible with gftools-builder. No `.glyphs`, `.ufo`, or `.designspace` files exist.
-
-## Conclusion
-
-The upstream repository is `https://github.com/librefonts/jockeyone` at commit `71261c6f0c80fb7269df32e4aa396669a038030f`. However, the only sources available are `.sfd` (FontForge) and `.vfb` (FontLab Studio) files, which are not gftools-builder compatible. No config.yaml is possible with these sources. A source block needs to be added to METADATA.pb but the status will remain `missing_config` until buildable sources become available.
+The original FontForge sources are at https://github.com/librefonts/jockeyone (`.sfd`), latest at commit `71261c6f0c80fb7269df32e4aa396669a038030f`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/juliussansone/METADATA.pb
+++ b/ofl/juliussansone/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/juliussansone"
-  commit: "8aadb0e8d6ef7f45aa2844ccd99f7e28f0cd1498"
+  repository_url: "https://github.com/googlefonts/juliussansone"
+  commit: "6e629197948d3aef530fba4cfa8f9e754b947cc1"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/JuliusSansOne-Regular.ttf"
+    dest_file: "JuliusSansOne-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/juliussansone/upstream_info.md
+++ b/ofl/juliussansone/upstream_info.md
@@ -1,44 +1,26 @@
-# Investigation: Julius Sans One
+# Julius Sans One
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Julius Sans One |
-| Slug | julius-sans-one |
-| License Dir | ofl |
-| Repository URL | https://github.com/librefonts/juliussansone |
-| Commit Hash | 8aadb0e8d6ef7f45aa2844ccd99f7e28f0cd1498 |
-| Config YAML | none (OTF-only sources in librefonts mirror) |
-| Status | no_config_possible |
-| Confidence | MEDIUM |
+## Initial state
 
-## Source Data (METADATA.pb)
+Google Fonts shipped Julius Sans One (Regular) built from FontForge SFD sources at https://github.com/librefonts/juliussansone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-```
-No source block
-```
+## Actions taken
 
-## Investigation
+- The canonical FontForge SFD source (`JuliusSansOne-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- During conversion the no-break space (U+00A0) advance width was corrected to 360.
+- A new Unified Font Repository was created at https://github.com/googlefonts/juliussansone, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The METADATA.pb for Julius Sans One has no source block. The font was designed by Luciano Vergara from the Chilean type foundry LatinoType.
+## Final state
 
-The git history in google/fonts shows the font was present since the initial commit (`90abd17b4`) and was updated in commit `7a00bf8ff` ("Updating Julius Sans One") on 2015-04-20 by Dave Crossland, which applied ttfautohint 1.3 and minor fixes. The copyright notice reads: "Copyright (c) 2012, LatinoType (luciano@latinotype.com), with Reserved Font Names 'Julius'".
+The source now lives at https://github.com/googlefonts/juliussansone (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-The DESCRIPTION.en_us.html mentions LatinoType's website `http://www.latinotype.com` but no GitHub repository URL. No override `config.yaml` exists in the google/fonts `ofl/juliussansone/` directory.
+## Verification
 
-A `librefonts` mirror of Julius Sans One exists in the cache at `upstream_repos/fontc_crater_cache/librefonts/juliussansone/`. This contains TTX-decompiled OTF files and a `src/` directory with more TTX files. No Glyphs, UFO, or other gftools-builder compatible sources are present. The commit `8aadb0e8d6ef7f45aa2844ccd99f7e28f0cd1498` is the recorded commit in the tracking JSON.
+Matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 4 glyphs were renamed to their production names; glyph coverage is unchanged, so this is accepted as functionally equivalent.
 
-This means the `librefonts/juliussansone` mirror is the only known upstream reference, but it contains only decompiled font files (TTX format), not editable source files. No gftools-builder compatible sources are available.
+## Original repository (dormant)
 
-The font file structure in google/fonts contains only:
-- `JuliusSansOne-Regular.ttf`
-- `METADATA.pb`
-- `OFL.txt`
-- `DESCRIPTION.en_us.html`
-
-No override `config.yaml` exists in the google/fonts directory.
-
-## Conclusion
-
-Julius Sans One has a librefonts mirror at `https://github.com/librefonts/juliussansone` with commit `8aadb0e8d6ef7f45aa2844ccd99f7e28f0cd1498`. The librefonts mirror contains only TTX-decompiled OTF files — no gftools-builder compatible sources. No `config.yaml` can be created without first identifying and converting original source files. Status: no_config_possible.
+The original FontForge sources are at https://github.com/librefonts/juliussansone (`.sfd`), latest at commit `8aadb0e8d6ef7f45aa2844ccd99f7e28f0cd1498`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/justmeagaindownhere/METADATA.pb
+++ b/ofl/justmeagaindownhere/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/justmeagaindownhere"
-  commit: "63543cec6964e5061ece828c63948d1910e0dbdd"
+  repository_url: "https://github.com/googlefonts/justmeagaindownhere"
+  commit: "23514049cb37c16431521835a69aa7cfe5d9b709"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/JustMeAgainDownHere-Regular.ttf"
+    dest_file: "JustMeAgainDownHere.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/justmeagaindownhere/upstream_info.md
+++ b/ofl/justmeagaindownhere/upstream_info.md
@@ -1,51 +1,26 @@
-# Investigation: Just Me Again Down Here
+# Just Me Again Down Here
 
-## Summary
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-| Field | Value |
-|-------|-------|
-| Family Name | Just Me Again Down Here |
-| Slug | just-me-again-down-here |
-| License Dir | ofl |
-| Repository URL | https://github.com/librefonts/justmeagaindownhere |
-| Commit Hash | 63543cec6964e5061ece828c63948d1910e0dbdd |
-| Config YAML | none (OTF-only sources in librefonts mirror) |
-| Status | no_config_possible |
-| Confidence | MEDIUM |
+## Initial state
 
-## Source Data (METADATA.pb)
+Google Fonts shipped Just Me Again Down Here (Regular) built from FontForge SFD sources at https://github.com/librefonts/justmeagaindownhere. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-```
-No source block
-```
+## Actions taken
 
-## Investigation
+- The canonical FontForge SFD source (`JustMeAgainDownHere-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- During conversion, stray NUL bytes were stripped from the SFD and the no-break space was given its correct advance width.
+- A new Unified Font Repository was created at https://github.com/googlefonts/justmeagaindownhere, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-The METADATA.pb for Just Me Again Down Here has no source block. The font was designed by Kimberly Geswein (kimberlygeswein@gmail.com), a prolific handwriting font designer with many fonts in the Google Fonts catalog.
+## Final state
 
-The git history in google/fonts shows:
-- Initial commit `90abd17b4` (earliest record, pre-dating 2011)
-- `883939708` — "Remove METADATA.json files"
-- `480630de3` — "Tentative update to METADATA.pb textprotos"
-- `27f377ab0` — "Update copyright field in METADATA.pb"
-- Several language/metadata-only changes since then
+The source now lives at https://github.com/googlefonts/justmeagaindownhere (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-The copyright reads: "Copyright (c) 2011 by Kimberly Geswein (kimberlygeswein@gmail.com). All rights reserved."
+## Verification
 
-The DESCRIPTION.en_us.html describes the font as created shortly after the designer's family moved to China in 2010/2011, created using a Wacom Tablet and Adobe Illustrator. No GitHub repository URL is mentioned.
+The build matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, and GSUB/GPOS feature sets. The accepted differences are cosmetic or corrective: the FontForge legacy glyph `nonmarkingreturn` was dropped; 21 glyphs were renamed to production names with unchanged coverage; the GDEF table now classifies the combining mark uni0326 that the shipped font had missed; and the private-use combining mark U+F6C3 was zeroed where the shipped font had given it a spacing advance.
 
-A `librefonts` mirror exists in the cache at `upstream_repos/fontc_crater_cache/librefonts/justmeagaindownhere/`. This contains TTX-decompiled OTF files and a `src/` directory with more OTF TTX files. No Glyphs, UFO, or gftools-builder compatible sources are present. The commit `63543cec6964e5061ece828c63948d1910e0dbdd` is recorded in the tracking JSON.
+## Original repository (dormant)
 
-The DESCRIPTION.en_us.html confirms the font was created using a Wacom Tablet and Adobe Illustrator, suggesting the original sources are in Illustrator's proprietary format (AI or EPS), which is not compatible with gftools-builder.
-
-The font file structure in google/fonts contains only:
-- `JustMeAgainDownHere.ttf`
-- `METADATA.pb`
-- `OFL.txt`
-- `DESCRIPTION.en_us.html`
-
-No override `config.yaml` exists in the google/fonts directory.
-
-## Conclusion
-
-Just Me Again Down Here has a librefonts mirror at `https://github.com/librefonts/justmeagaindownhere` with commit `63543cec6964e5061ece828c63948d1910e0dbdd`. The librefonts mirror contains only TTX-decompiled OTF files — no gftools-builder compatible sources. The font was originally created in Adobe Illustrator, so no `.glyphs` or `.ufo` sources are expected to exist. Status: no_config_possible.
+The original FontForge sources are at https://github.com/librefonts/justmeagaindownhere (`.sfd`), latest at commit `63543cec6964e5061ece828c63948d1910e0dbdd`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/lusitana/METADATA.pb
+++ b/ofl/lusitana/METADATA.pb
@@ -26,6 +26,20 @@ subsets: "latin"
 subsets: "latin-ext"
 
 source {
-  repository_url: "https://github.com/librefonts/lusitana"
-  commit: "8fa070c2ac2963f13feee142e2001777ac48e774"
+  repository_url: "https://github.com/googlefonts/lusitana"
+  commit: "393d85168ac2026bfc47c6c15bcb3868e279d92b"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Lusitana-Bold.ttf"
+    dest_file: "Lusitana-Bold.ttf"
+  }
+  files {
+    source_file: "fonts/ttf/Lusitana-Regular.ttf"
+    dest_file: "Lusitana-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/lusitana/upstream_info.md
+++ b/ofl/lusitana/upstream_info.md
@@ -1,33 +1,26 @@
-# Lusitana — Source Repository Investigation
+# Lusitana
 
-**Model**: Claude Opus 4.6
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Repository
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| Repository | https://github.com/librefonts/lusitana |
-| Commit | `8fa070c2ac2963f13feee142e2001777ac48e774` |
-| Confidence | Medium |
+Google Fonts shipped Lusitana (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/lusitana. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Source Types
+## Actions taken
 
-The repository contains TTX-decompiled sources only.
+- The canonical FontForge SFD sources were converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The Bold source's OS/2 usWeightClass was set to 700, which the conversion had not preserved.
+- A new Unified Font Repository was created at https://github.com/googlefonts/lusitana, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-## Build Compatibility
+## Final state
 
-Not buildable with gftools-builder. The TTX files are decompiled binary font dumps, not original editable design sources.
+The source now lives at https://github.com/googlefonts/lusitana (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binaries.
 
-## Investigation Notes
+## Verification
 
-This is a librefonts mirror repository containing TTX-decompiled binary dumps. Two other repositories were investigated: googlefonts/lusitana exists but appears to be empty (size=0), and fontalternative/lusitana exists but is very small (56KB). Neither alternative provides usable original design sources.
+The rebuilt Regular and Bold matched the shipped binaries on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 4 glyphs in each weight were renamed to their production names; character coverage is unchanged, so this is benign.
 
-**Note on librefonts TTX mirrors**: These repositories contain TTX (XML) representations of the compiled font binaries. They are mechanically decompiled from the .ttf files and do not represent original design sources. They cannot be used for font development or rebuilding with gftools-builder.
+## Original repository (dormant)
 
-The binary in google/fonts dates from the initial commit (2015-03-07).
-
-A source block was added to METADATA.pb pointing to this repository and commit.
-
-## Confidence: Medium
-
-Librefonts TTX mirror; original design sources are not available. Alternative repos are empty or insufficient.
+The original FontForge sources are at https://github.com/librefonts/lusitana (`.sfd`), latest at commit `8fa070c2ac2963f13feee142e2001777ac48e774`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/macondoswashcaps/METADATA.pb
+++ b/ofl/macondoswashcaps/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 classifications: "DISPLAY"
 classifications: "HANDWRITING"
 source {
-  repository_url: "https://github.com/librefonts/macondoswashcaps"
-  commit: "2768d9b33c7d703085314fcd8c823ad1a8b02edb"
+  repository_url: "https://github.com/googlefonts/macondoswashcaps"
+  commit: "bd29bdafaab2e21ae4bdcc16106b15f2365bca61"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/MacondoSwashCaps-Regular.ttf"
+    dest_file: "MacondoSwashCaps-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/macondoswashcaps/upstream_info.md
+++ b/ofl/macondoswashcaps/upstream_info.md
@@ -1,42 +1,25 @@
-# Macondo Swash Caps - Source Repository Investigation
+# Macondo Swash Caps
 
-**Model**: Claude Opus 4.6
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Repository
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| **Repository** | [librefonts/macondoswashcaps](https://github.com/librefonts/macondoswashcaps) |
-| **Commit** | `2768d9b33c7d703085314fcd8c823ad1a8b02edb` |
-| **Confidence** | medium |
-| **Source Types** | ttx |
-| **Has config.yaml** | No |
+Google Fonts shipped Macondo Swash Caps (Regular) built from FontForge SFD sources at https://github.com/librefonts/macondoswashcaps. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Investigation Summary
+## Actions taken
 
-METADATA.pb for Macondo Swash Caps had no source block. A source block was added pointing to the librefonts mirror repository.
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/macondoswashcaps, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## Source Analysis
+## Final state
 
-The repository at https://github.com/librefonts/macondoswashcaps is a **librefonts mirror**. These repositories contain TTX (XML) files that were mechanically decompiled from the binary TTF fonts, not original design sources. They do not contain the original .glyphs, .ufo, .sfd, or other editable source files that the designer used to create the font.
+The source now lives at https://github.com/googlefonts/macondoswashcaps (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-**Available source types**: ttx (decompiled from binaries)
+## Verification
 
-## Build Status
+Identical to the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 9 glyphs were renamed to their standard production names; glyph coverage is unchanged, so this is cosmetic and acceptable.
 
-This family is **not buildable** with gftools-builder from these sources. The TTX files in librefonts mirrors are binary round-trips, not design sources. No config.yaml was created because there are no compatible sources to build from.
+## Original repository (dormant)
 
-## Notes
-
-librefonts mirror with TTX sources.
-
-## Binary History in google/fonts
-
-```
-2015-03-07 05:14:52 +0530 90abd17b4f97671435798b6147b698aa9087612f Initial commit
-```
-
-## Actions Taken
-
-1. A `source { }` block was added to METADATA.pb with the librefonts mirror repository URL and commit hash.
-2. No config.yaml was created because the repository contains only TTX decompiled binary dumps, not original design sources suitable for gftools-builder.
+The original FontForge sources are at https://github.com/librefonts/macondoswashcaps (`.sfd`), latest at commit `2768d9b33c7d703085314fcd8c823ad1a8b02edb`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/marckscript/METADATA.pb
+++ b/ofl/marckscript/METADATA.pb
@@ -19,6 +19,16 @@ subsets: "latin-ext"
 classifications: "DISPLAY"
 classifications: "HANDWRITING"
 source {
-  repository_url: "https://github.com/librefonts/marckscript"
-  commit: "699f31478702f9901c943b7be7caa6e38b6535b7"
+  repository_url: "https://github.com/googlefonts/marckscript"
+  commit: "b85fe9173d03ac8c339274ead43f34f0752c0819"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/MarckScript-Regular.ttf"
+    dest_file: "MarckScript-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/marckscript/upstream_info.md
+++ b/ofl/marckscript/upstream_info.md
@@ -1,42 +1,25 @@
-# Marck Script - Source Repository Investigation
+# Marck Script
 
-**Model**: Claude Opus 4.6
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Repository
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| **Repository** | [librefonts/marckscript](https://github.com/librefonts/marckscript) |
-| **Commit** | `699f31478702f9901c943b7be7caa6e38b6535b7` |
-| **Confidence** | medium |
-| **Source Types** | ttx |
-| **Has config.yaml** | No |
+Google Fonts shipped Marck Script (Regular) built from FontForge SFD sources at https://github.com/librefonts/marckscript. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Investigation Summary
+## Actions taken
 
-METADATA.pb for Marck Script had no source block. A source block was added pointing to the librefonts mirror repository.
+- The canonical FontForge SFD source (`MarckScript-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- A new Unified Font Repository was created at https://github.com/googlefonts/marckscript, building the font with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## Source Analysis
+## Final state
 
-The repository at https://github.com/librefonts/marckscript is a **librefonts mirror**. These repositories contain TTX (XML) files that were mechanically decompiled from the binary TTF fonts, not original design sources. They do not contain the original .glyphs, .ufo, .sfd, or other editable source files that the designer used to create the font.
+The source now lives at https://github.com/googlefonts/marckscript (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at functional equivalence with the shipped binary.
 
-**Available source types**: ttx (decompiled from binaries)
+## Verification
 
-## Build Status
+The rebuilt Regular matched the shipped binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. Two differences were reviewed and accepted: the non-printing FontForge helper glyphs `.null` and `nonmarkingreturn` are no longer emitted (they carry no encoded codepoints), and one glyph was renamed to its production name with no change to codepoint coverage.
 
-This family is **not buildable** with gftools-builder from these sources. The TTX files in librefonts mirrors are binary round-trips, not design sources. No config.yaml was created because there are no compatible sources to build from.
+## Original repository (dormant)
 
-## Notes
-
-librefonts mirror with TTX sources.
-
-## Binary History in google/fonts
-
-```
-2015-03-07 05:14:52 +0530 90abd17b4f97671435798b6147b698aa9087612f Initial commit
-```
-
-## Actions Taken
-
-1. A `source { }` block was added to METADATA.pb with the librefonts mirror repository URL and commit hash.
-2. No config.yaml was created because the repository contains only TTX decompiled binary dumps, not original design sources suitable for gftools-builder.
+The original FontForge sources are at https://github.com/librefonts/marckscript (`.sfd`), latest at commit `699f31478702f9901c943b7be7caa6e38b6535b7`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/montaga/METADATA.pb
+++ b/ofl/montaga/METADATA.pb
@@ -16,6 +16,16 @@ subsets: "menu"
 subsets: "latin"
 subsets: "latin-ext"
 source {
-  repository_url: "https://github.com/librefonts/montaga"
-  commit: "1c439c4e7d38e452718e8e67834c810641d1685a"
+  repository_url: "https://github.com/googlefonts/montaga"
+  commit: "c01e6e195c2d67a0b9d5c3091f3c436991cafd90"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Montaga-Regular.ttf"
+    dest_file: "Montaga-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/montaga/upstream_info.md
+++ b/ofl/montaga/upstream_info.md
@@ -1,42 +1,26 @@
-# Montaga - Source Repository Investigation
+# Montaga
 
-**Model**: Claude Opus 4.6
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Repository
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| **Repository** | [librefonts/montaga](https://github.com/librefonts/montaga) |
-| **Commit** | `1c439c4e7d38e452718e8e67834c810641d1685a` |
-| **Confidence** | medium |
-| **Source Types** | ttx |
-| **Has config.yaml** | No |
+Google Fonts shipped Montaga (Regular) built from FontForge SFD sources at https://github.com/librefonts/montaga. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Investigation Summary
+## Actions taken
 
-METADATA.pb for Montaga had no source block. A source block was added pointing to the librefonts mirror repository.
+- The canonical FontForge SFD source (`src/Montaga-Regular-TTF.sfd`) was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- The non-breaking space (U+00A0) glyph handling was normalized during conversion.
+- A new Unified Font Repository was created at https://github.com/googlefonts/montaga, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binary.
 
-## Source Analysis
+## Final state
 
-The repository at https://github.com/librefonts/montaga is a **librefonts mirror**. These repositories contain TTX (XML) files that were mechanically decompiled from the binary TTF fonts, not original design sources. They do not contain the original .glyphs, .ufo, .sfd, or other editable source files that the designer used to create the font.
+The source now lives at https://github.com/googlefonts/montaga (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binary.
 
-**Available source types**: ttx (decompiled from binaries)
+## Verification
 
-## Build Status
+The build matched the shipped Montaga-Regular.ttf on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 9 glyphs carry their canonical production names (coverage unchanged), which is why the verdict is FUNCTIONAL rather than byte-for-byte identical.
 
-This family is **not buildable** with gftools-builder from these sources. The TTX files in librefonts mirrors are binary round-trips, not design sources. No config.yaml was created because there are no compatible sources to build from.
+## Original repository (dormant)
 
-## Notes
-
-librefonts mirror with TTX sources.
-
-## Binary History in google/fonts
-
-```
-2015-03-07 05:14:52 +0530 90abd17b4f97671435798b6147b698aa9087612f Initial commit
-```
-
-## Actions Taken
-
-1. A `source { }` block was added to METADATA.pb with the librefonts mirror repository URL and commit hash.
-2. No config.yaml was created because the repository contains only TTX decompiled binary dumps, not original design sources suitable for gftools-builder.
+The original FontForge sources are at https://github.com/librefonts/montaga (`.sfd`), latest at commit `1c439c4e7d38e452718e8e67834c810641d1685a`. Preserved for provenance; the new `.glyphs` source supersedes it for building.

--- a/ofl/quando/METADATA.pb
+++ b/ofl/quando/METADATA.pb
@@ -18,6 +18,16 @@ subsets: "latin-ext"
 stroke: "SERIF"
 classifications: "DISPLAY"
 source {
-  repository_url: "https://github.com/librefonts/quando"
-  commit: "328635dcbaae8f2fc4fd84c9b872e596a82bebe5"
+  repository_url: "https://github.com/googlefonts/quando"
+  commit: "bba03c60be43e46037df543ccce62fe7c7582b64"
+  files {
+    source_file: "OFL.txt"
+    dest_file: "OFL.txt"
+  }
+  files {
+    source_file: "fonts/ttf/Quando-Regular.ttf"
+    dest_file: "Quando-Regular.ttf"
+  }
+  branch: "master"
+  config_yaml: "sources/config.yaml"
 }

--- a/ofl/quando/upstream_info.md
+++ b/ofl/quando/upstream_info.md
@@ -1,42 +1,26 @@
-# Quando - Source Repository Investigation
+# Quando
 
-**Model**: Claude Opus 4.6
+Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
-## Source Repository
+## Initial state
 
-| Field | Value |
-|-------|-------|
-| **Repository** | [librefonts/quando](https://github.com/librefonts/quando) |
-| **Commit** | `328635dcbaae8f2fc4fd84c9b872e596a82bebe5` |
-| **Confidence** | medium |
-| **Source Types** | ttx |
-| **Has config.yaml** | No |
+Google Fonts shipped Quando (Regular) built from FontForge SFD sources at https://github.com/librefonts/quando. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.
 
-## Investigation Summary
+## Actions taken
 
-METADATA.pb for Quando had no source block. A source block was added pointing to the librefonts mirror repository.
+- The canonical FontForge SFD source was converted to Glyphs with babelfont-rs (upstream commit `219c0bb`).
+- In the converted source the non-breaking space (U+00A0) advance was set to 680 to match the space glyph, correcting a width FontForge had left inconsistent.
+- A new Unified Font Repository was created at https://github.com/googlefonts/quando, building the fonts with gftools-builder3 + fontc.
+- The build was verified against the shipped binaries.
 
-## Source Analysis
+## Final state
 
-The repository at https://github.com/librefonts/quando is a **librefonts mirror**. These repositories contain TTX (XML) files that were mechanically decompiled from the binary TTF fonts, not original design sources. They do not contain the original .glyphs, .ufo, .sfd, or other editable source files that the designer used to create the font.
+The source now lives at https://github.com/googlefonts/quando (see METADATA.pb) and builds reproducibly with gftools-builder3 + fontc at strict functional equivalence with the shipped binaries.
 
-**Available source types**: ttx (decompiled from binaries)
+## Verification
 
-## Build Status
+Identical to the shipped Quando-Regular binary on cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, GSUB/GPOS feature sets, GDEF classes and advance widths. The only difference is that 23 glyphs were renamed to their production names; glyph coverage is unchanged, so this is a naming-only change with no visible effect.
 
-This family is **not buildable** with gftools-builder from these sources. The TTX files in librefonts mirrors are binary round-trips, not design sources. No config.yaml was created because there are no compatible sources to build from.
+## Original repository (dormant)
 
-## Notes
-
-librefonts mirror with TTX sources.
-
-## Binary History in google/fonts
-
-```
-2015-03-07 05:14:52 +0530 90abd17b4f97671435798b6147b698aa9087612f Initial commit
-```
-
-## Actions Taken
-
-1. A `source { }` block was added to METADATA.pb with the librefonts mirror repository URL and commit hash.
-2. No config.yaml was created because the repository contains only TTX decompiled binary dumps, not original design sources suitable for gftools-builder.
+The original FontForge sources are at https://github.com/librefonts/quando (`.sfd`), latest at commit `328635dcbaae8f2fc4fd84c9b872e596a82bebe5`. Preserved for provenance; the new `.glyphs` source supersedes it for building.


### PR DESCRIPTION
The fourth batch in this series (after [#10697](https://github.com/google/fonts/pull/10697), [#10709](https://github.com/google/fonts/pull/10709) and [#10717](https://github.com/google/fonts/pull/10717)): 32 families whose upstream was a FontForge `.sfd` project with no source that builds on the current Google Fonts Rust pipeline. Each `.sfd` was converted to Glyphs (`.glyphs`), placed in a new Unified Font Repository under the `googlefonts` org, and made to build with gftools-builder3 + fontc. The rebuilt fonts were verified functionally equivalent to the shipped binaries.

Each family is one commit: it repoints the `source { }` block in METADATA.pb at the new repository (repository_url + merge commit + `config_yaml: sources/config.yaml` + the shipped file list) and rewrites `upstream_info.md`. The original `librefonts/*` `.sfd` repositories are preserved and cited in each report under "Original repository (dormant)".

**This PR changes source metadata only** -- it does not re-ship rebuilt binaries. The referenced repositories are the source of record for the next production build; that build's output would go through the usual QA.

### Verification

Each rebuild was graded against the shipped binary by codepoint (never by glyph name): cmap coverage, vertical metrics, usWeightClass, fsSelection/macStyle, and the GSUB/GPOS feature inventory all match. Remaining differences are benign modernizations (production-name renames with coverage unchanged, legacy `kern` rebuilt as a GPOS `kern` feature, U+00A0 advance corrected, GDEF/combining-mark fixes). Details per family are in each `upstream_info.md`.

### Families and source repositories

| family | source repository | commit |
|---|---|---|
| euphoriascript | googlefonts/euphoriascript | `78d9965282` |
| ewert | googlefonts/ewert | `1fdc40c5b4` |
| felipa | googlefonts/felipa | `1ba44f8353` |
| fenix | googlefonts/fenix | `cfae6dd042` |
| fjordone | googlefonts/fjordone | `a6c1784e33` |
| flamenco | googlefonts/flamenco | `457c24c540` |
| fresca | googlefonts/fresca | `6f0f0d00ca` |
| fugazone | googlefonts/fugazone | `cc513bad4e` |
| gafata | googlefonts/gafata | `145c6761d3` |
| galdeano | googlefonts/galdeano | `41268aaf05` |
| geostar | googlefonts/geostar | `cd70b3170a` |
| geostarfill | googlefonts/geostarfill | `61aec9b930` |
| germaniaone | googlefonts/germaniaone | `8c373b1705` |
| giveyouglory | googlefonts/giveyouglory | `79ab8c04f2` |
| glassantiqua | googlefonts/glassantiqua | `64763eadb6` |
| goblinone | googlefonts/goblinone | `82b0d4b4f5` |
| gochihand | googlefonts/gochihand | `af523d983c` |
| gravitasone | googlefonts/gravitasone | `feede2e878` |
| gudea | googlefonts/gudea | `7651bdceea` |
| habibi | googlefonts/habibi | `dca56369c2` |
| hammersmithone | googlefonts/hammersmithone | `fa842a5d78` |
| handlee | googlefonts/handlee | `f9930b13dd` |
| inder | googlefonts/inder | `e4d4209a92` |
| inika | googlefonts/inika | `07bb78b80a` |
| jockeyone | googlefonts/jockeyone | `4f6087374d` |
| juliussansone | googlefonts/juliussansone | `6e62919794` |
| justmeagaindownhere | googlefonts/justmeagaindownhere | `23514049cb` |
| lusitana | googlefonts/lusitana | `393d85168a` |
| macondoswashcaps | googlefonts/macondoswashcaps | `bd29bdafaa` |
| marckscript | googlefonts/marckscript | `b85fe9173d` |
| montaga | googlefonts/montaga | `c01e6e195c` |
| quando | googlefonts/quando | `bba03c60be` |

All 32 source-repo modernization PRs have merged into their `googlefonts/*` repositories; the commits referenced above are those repositories' current `master` tips.
