### PR TITLE
Sawarabi Gothic missing primary script

### DIFF
--- a/ofl/sawarabigothic/METADATA.pb
+++ b/ofl/sawarabigothic/METADATA.pb
@@ -22,3 +22,4 @@ source {
   repository_url: "https://github.com/googlefonts/sawarabi-mincho"
   commit: "397399cfaf018172046c936c0d774de0c5cbba82"
 }
+primary_script: "Jpan"


### PR DESCRIPTION
Missing `primary_script: "Jpan"` from metadata, leading to rendering of latin text on https://fonts.google.com/specimen/Sawarabi+Gothic