### PR TITLE
Murecho primary script to Jpan

### DIFF
--- a/ofl/murecho/METADATA.pb
+++ b/ofl/murecho/METADATA.pb
@@ -38,4 +38,4 @@ source {
   branch: "master"
   config_yaml: "sources/config.yaml"
 }
-primary_script: "Hira"
+primary_script: "Jpan"


### PR DESCRIPTION
Changing the primary script for Murecho from `Hira` to `Jpan`