### PR TITLE
Update Yomogi's METADATA.pb to set primary_language to js_Jpan

### DIFF
--- a/ofl/yomogi/METADATA.pb
+++ b/ofl/yomogi/METADATA.pb
@@ -35,4 +35,4 @@ source {
   branch: "ver3.00"
   commit: "8551d68706679b88ce6ff40e093a993e546e593e"
 }
-primary_script: "Jpan"
+primary_language: "ja_Jpan"


### PR DESCRIPTION
My last update was wrong.
It's fine to have a primary_language without primary_script.
The issue was that the primary_language was set to Jpan and it needs a qualifier in front of that, like ja_Jpan.
I'm guessing that's the right one and that's what this PR uses