### PR TITLE
Yomogi: use primary_script, not primary_language

### DIFF
--- a/ofl/yomogi/METADATA.pb
+++ b/ofl/yomogi/METADATA.pb
@@ -35,4 +35,4 @@ source {
   branch: "ver3.00"
   commit: "8551d68706679b88ce6ff40e093a993e546e593e"
 }
-primary_language: "Jpan"
+primary_script: "Jpan"


### PR DESCRIPTION
Use primary_script rather than primary_language.  primary_language is intended to choose a specific language within the script.  With just primary_language set, the script defaults to Latin and this resulted in the language Jpan not being found in the Latin script.