### PR TITLE
Remove superseded single-axis tag rows

### DIFF
--- a/tags/all/families.csv
+++ b/tags/all/families.csv
@@ -181,9 +181,6 @@ Advent Pro,"wdth,wght@100,100",/Expressive/Active,5
 Advent Pro,"wdth,wght@100,900",/Expressive/Active,40
 Advent Pro,"wdth,wght@200,100",/Expressive/Active,6
 Advent Pro,"wdth,wght@200,900",/Expressive/Active,42
-Advent Pro,wght@100,/Expressive/Active,5
-Advent Pro,wght@400,/Expressive/Active,5
-Advent Pro,wght@900,/Expressive/Active,15
 Advent Pro,"wdth,wght@100,100",/Expressive/Artistic,10
 Advent Pro,"wdth,wght@100,900",/Expressive/Artistic,10
 Advent Pro,"wdth,wght@200,100",/Expressive/Artistic,10
@@ -11561,9 +11558,6 @@ Kalnia Glaze,"wdth,wght@100,100",/Expressive/Active,20
 Kalnia Glaze,"wdth,wght@100,700",/Expressive/Active,35
 Kalnia Glaze,"wdth,wght@125,100",/Expressive/Active,21
 Kalnia Glaze,"wdth,wght@125,700",/Expressive/Active,36
-Kalnia Glaze,wght@100,/Expressive/Active,5
-Kalnia Glaze,wght@400,/Expressive/Active,20
-Kalnia Glaze,wght@700,/Expressive/Active,45
 Kalnia Glaze,"wdth,wght@100,100",/Expressive/Artistic,85
 Kalnia Glaze,"wdth,wght@100,700",/Expressive/Artistic,95
 Kalnia Glaze,"wdth,wght@125,100",/Expressive/Artistic,90
@@ -11602,9 +11596,6 @@ Kalnia,"wdth,wght@100,100",/Expressive/Active,20
 Kalnia,"wdth,wght@100,700",/Expressive/Active,32
 Kalnia,"wdth,wght@125,100",/Expressive/Active,25
 Kalnia,"wdth,wght@125,700",/Expressive/Active,39
-Kalnia,wght@100,/Expressive/Active,1
-Kalnia,wght@400,/Expressive/Active,20
-Kalnia,wght@700,/Expressive/Active,33
 Kalnia,"wdth,wght@100,100",/Expressive/Artistic,75
 Kalnia,"wdth,wght@100,700",/Expressive/Artistic,85
 Kalnia,"wdth,wght@125,100",/Expressive/Artistic,80
@@ -14332,9 +14323,6 @@ Merriweather,"wdth,wght@87,300",/Expressive/Active,20
 Merriweather,"wdth,wght@87,900",/Expressive/Active,22
 Merriweather,"wdth,wght@112,300",/Expressive/Active,23
 Merriweather,"wdth,wght@112,900",/Expressive/Active,25
-Merriweather,wght@300,/Expressive/Active,8
-Merriweather,wght@400,/Expressive/Active,10
-Merriweather,wght@900,/Expressive/Active,15
 Merriweather,"wdth,wght@87,300",/Expressive/Artistic,10
 Merriweather,"wdth,wght@87,900",/Expressive/Artistic,15
 Merriweather,"wdth,wght@112,300",/Expressive/Artistic,10
@@ -15140,9 +15128,6 @@ Mozilla Headline,"wdth,wght@75,200",/Expressive/Artistic,10
 Mozilla Headline,"wdth,wght@75,700",/Expressive/Artistic,12
 Mozilla Headline,"wdth,wght@125,200",/Expressive/Artistic,10
 Mozilla Headline,"wdth,wght@125,700",/Expressive/Artistic,12
-Mozilla Headline,wght@200,/Expressive/Artistic,8
-Mozilla Headline,wght@400,/Expressive/Artistic,40
-Mozilla Headline,wght@700,/Expressive/Artistic,45
 Mozilla Headline,"wdth,wght@75,200",/Expressive/Awkward,5
 Mozilla Headline,"wdth,wght@75,700",/Expressive/Awkward,5
 Mozilla Headline,"wdth,wght@125,200",/Expressive/Awkward,5
@@ -27265,9 +27250,6 @@ Tourney,"wdth,wght@75,100",/Expressive/Active,25
 Tourney,"wdth,wght@75,900",/Expressive/Active,25
 Tourney,"wdth,wght@125,100",/Expressive/Active,30
 Tourney,"wdth,wght@125,900",/Expressive/Active,30
-Tourney,wght@100,/Expressive/Active,70
-Tourney,wght@400,/Expressive/Active,73
-Tourney,wght@900,/Expressive/Active,68
 Tourney,"wdth,wght@75,100",/Expressive/Artistic,70
 Tourney,"wdth,wght@75,900",/Expressive/Artistic,68
 Tourney,"wdth,wght@125,100",/Expressive/Artistic,71


### PR DESCRIPTION
## Summary
- Removes 18 single-axis VF tag rows (e.g. `wght@400`) that are superseded by multi-axis rows (e.g. `wdth,wght@75,400`) for the same family+tag
- Affects 6 families across `/Expressive/Active` and `/Expressive/Artistic`: Advent Pro, Kalnia, Kalnia Glaze, Merriweather, Mozilla Headline, Tourney
- No value changes — purely removing obsolete rows