### PR TITLE
Yomogi Primary Script

### DIFF
--- a/ofl/yomogi/METADATA.pb
+++ b/ofl/yomogi/METADATA.pb
@@ -35,4 +35,4 @@ source {
   branch: "ver3.00"
   commit: "8551d68706679b88ce6ff40e093a993e546e593e"
 }
-primary_script: "Hira"
+primary_script: "Jpan"


### PR DESCRIPTION
Changing primary script from Hiragana to Japanese, as it has broad Kanji coverage. 