### PR TITLE
Reference the rebuilt-from-.sfd sources for 42 SFD-modernized families

### DIFF
--- a/ofl/aguafinascript/METADATA.pb
+++ b/ofl/aguafinascript/METADATA.pb
@@ -5,7 +5,7 @@ category: "HANDWRITING"
 date_added: "2011-11-30"
 source {
   repository_url: "https://github.com/googlefonts/aguafinascript"
-  commit: "0cd0eecf14f34e946400cb472a9241616e4833ac"
+  commit: "723ec37b4f2657506b004f6db007c482f3a8af02"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/aguafinascript/upstream_info.md
+++ b/ofl/aguafinascript/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `723ec37b4f26`.
+
 ## Initial state
 
 Google Fonts shipped Aguafina Script (Regular) built from FontForge SFD sources at https://github.com/librefonts/aguafinascript. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/aladin/METADATA.pb
+++ b/ofl/aladin/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-11-30"
 source {
   repository_url: "https://github.com/googlefonts/aladin"
-  commit: "b9b4da7c18ceab08e86942dd5a0a181a6f2d1be3"
+  commit: "acd3f4b4e28fc7b6a6932a1ff3110c53d09bc987"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/aladin/upstream_info.md
+++ b/ofl/aladin/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `acd3f4b4e28f`.
+
 ## Initial state
 
 Google Fonts shipped Aladin (Regular) built from FontForge SFD sources at https://github.com/librefonts/aladin. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/allerta/METADATA.pb
+++ b/ofl/allerta/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2010-11-30"
 source {
   repository_url: "https://github.com/googlefonts/allerta"
-  commit: "2efd2499258022f0a5b1887da95ecfc62a5793cd"
+  commit: "bdd9557493a2cdd003d2dcbc9a37d47868ec3606"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/allerta/upstream_info.md
+++ b/ofl/allerta/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `bdd9557493a2`.
+
 ## Initial state
 
 Google Fonts shipped Allerta (Regular) built from FontForge SFD sources at https://github.com/librefonts/allerta. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/balthazar/METADATA.pb
+++ b/ofl/balthazar/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2011-12-13"
 source {
   repository_url: "https://github.com/googlefonts/balthazar"
-  commit: "40ec71e48349bc565c42eb3c750b50a5d8d19087"
+  commit: "3aa1b5a856e450e64d0f9c088bc1d9dd40c74a50"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/balthazar/upstream_info.md
+++ b/ofl/balthazar/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `3aa1b5a856e4`.
+
 ## Initial state
 
 Google Fonts shipped Balthazar (Regular) built from FontForge SFD sources at https://github.com/librefonts/balthazar. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/bubblegumsans/METADATA.pb
+++ b/ofl/bubblegumsans/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-11-23"
 source {
   repository_url: "https://github.com/googlefonts/bubblegumsans"
-  commit: "ad8f70f6b46d0c3e66f2e38f943435eb2b6bb625"
+  commit: "a2d0062318639fe63f2a8ffd78fec793ee8e6248"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/bubblegumsans/upstream_info.md
+++ b/ofl/bubblegumsans/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `a2d006231863`.
+
 ## Initial state
 
 Google Fonts shipped Bubblegum Sans (Regular) built from FontForge SFD sources at https://github.com/librefonts/bubblegumsans. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/cagliostro/METADATA.pb
+++ b/ofl/cagliostro/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2011-11-30"
 source {
   repository_url: "https://github.com/googlefonts/cagliostro"
-  commit: "871f5caf05c9d0a09e8eb11f9c43e27bb8679673"
+  commit: "b824b7c2a0aab695ab27f28fb54a1b6c42fd36ac"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cagliostro/upstream_info.md
+++ b/ofl/cagliostro/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `b824b7c2a0aa`.
+
 ## Initial state
 
 Google Fonts shipped Cagliostro (Regular) built from FontForge SFD sources at https://github.com/librefonts/cagliostro. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/carterone/METADATA.pb
+++ b/ofl/carterone/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-05-04"
 source {
   repository_url: "https://github.com/googlefonts/carterone"
-  commit: "dfb0d97f8eb2fa66680b6098cdde15277b069b2b"
+  commit: "7055fdb03b89cff87481cd41dfee324ab89b5a7d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/carterone/upstream_info.md
+++ b/ofl/carterone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `7055fdb03b89`.
+
 ## Initial state
 
 Google Fonts shipped Carter One (Regular) built from FontForge SFD sources at https://github.com/librefonts/carterone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/cevicheone/METADATA.pb
+++ b/ofl/cevicheone/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-12-07"
 source {
   repository_url: "https://github.com/googlefonts/cevicheone"
-  commit: "1af833a0fd47b174386916453a54e6bf1f6d5a34"
+  commit: "72a6df0567207a62272bd172230a8a089197036b"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cevicheone/upstream_info.md
+++ b/ofl/cevicheone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `72a6df056720`.
+
 ## Initial state
 
 Google Fonts shipped Ceviche One (Regular) built from FontForge SFD sources at https://github.com/librefonts/cevicheone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/chango/METADATA.pb
+++ b/ofl/chango/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-12-13"
 source {
   repository_url: "https://github.com/googlefonts/chango"
-  commit: "fed28f46958e46610efc52780476adcfc91745e6"
+  commit: "cc5a73fc2986d109343d4a42aacaf5428274ad12"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/chango/upstream_info.md
+++ b/ofl/chango/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `cc5a73fc2986`.
+
 ## Initial state
 
 The family shipped from a FontForge project (`src/Chango-Regular-TTF.sfd`) with no gftools-builder configuration. METADATA.pb pointed at the librefonts repository but recorded no config_yaml, so the family could not be rebuilt with the current pipeline.

--- a/ofl/chelaone/METADATA.pb
+++ b/ofl/chelaone/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2012-10-05"
 source {
   repository_url: "https://github.com/googlefonts/chelaone"
-  commit: "cb7da0a381984ec348a9c88e2095f9592149c838"
+  commit: "b0f6d8fe1f2023702a20caeb83f74e2b5245749c"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/chelaone/upstream_info.md
+++ b/ofl/chelaone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `b0f6d8fe1f20`.
+
 ## Initial state
 
 Google Fonts shipped Chela One (Regular) built from FontForge SFD sources at https://github.com/librefonts/chelaone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/cherryswash/METADATA.pb
+++ b/ofl/cherryswash/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2012-10-05"
 source {
   repository_url: "https://github.com/googlefonts/cherryswash"
-  commit: "f1c0f2dbc3f64ef4f85e54544626e6d629599e4c"
+  commit: "d676530fe73151137f5e69519a1ee4beb0c12c49"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cherryswash/upstream_info.md
+++ b/ofl/cherryswash/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `d676530fe731`.
+
 ## Initial state
 
 Google Fonts shipped Cherry Swash (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/cherryswash. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/chicle/METADATA.pb
+++ b/ofl/chicle/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-11-30"
 source {
   repository_url: "https://github.com/googlefonts/chicle"
-  commit: "f68c0fa9e45e089b7cb3fb7bbef873b9e7bf8123"
+  commit: "07b8112c518449245b5c2c195c31f73cd993ab64"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/chicle/upstream_info.md
+++ b/ofl/chicle/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `07b8112c5184`.
+
 ## Initial state
 
 The family shipped from FontForge `.sfd` sources with no gftools-builder configuration. METADATA.pb pointed at the librefonts mirror with an onboarding commit but no config_yaml, so the family could not be rebuilt with the current pipeline.

--- a/ofl/condiment/METADATA.pb
+++ b/ofl/condiment/METADATA.pb
@@ -5,7 +5,7 @@ category: "HANDWRITING"
 date_added: "2012-01-25"
 source {
   repository_url: "https://github.com/googlefonts/condiment"
-  commit: "a89340dd6409f34edd3d00dba5326e870b910f2a"
+  commit: "e9c65b8fd13846909ca137e6c36112ba2d959807"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/condiment/upstream_info.md
+++ b/ofl/condiment/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `e9c65b8fd138`.
+
 ## Initial state
 
 Google Fonts shipped Condiment (Regular) built from FontForge SFD sources at https://github.com/librefonts/condiment. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/contrailone/METADATA.pb
+++ b/ofl/contrailone/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-10-26"
 source {
   repository_url: "https://github.com/googlefonts/contrailone"
-  commit: "755f2a5959072b2ce7e09b555cc55917bf3c7ce0"
+  commit: "7a15438313700f49eaabd97d35a71d6987c8f6d6"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/contrailone/upstream_info.md
+++ b/ofl/contrailone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `7a1543831370`.
+
 ## Initial state
 
 Google Fonts shipped Contrail One (Regular) built from FontForge SFD sources at https://github.com/librefonts/contrailone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/convergence/METADATA.pb
+++ b/ofl/convergence/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2011-11-09"
 source {
   repository_url: "https://github.com/googlefonts/convergence"
-  commit: "0f57768c9ddc32b357bf4d32897b8ea4e846d71e"
+  commit: "343573d0ed24387f782b02c8536316f243ac03d2"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/convergence/upstream_info.md
+++ b/ofl/convergence/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `343573d0ed24`.
+
 ## Initial state
 
 Google Fonts shipped Convergence (Regular) built from FontForge SFD sources at https://github.com/librefonts/convergence. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/cookie/METADATA.pb
+++ b/ofl/cookie/METADATA.pb
@@ -5,7 +5,7 @@ category: "HANDWRITING"
 date_added: "2011-10-12"
 source {
   repository_url: "https://github.com/googlefonts/cookie"
-  commit: "a86099c7b0fb4176bea1657e2b9e66ac3ab85513"
+  commit: "04beabaf5fe9a6c83b63514600b85190ffac4401"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cookie/upstream_info.md
+++ b/ofl/cookie/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `04beabaf5fe9`.
+
 ## Initial state
 
 Google Fonts shipped Cookie (Regular) built from FontForge SFD sources at https://github.com/librefonts/cookie. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/croissantone/METADATA.pb
+++ b/ofl/croissantone/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2012-11-12"
 source {
   repository_url: "https://github.com/googlefonts/croissantone"
-  commit: "0747cf401c74b546f997a820cb036a39513ba09c"
+  commit: "62d7d39fdbd2c94bc1ab7593d4c984ce327146eb"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/croissantone/upstream_info.md
+++ b/ofl/croissantone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `62d7d39fdbd2`.
+
 ## Initial state
 
 Google Fonts shipped Croissant One (Regular) built from FontForge SFD sources at https://github.com/librefonts/croissantone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/delius/METADATA.pb
+++ b/ofl/delius/METADATA.pb
@@ -5,7 +5,7 @@ category: "HANDWRITING"
 date_added: "2011-07-27"
 source {
   repository_url: "https://github.com/googlefonts/delius"
-  commit: "99e93e1a8034bf205d3978eaa98b8254a8faff3e"
+  commit: "ed462df7139cca792e2a3df0111c5f43dd2bafce"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/delius/upstream_info.md
+++ b/ofl/delius/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `ed462df7139c`.
+
 ## Initial state
 
 Google Fonts shipped Delius (Regular) built from FontForge SFD sources at https://github.com/librefonts/delius. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/deliusswashcaps/METADATA.pb
+++ b/ofl/deliusswashcaps/METADATA.pb
@@ -5,7 +5,7 @@ category: "HANDWRITING"
 date_added: "2011-08-03"
 source {
   repository_url: "https://github.com/googlefonts/deliusswashcaps"
-  commit: "2bcc0f94b70fdc0c94bc30d803f8c646224c1eab"
+  commit: "d5570948565c7ed27cfeaaf163cb3835f6742445"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/deliusswashcaps/upstream_info.md
+++ b/ofl/deliusswashcaps/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `d5570948565c`.
+
 ## Initial state
 
 The family shipped a single static TTF (Delius Swash Caps Regular) whose only upstream source was a FontForge `.sfd` file (`src/DeliusSwashCaps-Regular-TTF.sfd`). METADATA.pb pointed at the dormant librefonts repository and carried no `config_yaml`, so the family could not be rebuilt with the current Google Fonts tooling.

--- a/ofl/deliusunicase/METADATA.pb
+++ b/ofl/deliusunicase/METADATA.pb
@@ -5,7 +5,7 @@ category: "HANDWRITING"
 date_added: "2011-10-12"
 source {
   repository_url: "https://github.com/googlefonts/deliusunicase"
-  commit: "2440c19ebfa6d4a898d9b8d439e9888e7d2fd71f"
+  commit: "b4e89d5702b05d66107280bc250f2502ac97b947"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/deliusunicase/upstream_info.md
+++ b/ofl/deliusunicase/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `b4e89d5702b0`.
+
 ## Initial state
 
 Google Fonts shipped Delius Unicase (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/deliusunicase. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/devonshire/METADATA.pb
+++ b/ofl/devonshire/METADATA.pb
@@ -5,7 +5,7 @@ category: "HANDWRITING"
 date_added: "2011-11-16"
 source {
   repository_url: "https://github.com/googlefonts/devonshire"
-  commit: "7a5ccf2a745c1b08c55181ce87fb522dedcbe631"
+  commit: "b13788b9f4b6975f7286e3fa0784f36944a3c3b0"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/devonshire/upstream_info.md
+++ b/ofl/devonshire/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `b13788b9f4b6`.
+
 ## Initial state
 
 Google Fonts shipped Devonshire (Regular) built from FontForge SFD sources at https://github.com/librefonts/devonshire. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/economica/METADATA.pb
+++ b/ofl/economica/METADATA.pb
@@ -46,7 +46,7 @@ stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/economica"
-  commit: "03c3c4473a043aa560421b3d54d67f66d4a98a31"
+  commit: "97d9d775227f19b63adc1b073ecc073f43cebefc"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/economica/upstream_info.md
+++ b/ofl/economica/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `97d9d775227f`.
+
 ## Initial state
 
 Google Fonts shipped Economica (Regular, Italic, Bold, Bold Italic) built from FontForge SFD sources at https://github.com/librefonts/economica. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/emblemaone/METADATA.pb
+++ b/ofl/emblemaone/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/emblemaone"
-  commit: "79205499f351bf5c95c8dcf6121180c18789f62f"
+  commit: "70b9d48e6e1d27d74cc177bf7f12f958fe13dd28"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/emblemaone/upstream_info.md
+++ b/ofl/emblemaone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `70b9d48e6e1d`.
+
 ## Initial state
 
 Google Fonts shipped Emblema One (Regular) built from FontForge SFD sources at https://github.com/librefonts/emblemaone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/ericaone/METADATA.pb
+++ b/ofl/ericaone/METADATA.pb
@@ -19,7 +19,7 @@ stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/ericaone"
-  commit: "34ddbe60f433f69a959c8200e97b8b9be4499900"
+  commit: "7b144141a0c64f8345146826f0132ea2f15a8866"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/ericaone/upstream_info.md
+++ b/ofl/ericaone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `7b144141a0c6`.
+
 ## Initial state
 
 Google Fonts shipped Erica One (Regular) built from FontForge SFD sources at https://github.com/librefonts/ericaone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/esteban/METADATA.pb
+++ b/ofl/esteban/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/esteban"
-  commit: "6e017f92549326738359a4c43c5ac7302ca773f7"
+  commit: "c268b4f87279884fe0765e8d40eb65e0d17621ef"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/esteban/upstream_info.md
+++ b/ofl/esteban/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `c268b4f87279`.
+
 ## Initial state
 
 Google Fonts shipped Esteban (Regular) built from FontForge SFD sources at https://github.com/librefonts/esteban. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/ewert/METADATA.pb
+++ b/ofl/ewert/METADATA.pb
@@ -19,7 +19,7 @@ stroke: "SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/ewert"
-  commit: "1fdc40c5b4f330020515d69ca4e3d1fd18e1df64"
+  commit: "2923c2b66dd871ce269cccaba064c6621d1dec0e"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/ewert/upstream_info.md
+++ b/ofl/ewert/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `2923c2b66dd8`.
+
 ## Initial state
 
 Google Fonts shipped Ewert (Regular) built from FontForge SFD sources at https://github.com/librefonts/ewert. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/fenix/METADATA.pb
+++ b/ofl/fenix/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/fenix"
-  commit: "cfae6dd0422933ef47db060c6710166fb5ed30d1"
+  commit: "4b215f7cc3c4a4be844dcbcb504d271c8a5086a1"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/fenix/upstream_info.md
+++ b/ofl/fenix/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `4b215f7cc3c4`.
+
 ## Initial state
 
 Google Fonts shipped Fenix (Regular) built from FontForge SFD sources at https://github.com/librefonts/fenix. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/fresca/METADATA.pb
+++ b/ofl/fresca/METADATA.pb
@@ -19,7 +19,7 @@ stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/fresca"
-  commit: "6f0f0d00ca1fc37032e87cb12c365a1a31bea443"
+  commit: "c21be75086b74f71a72e992977f05243c9c99ef3"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/fresca/upstream_info.md
+++ b/ofl/fresca/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `c21be75086b7`.
+
 ## Initial state
 
 Google Fonts shipped Fresca (Regular) built from FontForge SFD sources at https://github.com/librefonts/fresca. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/fugazone/METADATA.pb
+++ b/ofl/fugazone/METADATA.pb
@@ -19,7 +19,7 @@ stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/fugazone"
-  commit: "cc513bad4e98bf35e593423ddcbe6a71ec532143"
+  commit: "a569b175e4b89e8915708a55c2796debdfe46aeb"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/fugazone/upstream_info.md
+++ b/ofl/fugazone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `a569b175e4b8`.
+
 ## Initial state
 
 Google Fonts shipped Fugaz One (Regular) built from FontForge SFD sources at https://github.com/librefonts/fugazone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/galdeano/METADATA.pb
+++ b/ofl/galdeano/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/galdeano"
-  commit: "41268aaf05c1ab2716d0b4a8114aa6b7beff8e31"
+  commit: "79cf98b98a74be1aac08d719abd22e7986ee9949"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/galdeano/upstream_info.md
+++ b/ofl/galdeano/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `79cf98b98a74`.
+
 ## Initial state
 
 Google Fonts shipped Galdeano (Regular) built from FontForge SFD sources at https://github.com/librefonts/galdeano. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/geostar/METADATA.pb
+++ b/ofl/geostar/METADATA.pb
@@ -18,7 +18,7 @@ stroke: "SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/geostar"
-  commit: "cd70b3170a6db347032f02d4f773e2f0ecff25a3"
+  commit: "9204e39b28291c336ee12fd2e3235e3a9436ebed"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/geostar/upstream_info.md
+++ b/ofl/geostar/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `9204e39b2829`.
+
 ## Initial state
 
 Google Fonts shipped Geostar (Regular) built from FontForge SFD sources at https://github.com/librefonts/geostar (`src/Geostar-Regular-TTF.sfd`). METADATA.pb carried a bare source block with the upstream repository URL and onboarding commit but no config, and there was no source that builds with fontc.

--- a/ofl/geostarfill/METADATA.pb
+++ b/ofl/geostarfill/METADATA.pb
@@ -18,7 +18,7 @@ stroke: "SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/geostarfill"
-  commit: "61aec9b9308292407c258a90b15a66b0449135bc"
+  commit: "4bee66afd797da22ee772995c2344fce81817c6e"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/geostarfill/upstream_info.md
+++ b/ofl/geostarfill/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `4bee66afd797`.
+
 ## Initial state
 
 Google Fonts shipped Geostar Fill (Regular) built from FontForge SFD sources at https://github.com/librefonts/geostarfill. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/germaniaone/METADATA.pb
+++ b/ofl/germaniaone/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/germaniaone"
-  commit: "8c373b1705299e083f48de2a4c5a818b35c83ad4"
+  commit: "fea6803846d3270d2fde56a8678004cf67841852"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/germaniaone/upstream_info.md
+++ b/ofl/germaniaone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `fea6803846d3`.
+
 ## Initial state
 
 The `source { }` block pointed at the dormant librefonts repository and recorded only a repository URL and onboarding commit. The upstream sources were FontForge `.sfd` files (`src/GermaniaOne-Regular-TTF.sfd`), which the current Rust build pipeline cannot consume, and no build configuration was present.

--- a/ofl/glassantiqua/METADATA.pb
+++ b/ofl/glassantiqua/METADATA.pb
@@ -19,7 +19,7 @@ stroke: "SERIF"
 classifications: "HANDWRITING"
 source {
   repository_url: "https://github.com/googlefonts/glassantiqua"
-  commit: "64763eadb6bf4a38f7fe638b06683ef7cea15266"
+  commit: "b1c269f4671ac3926d35635dd6d87db0945dd9d8"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/glassantiqua/upstream_info.md
+++ b/ofl/glassantiqua/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `b1c269f4671a`.
+
 ## Initial state
 
 The upstream repository shipped only FontForge `.sfd` sources and had no gftools-builder configuration. METADATA.pb pointed at the librefonts mirror with an onboarding commit but no `config_yaml`, so the family could not be rebuilt with the current Google Fonts pipeline.

--- a/ofl/goblinone/METADATA.pb
+++ b/ofl/goblinone/METADATA.pb
@@ -18,7 +18,7 @@ stroke: "SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/goblinone"
-  commit: "82b0d4b4f5e17c953c5a6e42e73d2e93ea2ea9e2"
+  commit: "7c9287369c25fb772486d41b574a4dc0ae6340f5"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/goblinone/upstream_info.md
+++ b/ofl/goblinone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `7c9287369c25`.
+
 ## Initial state
 
 Google Fonts shipped Goblin One (Regular) built from FontForge SFD sources at https://github.com/librefonts/goblinone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/gravitasone/METADATA.pb
+++ b/ofl/gravitasone/METADATA.pb
@@ -18,7 +18,7 @@ stroke: "SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/gravitasone"
-  commit: "feede2e8781269a901f8bddb91f05965d294e5a9"
+  commit: "8eb45dc3e5bdf6cbf377f906554ea01f0e54f92f"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/gravitasone/upstream_info.md
+++ b/ofl/gravitasone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `8eb45dc3e5bd`.
+
 ## Initial state
 
 Google Fonts shipped Gravitas One (Regular) built from FontForge SFD sources at https://github.com/librefonts/gravitasone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/inika/METADATA.pb
+++ b/ofl/inika/METADATA.pb
@@ -26,7 +26,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/inika"
-  commit: "07bb78b80a644c3e4979fbd4b6a6a6548d5a2934"
+  commit: "445fa596f166fc6c91c293eccd75b588d9b1fef4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/inika/upstream_info.md
+++ b/ofl/inika/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `445fa596f166`.
+
 ## Initial state
 
 Google Fonts shipped Inika (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/inika. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/jockeyone/METADATA.pb
+++ b/ofl/jockeyone/METADATA.pb
@@ -19,7 +19,7 @@ stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/jockeyone"
-  commit: "4f6087374d94a145a80a2b297f27db8b52e52dd9"
+  commit: "328c36706235aca94efbd2c56d2ee7b69d494bb0"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/jockeyone/upstream_info.md
+++ b/ofl/jockeyone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `328c36706235`.
+
 ## Initial state
 
 Google Fonts shipped Jockey One (Regular) built from FontForge SFD sources at https://github.com/librefonts/jockeyone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/justmeagaindownhere/METADATA.pb
+++ b/ofl/justmeagaindownhere/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/justmeagaindownhere"
-  commit: "23514049cb37c16431521835a69aa7cfe5d9b709"
+  commit: "bc6529922d3d9ced792726d687ed7c613a25c6f3"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/justmeagaindownhere/upstream_info.md
+++ b/ofl/justmeagaindownhere/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `bc6529922d3d`.
+
 ## Initial state
 
 Google Fonts shipped Just Me Again Down Here (Regular) built from FontForge SFD sources at https://github.com/librefonts/justmeagaindownhere. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/lusitana/METADATA.pb
+++ b/ofl/lusitana/METADATA.pb
@@ -27,7 +27,7 @@ subsets: "latin-ext"
 
 source {
   repository_url: "https://github.com/googlefonts/lusitana"
-  commit: "393d85168ac2026bfc47c6c15bcb3868e279d92b"
+  commit: "cae968a717a2e73cdf7b76fac5c339d5e45cbf93"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/lusitana/upstream_info.md
+++ b/ofl/lusitana/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `cae968a717a2`.
+
 ## Initial state
 
 Google Fonts shipped Lusitana (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/lusitana. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/macondoswashcaps/METADATA.pb
+++ b/ofl/macondoswashcaps/METADATA.pb
@@ -19,7 +19,7 @@ classifications: "DISPLAY"
 classifications: "HANDWRITING"
 source {
   repository_url: "https://github.com/googlefonts/macondoswashcaps"
-  commit: "bd29bdafaab2e21ae4bdcc16106b15f2365bca61"
+  commit: "6a61c5175a68a2449241a70bc7dbcbaee45f2a8a"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/macondoswashcaps/upstream_info.md
+++ b/ofl/macondoswashcaps/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `6a61c5175a68`.
+
 ## Initial state
 
 Google Fonts shipped Macondo Swash Caps (Regular) built from FontForge SFD sources at https://github.com/librefonts/macondoswashcaps. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/montaga/METADATA.pb
+++ b/ofl/montaga/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/montaga"
-  commit: "c01e6e195c2d67a0b9d5c3091f3c436991cafd90"
+  commit: "90712149c2d25ebaff039e96e375b7bb2bc2f7f7"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/montaga/upstream_info.md
+++ b/ofl/montaga/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied vertical metrics, GDEF classes and other values out of the shipped binary). The sources were regenerated purely from the original FontForge `.sfd`, byte-identical to the repository's own history, with babelfont `c368660` (gftools-builder3 `17b215c5` + fontc `3518040e`, 0.6.0); diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. METADATA.pb now references the rebuild commit `90712149c2d2`.
+
 ## Initial state
 
 Google Fonts shipped Montaga (Regular) built from FontForge SFD sources at https://github.com/librefonts/montaga. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.


### PR DESCRIPTION
The .glyphs sources these 42 families' METADATA.pb entries pointed at were back-fitted: post-conversion scripts copied several values (vertical metrics, GDEF classes, vendor ID, ...) out of the shipped binaries. Each upstream repository has since merged a rebuild that regenerates the sources purely from the original FontForge .sfd, byte-identical to that repository's own history, with nothing copied from the shipped binaries (see each repo's "Rebuild the sources from the original .sfd" pull request, all merged).

This PR updates, one commit per family, the METADATA.pb source commit to the merged rebuild commit and adds a dated note to each upstream_info.md. No binaries change and no other METADATA.pb fields change (repository_url, branch and config_yaml were already correct).

Verification, per family: deterministic conversion; builds with gftools-builder3 17b215c5 + fontc 3518040e (0.6.0); babelfont c368660; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the binaries currently shipped by Google Fonts, on every style.

Families: Aguafina Script, Aladin, Allerta, Balthazar, Bubblegum Sans, Cagliostro, Carter One, Ceviche One, Chango, Chela One, Cherry Swash, Chicle, Condiment, Contrail One, Convergence, Cookie, Croissant One, Delius, Delius Swash Caps, Delius Unicase, Devonshire, Economica, Emblema One, Erica One, Esteban, Ewert, Fenix, Fresca, Fugaz One, Galdeano, Geostar, Geostar Fill, Germania One, Glass Antiqua, Goblin One, Gravitas One, Inika, Jockey One, Just Me Again Down Here, Lusitana, Macondo Swash Caps, Montaga.