### PR TITLE
Update quant.csv -- remove not-yet-onboarded entries

### DIFF
--- a/tags/all/quant.csv
+++ b/tags/all/quant.csv
@@ -12978,20 +12978,8 @@ Geist Mono,wght@900,/quant/stroke_width_min,145.71
 Geist Mono,wght@900,/quant/stroke_width_max,176.00
 Hedvig Letters Serif,wght@400,/quant/stroke_width_min,38.00
 Hedvig Letters Serif,wght@400,/quant/stroke_width_max,99.34
-Hermeneus One,wght@400,/quant/stroke_width_min,59.88
-Hermeneus One,wght@400,/quant/stroke_width_max,106.00
 Hina Mincho,wght@400,/quant/stroke_width_min,25.95
 Hina Mincho,wght@400,/quant/stroke_width_max,78.00
-Hind Kochi,wght@300,/quant/stroke_width_min,57.86
-Hind Kochi,wght@300,/quant/stroke_width_max,65.07
-Hind Kochi,wght@400,/quant/stroke_width_min,69.84
-Hind Kochi,wght@400,/quant/stroke_width_max,82.33
-Hind Kochi,wght@500,/quant/stroke_width_min,82.82
-Hind Kochi,wght@500,/quant/stroke_width_max,103.01
-Hind Kochi,wght@600,/quant/stroke_width_min,95.80
-Hind Kochi,wght@600,/quant/stroke_width_max,126.07
-Hind Kochi,wght@700,/quant/stroke_width_min,112.78
-Hind Kochi,wght@700,/quant/stroke_width_max,152.07
 Imbue,wght@100,/quant/stroke_width_min,28.66
 Imbue,wght@100,/quant/stroke_width_max,33.00
 Imbue,wght@200,/quant/stroke_width_min,30.95
@@ -13078,8 +13066,6 @@ M PLUS Rounded 1c,wght@900,/quant/stroke_width_min,129.77
 M PLUS Rounded 1c,wght@900,/quant/stroke_width_max,190.00
 Madimi One,wght@400,/quant/stroke_width_min,119.76
 Madimi One,wght@400,/quant/stroke_width_max,144.00
-Merge One,wght@400,/quant/stroke_width_min,67.86
-Merge One,wght@400,/quant/stroke_width_max,85.00
 Metal,wght@400,/quant/stroke_width_min,34.77
 Metal,wght@400,/quant/stroke_width_max,75.05
 Micro 5,wght@400,/quant/stroke_width_min,79.45
@@ -14494,32 +14480,20 @@ Big Shoulders,,/quant/opsz_min,24
 Big Shoulders,,/quant/opsz_max,48
 Big Shoulders Display,wght@900,/quant/opsz_min,24
 Big Shoulders Display,wght@900,/quant/opsz_max,48
-Big Shoulders Display SC,wght@900,/quant/opsz_min,24
-Big Shoulders Display SC,wght@900,/quant/opsz_max,48
 Big Shoulders Inline,,/quant/opsz_min,48
 Big Shoulders Inline,,/quant/opsz_max,300
 Big Shoulders Inline Display,wght@900,/quant/opsz_min,24
 Big Shoulders Inline Display,wght@900,/quant/opsz_max,48
-Big Shoulders Inline Display SC,wght@900,/quant/opsz_min,24
-Big Shoulders Inline Display SC,wght@900,/quant/opsz_max,48
 Big Shoulders Inline Text,wght@900,/quant/opsz_min,24
 Big Shoulders Inline Text,wght@900,/quant/opsz_max,48
-Big Shoulders Inline Text SC,wght@900,/quant/opsz_min,24
-Big Shoulders Inline Text SC,wght@900,/quant/opsz_max,48
 Big Shoulders Stencil,,/quant/opsz_min,24
 Big Shoulders Stencil,,/quant/opsz_max,48
 Big Shoulders Stencil Display,wght@900,/quant/opsz_min,24
 Big Shoulders Stencil Display,wght@900,/quant/opsz_max,48
-Big Shoulders Stencil Display SC,wght@900,/quant/opsz_min,24
-Big Shoulders Stencil Display SC,wght@900,/quant/opsz_max,48
 Big Shoulders Stencil Text,wght@900,/quant/opsz_min,24
 Big Shoulders Stencil Text,wght@900,/quant/opsz_max,48
-Big Shoulders Stencil Text SC,wght@900,/quant/opsz_min,24
-Big Shoulders Stencil Text SC,wght@900,/quant/opsz_max,48
 Big Shoulders Text,wght@900,/quant/opsz_min,24
 Big Shoulders Text,wght@900,/quant/opsz_max,48
-Big Shoulders Text SC,wght@900,/quant/opsz_min,24
-Big Shoulders Text SC,wght@900,/quant/opsz_max,48
 Bigelow Rules,,/quant/opsz_min,24
 Bigelow Rules,,/quant/opsz_max,48
 Bigshot One,,/quant/opsz_min,24
@@ -14998,8 +14972,6 @@ Dhyana,,/quant/opsz_min,5
 Dhyana,,/quant/opsz_max,24
 Didact Gothic,,/quant/opsz_min,5
 Didact Gothic,,/quant/opsz_max,24
-Digital Numbers,,/quant/opsz_min,24
-Digital Numbers,,/quant/opsz_max,48
 Diphylleia,,/quant/opsz_min,5
 Diphylleia,,/quant/opsz_max,24
 Diplomata,,/quant/opsz_min,24
@@ -15030,10 +15002,6 @@ Doto,"ROND,wght@100,100",/quant/opsz_min,24
 Doto,"ROND,wght@100,100",/quant/opsz_max,48
 Doto,"ROND,wght@100,900",/quant/opsz_min,24
 Doto,"ROND,wght@100,900",/quant/opsz_max,48
-Dotum,,/quant/opsz_min,5
-Dotum,,/quant/opsz_max,24
-DotumChe,,/quant/opsz_min,5
-DotumChe,,/quant/opsz_max,24
 Dr Sugiyama,,/quant/opsz_min,24
 Dr Sugiyama,,/quant/opsz_max,48
 Duru Sans,,/quant/opsz_min,5
@@ -15236,8 +15204,6 @@ Forum,,/quant/opsz_min,5
 Forum,,/quant/opsz_max,24
 Fragment Mono,,/quant/opsz_min,5
 Fragment Mono,,/quant/opsz_max,24
-Fragment Mono SC,,/quant/opsz_min,5
-Fragment Mono SC,,/quant/opsz_max,24
 Francois One,,/quant/opsz_min,24
 Francois One,,/quant/opsz_max,48
 Frank Ruhl Libre,wght@300,/quant/opsz_min,5
@@ -15446,16 +15412,8 @@ Gudea,,/quant/opsz_min,5
 Gudea,,/quant/opsz_max,24
 Gugi,,/quant/opsz_min,24
 Gugi,,/quant/opsz_max,48
-Gulim,,/quant/opsz_min,5
-Gulim,,/quant/opsz_max,24
-GulimChe,,/quant/opsz_min,24
-GulimChe,,/quant/opsz_max,48
 Gulzar,,/quant/opsz_min,5
 Gulzar,,/quant/opsz_max,24
-Gungsuh,,/quant/opsz_min,5
-Gungsuh,,/quant/opsz_max,24
-GungsuhChe,,/quant/opsz_min,5
-GungsuhChe,,/quant/opsz_max,24
 Gupter,,/quant/opsz_min,5
 Gupter,,/quant/opsz_max,24
 Gurajada,,/quant/opsz_min,24
@@ -15544,8 +15502,6 @@ Hepta Slab,wght@1,/quant/opsz_min,24
 Hepta Slab,wght@1,/quant/opsz_max,48
 Hepta Slab,wght@900,/quant/opsz_min,24
 Hepta Slab,wght@900,/quant/opsz_max,48
-Hermeneus One,,/quant/opsz_min,5
-Hermeneus One,,/quant/opsz_max,24
 Herr Von Muellerhoff,,/quant/opsz_min,24
 Herr Von Muellerhoff,,/quant/opsz_max,48
 Hi Melody,,/quant/opsz_min,24
@@ -15554,14 +15510,8 @@ Hina Mincho,,/quant/opsz_min,24
 Hina Mincho,,/quant/opsz_max,48
 Hind,,/quant/opsz_min,5
 Hind,,/quant/opsz_max,24
-Hind Colombo,,/quant/opsz_min,5
-Hind Colombo,,/quant/opsz_max,24
 Hind Guntur,,/quant/opsz_min,5
 Hind Guntur,,/quant/opsz_max,24
-Hind Jalandhar,,/quant/opsz_min,5
-Hind Jalandhar,,/quant/opsz_max,24
-Hind Kochi,,/quant/opsz_min,5
-Hind Kochi,,/quant/opsz_max,24
 Hind Madurai,,/quant/opsz_min,5
 Hind Madurai,,/quant/opsz_max,24
 Hind Mysuru,,/quant/opsz_min,5
@@ -17216,49 +17166,5 @@ Zalando Sans SemiExpanded,wght@200,/quant/opsz_min,24
 Zalando Sans SemiExpanded,wght@200,/quant/opsz_max,48
 Zalando Sans SemiExpanded,wght@900,/quant/opsz_min,24
 Zalando Sans SemiExpanded,wght@900,/quant/opsz_max,48
-aksarabaligalang,,/quant/opsz_min,5
-aksarabaligalang,,/quant/opsz_max,24
-amstelvaralpha,,/quant/opsz_min,48
-amstelvaralpha,,/quant/opsz_max,300
-asapvfbeta,"wdth,wght@80,129",/quant/opsz_min,24
-asapvfbeta,"wdth,wght@80,129",/quant/opsz_max,48
-decovaralpha,,/quant/opsz_min,24
-decovaralpha,,/quant/opsz_max,48
-hanna,,/quant/opsz_min,24
-hanna,,/quant/opsz_max,48
-hannari,,/quant/opsz_min,5
-hannari,,/quant/opsz_max,24
-intelmono2,,/quant/opsz_min,5
-intelmono2,,/quant/opsz_max,24
-jejugothic,,/quant/opsz_min,5
-jejugothic,,/quant/opsz_max,24
-jejuhallasan,,/quant/opsz_min,24
-jejuhallasan,,/quant/opsz_max,48
-jejumyeongjo,,/quant/opsz_min,5
-jejumyeongjo,,/quant/opsz_max,24
-khyay,,/quant/opsz_min,5
-khyay,,/quant/opsz_max,24
-kokoro,,/quant/opsz_min,5
-kokoro,,/quant/opsz_max,24
-kopubbatang,,/quant/opsz_min,5
-kopubbatang,,/quant/opsz_max,24
-laomuangdon,,/quant/opsz_min,24
-laomuangdon,,/quant/opsz_max,48
-laomuangkhong,,/quant/opsz_min,5
-laomuangkhong,,/quant/opsz_max,24
-laosanspro,,/quant/opsz_min,5
-laosanspro,,/quant/opsz_max,24
-lemonadavfbeta,wght@300,/quant/opsz_min,24
-lemonadavfbeta,wght@300,/quant/opsz_max,48
-lemonadavfbeta,wght@700,/quant/opsz_min,24
-lemonadavfbeta,wght@700,/quant/opsz_max,48
-lohitdevanagari,,/quant/opsz_min,5
-lohitdevanagari,,/quant/opsz_max,24
-markazitextvfbeta,wght@700,/quant/opsz_min,5
-markazitextvfbeta,wght@700,/quant/opsz_max,24
-mavenprovfbeta,wght@900,/quant/opsz_min,24
-mavenprovfbeta,wght@900,/quant/opsz_max,48
-rokkittvfbeta,wght@100,/quant/opsz_min,24
-rokkittvfbeta,wght@100,/quant/opsz_max,48
-rokkittvfbeta,wght@900,/quant/opsz_min,24
-rokkittvfbeta,wght@900,/quant/opsz_max,48
+Lohit Devanagari,,/quant/opsz_min,5
+Lohit Devanagari,,/quant/opsz_max,24


### PR DESCRIPTION
Remove the entries for fonts that have not been onboarded to sandbox yet.

Some of the entries appear to be phantom as they don't match any fonts in GitHub.  The rest will have their data copied into files {family,quant,skip}.csv in their font directory.  That will happen in a separate PR