### PR TITLE
Reference the reconstructed .glyphs sources for 31 SFD-modernized families

### DIFF
--- a/ofl/amarante/METADATA.pb
+++ b/ofl/amarante/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2012-07-10"
 source {
   repository_url: "https://github.com/googlefonts/amarante"
-  commit: "46979134e6b96a867f1441e91d06bbecc3eba8d2"
+  commit: "0eda1ae2955c3b3a56da48abf1517afac0e8391f"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/amarante/upstream_info.md
+++ b/ofl/amarante/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `0eda1ae2955c`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Amarante (Regular) built from FontForge SFD sources at https://github.com/librefonts/amarante. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/anticdidone/METADATA.pb
+++ b/ofl/anticdidone/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2012-03-14"
 source {
   repository_url: "https://github.com/googlefonts/anticdidone"
-  commit: "a69ba5c398a94f60b93bf779c1d9c2dc27975258"
+  commit: "078e3e73a45ea71a9b0b1b67e7df91ce0e0b2f9b"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/anticdidone/upstream_info.md
+++ b/ofl/anticdidone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `078e3e73a45e`; diffenator3 1.1.4 reports the rendering pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified), with residual antialiasing coverage-rounding noise of at most 0/255 gray levels, stated in the conversion commit message.
+
 ## Initial state
 
 Google Fonts shipped Antic Didone (Regular) built from FontForge SFD sources at https://github.com/librefonts/anticdidone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/anticslab/METADATA.pb
+++ b/ofl/anticslab/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2012-03-14"
 source {
   repository_url: "https://github.com/googlefonts/anticslab"
-  commit: "94821708c44ba2ac3c9bcd011141dbb888b0b26d"
+  commit: "53727d3f8f4e4ab3bf0f28aace4ecf7c8eecfb34"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/anticslab/upstream_info.md
+++ b/ofl/anticslab/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `53727d3f8f4e`; diffenator3 1.1.4 reports the rendering pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified), with residual antialiasing coverage-rounding noise of at most 0/255 gray levels, stated in the conversion commit message.
+
 ## Initial state
 
 Google Fonts shipped Antic Slab (Regular) built from FontForge SFD sources at https://github.com/librefonts/anticslab. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/averagesans/METADATA.pb
+++ b/ofl/averagesans/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2012-10-26"
 source {
   repository_url: "https://github.com/googlefonts/averagesans"
-  commit: "25392b948053363b34308e1f95e29c5401997b00"
+  commit: "1b1058cd63195d26fe2ccc70a7662d90220373ac"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/averagesans/upstream_info.md
+++ b/ofl/averagesans/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `1b1058cd6319`; diffenator3 1.1.4 reports the rendering pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified), with residual antialiasing coverage-rounding noise of at most 1/255 gray levels, stated in the conversion commit message.
+
 ## Initial state
 
 Google Fonts shipped Average Sans (Regular) built from FontForge SFD sources at https://github.com/librefonts/averagesans. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/benchnine/METADATA.pb
+++ b/ofl/benchnine/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2012-09-24"
 source {
   repository_url: "https://github.com/googlefonts/benchnine"
-  commit: "dd9d771443fa68ea48ef0819d28fc64e0fded42f"
+  commit: "c8159512c8ad0159a551fd074c00b60c044c3748"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/benchnine/upstream_info.md
+++ b/ofl/benchnine/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `c8159512c8ad`; diffenator3 1.1.4 reports the rendering pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified), with residual antialiasing coverage-rounding noise of at most 0/255 gray levels, stated in the conversion commit message.
+
 ## Initial state
 
 Google Fonts shipped BenchNine (Light, Regular, Bold) built from FontForge SFD sources at https://github.com/librefonts/benchnine. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/bigshotone/METADATA.pb
+++ b/ofl/bigshotone/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-05-04"
 source {
   repository_url: "https://github.com/googlefonts/bigshotone"
-  commit: "354d1d8880d46e04cf3b57980e6d56d1a5e1400d"
+  commit: "f29b15c2cb862fd0f2cadbe1929dc0786ac87225"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/bigshotone/upstream_info.md
+++ b/ofl/bigshotone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `f29b15c2cb86`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Bigshot One (Regular) built from FontForge SFD sources at https://github.com/librefonts/bigshotone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/bilboswashcaps/METADATA.pb
+++ b/ofl/bilboswashcaps/METADATA.pb
@@ -5,7 +5,7 @@ category: "HANDWRITING"
 date_added: "2011-12-13"
 source {
   repository_url: "https://github.com/googlefonts/bilboswashcaps"
-  commit: "ee601350e786d859e659a17d05934e1a62cb4785"
+  commit: "43f17107cce1c680ccf6d8e959f26dc4ac7d1823"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/bilboswashcaps/upstream_info.md
+++ b/ofl/bilboswashcaps/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `43f17107cce1`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 The family shipped from a FontForge `.sfd` source (`src/BilboSwashCaps-Regular-TTF.sfd`) with no config.yaml and no build pipeline compatible with the current Google Fonts tooling. METADATA.pb recorded only the repository URL and onboarding commit.

--- a/ofl/bowlbyone/METADATA.pb
+++ b/ofl/bowlbyone/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-07-13"
 source {
   repository_url: "https://github.com/googlefonts/bowlbyone"
-  commit: "d469e83e10f7c1e7294e5586da5da1d9725f417c"
+  commit: "8e8163e23a6573833332ef4f10b2c48d78be2c7b"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/bowlbyone/upstream_info.md
+++ b/ofl/bowlbyone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `8e8163e23a65`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Bowlby One (Regular) built from FontForge SFD sources at https://github.com/librefonts/bowlbyone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/bowlbyonesc/METADATA.pb
+++ b/ofl/bowlbyonesc/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-07-06"
 source {
   repository_url: "https://github.com/googlefonts/bowlbyonesc"
-  commit: "7fc977deba6f6a55ede3fd17ebfc9d299afdfd83"
+  commit: "7cdb4c893d50681fe94144c3de09a285f01f8845"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/bowlbyonesc/upstream_info.md
+++ b/ofl/bowlbyonesc/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `7cdb4c893d50`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Bowlby One SC (Regular) built from FontForge SFD sources at https://github.com/librefonts/bowlbyonesc. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/butcherman/METADATA.pb
+++ b/ofl/butcherman/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-12-19"
 source {
   repository_url: "https://github.com/googlefonts/butcherman"
-  commit: "f4f7f3e2cd993e09bb72e154c5fd34f3dc99d3c0"
+  commit: "6101b20d2e2ba2773da7d92f0c92c1ce707b6287"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/butcherman/upstream_info.md
+++ b/ofl/butcherman/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `6101b20d2e2b`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Butcherman (Regular) built from FontForge SFD sources at https://github.com/librefonts/butcherman. The shipped binary is pre-OpenType: it has no GSUB, no GPOS and no legacy kern table. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/cantataone/METADATA.pb
+++ b/ofl/cantataone/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/cantataone"
-  commit: "12fb64c8cad39f95d18ea97713683cdebe08693a"
+  commit: "d5dba9030c571d45e9e9e6971ffa20d4336529ff"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cantataone/upstream_info.md
+++ b/ofl/cantataone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `d5dba9030c57`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 The family shipped from the librefonts `cantataone` repository, whose only editable sources were FontForge `.sfd` files (`src/CantataOne-Regular-TTF.sfd`). METADATA.pb carried a bare `source { }` block with the repository URL and onboarding commit but no build configuration, and the sources could not be built by the current Rust toolchain.

--- a/ofl/copse/METADATA.pb
+++ b/ofl/copse/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2010-12-15"
 source {
   repository_url: "https://github.com/googlefonts/copse"
-  commit: "3022d037cd17945ad478f853ce401fc51185f8d0"
+  commit: "53eac2d38908f158fbbf0cc1863240a5fc8bc7a4"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/copse/upstream_info.md
+++ b/ofl/copse/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `53eac2d38908`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Copse (Regular) built from FontForge SFD sources at https://github.com/librefonts/copse. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/courgette/METADATA.pb
+++ b/ofl/courgette/METADATA.pb
@@ -5,7 +5,7 @@ category: "HANDWRITING"
 date_added: "2012-07-10"
 source {
   repository_url: "https://github.com/googlefonts/courgette"
-  commit: "dcdd6f44e43530c55ae4d154b23b8f2fbb0e137f"
+  commit: "c7884413c3ff6401df0abd685b20e7d419db2684"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/courgette/upstream_info.md
+++ b/ofl/courgette/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `c7884413c3ff`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Courgette (Regular) built from FontForge SFD sources at https://github.com/librefonts/courgette. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/coveredbyyourgrace/METADATA.pb
+++ b/ofl/coveredbyyourgrace/METADATA.pb
@@ -5,7 +5,7 @@ category: "HANDWRITING"
 date_added: "2010-12-07"
 source {
   repository_url: "https://github.com/googlefonts/coveredbyyourgrace"
-  commit: "705a49490c07c9e76f1ba8dc2d4f56d1b7bbf42c"
+  commit: "ec5beabb11b92f63abd716bac8d181b763bc366e"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/coveredbyyourgrace/upstream_info.md
+++ b/ofl/coveredbyyourgrace/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `ec5beabb11b9`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style. The commits above the referenced commit reintroduce the author's post-release design work (the repository `.sfd` was saved after the shipped binary was generated) and await onboarder review as a future design update; METADATA.pb deliberately references the correspondence commit, not the branch tip.
+
 ## Initial state
 
 Google Fonts shipped Covered By Your Grace (Regular) built from FontForge SFD sources at https://github.com/librefonts/coveredbyyourgrace. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/creteround/METADATA.pb
+++ b/ofl/creteround/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2011-12-19"
 source {
   repository_url: "https://github.com/googlefonts/creteround"
-  commit: "65f7a13699e262832f4fa0cd2a61908da6da811d"
+  commit: "64e1c753a1216a4f5b71198ec15fde39a9016af5"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/creteround/upstream_info.md
+++ b/ofl/creteround/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `64e1c753a121`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Crete Round (Regular and Italic) built from FontForge SFD sources at https://github.com/librefonts/creteround. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/doppioone/METADATA.pb
+++ b/ofl/doppioone/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2012-02-22"
 source {
   repository_url: "https://github.com/googlefonts/doppioone"
-  commit: "34f9329a27b33de4a879733d65daaee5e7eb61d5"
+  commit: "f2fcd625359c4aa7d2b76aa5ab99b760707f6669"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/doppioone/upstream_info.md
+++ b/ofl/doppioone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `f2fcd625359c`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Doppio One (Regular) built from FontForge SFD sources at https://github.com/librefonts/doppioone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/drsugiyama/METADATA.pb
+++ b/ofl/drsugiyama/METADATA.pb
@@ -19,7 +19,7 @@ classifications: "DISPLAY"
 classifications: "HANDWRITING"
 source {
   repository_url: "https://github.com/googlefonts/drsugiyama"
-  commit: "67e9b2e25cd7b9bde6ea5d5001fce5da54a9e877"
+  commit: "277b8789c528b1d6deb4d4e8a89646f33eb2c0bf"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/drsugiyama/upstream_info.md
+++ b/ofl/drsugiyama/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `277b8789c528`; diffenator3 1.1.4 reports the rendering pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified), with residual antialiasing coverage-rounding noise of at most 1/255 gray levels, stated in the conversion commit message.
+
 ## Initial state
 
 Google Fonts shipped Dr Sugiyama (Regular) built from FontForge SFD sources at https://github.com/librefonts/drsugiyama. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/durusans/METADATA.pb
+++ b/ofl/durusans/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/durusans"
-  commit: "d1fe3f7222addb4f12bf8fd244a26e9304a7a376"
+  commit: "43875057a510192707f378af813ecd280b6bbc02"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/durusans/upstream_info.md
+++ b/ofl/durusans/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `43875057a510`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Duru Sans (Regular) built from FontForge SFD sources at https://github.com/librefonts/durusans. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/elsie/METADATA.pb
+++ b/ofl/elsie/METADATA.pb
@@ -26,7 +26,7 @@ subsets: "latin-ext"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/elsie"
-  commit: "32783244780b4fdd904d5a1aa3f45a25c76ed15f"
+  commit: "5dc3946767fc57b80f3aec071dc15d5bff1fe491"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/elsie/upstream_info.md
+++ b/ofl/elsie/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `5dc3946767fc`; diffenator3 1.1.4 reports the rendering pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified), with residual antialiasing coverage-rounding noise of at most 0/255 gray levels, stated in the conversion commit message.
+
 ## Initial state
 
 Google Fonts shipped Elsie (Regular and Black) built from FontForge SFD sources at https://github.com/librefonts/elsie. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/elsieswashcaps/METADATA.pb
+++ b/ofl/elsieswashcaps/METADATA.pb
@@ -28,7 +28,7 @@ stroke: "SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/elsieswashcaps"
-  commit: "411b5d70587edced2c2c23f9d4c1393be55bf5d4"
+  commit: "2b557e85ca905af987167cea3c279fc7f51e15ed"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/elsieswashcaps/upstream_info.md
+++ b/ofl/elsieswashcaps/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `2b557e85ca90`; diffenator3 1.1.4 reports the rendering pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified), with residual antialiasing coverage-rounding noise of at most 0/255 gray levels, stated in the conversion commit message.
+
 ## Initial state
 
 Google Fonts shipped Elsie Swash Caps (Regular and Black) built from FontForge SFD sources at https://github.com/librefonts/elsieswashcaps. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/euphoriascript/METADATA.pb
+++ b/ofl/euphoriascript/METADATA.pb
@@ -19,7 +19,7 @@ classifications: "DISPLAY"
 classifications: "HANDWRITING"
 source {
   repository_url: "https://github.com/googlefonts/euphoriascript"
-  commit: "78d99652827fb969c23ab117ca38d93152b32bce"
+  commit: "5c641480f1c300fc9424db0fe888bf5cfc285e10"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/euphoriascript/upstream_info.md
+++ b/ofl/euphoriascript/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `5c641480f1c3`; diffenator3 1.1.4 reports the rendering pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified), with residual antialiasing coverage-rounding noise of at most 5/255 gray levels, stated in the conversion commit message.
+
 ## Initial state
 
 Google Fonts shipped Euphoria Script (Regular) built from FontForge SFD sources at https://github.com/librefonts/euphoriascript. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/felipa/METADATA.pb
+++ b/ofl/felipa/METADATA.pb
@@ -19,7 +19,7 @@ stroke: "SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/felipa"
-  commit: "1ba44f83532b9074cc71a2c13c526dea5118bb50"
+  commit: "43b2f5ee04fe88c90359d44ec195e13be4d0eab1"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/felipa/upstream_info.md
+++ b/ofl/felipa/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `43b2f5ee04fe`; diffenator3 1.1.4 reports the rendering pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified), with residual antialiasing coverage-rounding noise of at most 0/255 gray levels, stated in the conversion commit message.
+
 ## Initial state
 
 Google Fonts shipped Felipa (Regular) built from FontForge SFD sources at https://github.com/librefonts/felipa. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/flamenco/METADATA.pb
+++ b/ofl/flamenco/METADATA.pb
@@ -25,7 +25,7 @@ subsets: "latin"
 subsets: "menu"
 source {
   repository_url: "https://github.com/googlefonts/flamenco"
-  commit: "457c24c5400c78afac2d6cb6c24e1fec4d3cfbb6"
+  commit: "f6d683a8829b264edea2566800df007a19cb2069"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/flamenco/upstream_info.md
+++ b/ofl/flamenco/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `f6d683a8829b`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Flamenco (Light and Regular) built from FontForge SFD sources at https://github.com/librefonts/flamenco. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/gafata/METADATA.pb
+++ b/ofl/gafata/METADATA.pb
@@ -19,7 +19,7 @@ stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/gafata"
-  commit: "145c6761d3cf3aa1522f0bcec92b5378f67e4139"
+  commit: "d3a34e7cacb38c4cde02605a7f1d8168e6cfd32a"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/gafata/upstream_info.md
+++ b/ofl/gafata/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `d3a34e7cacb3`; diffenator3 1.1.4 reports the rendering pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified), with residual antialiasing coverage-rounding noise of at most 1/255 gray levels, stated in the conversion commit message.
+
 ## Initial state
 
 The family shipped from FontForge `.sfd` sources with no gftools-builder configuration. METADATA.pb pointed at the librefonts repository but recorded no config_yaml, so the family could not be rebuilt by the current pipeline.

--- a/ofl/gochihand/METADATA.pb
+++ b/ofl/gochihand/METADATA.pb
@@ -18,7 +18,7 @@ classifications: "DISPLAY"
 classifications: "HANDWRITING"
 source {
   repository_url: "https://github.com/googlefonts/gochihand"
-  commit: "af523d983cfa89c7216edbb907db7e39cef756d2"
+  commit: "3b094579959c9489e3b401d001c895cb2dfaad02"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/gochihand/upstream_info.md
+++ b/ofl/gochihand/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `3b094579959c`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Gochi Hand (Regular) built from FontForge SFD sources at https://github.com/librefonts/gochihand. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/gudea/METADATA.pb
+++ b/ofl/gudea/METADATA.pb
@@ -35,7 +35,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/gudea"
-  commit: "7651bdceeaa8148f45ee5781d87914346be8e9bc"
+  commit: "84926eb57483e1748fbdeab9d337db348dafa88d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/gudea/upstream_info.md
+++ b/ofl/gudea/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `84926eb57483`; diffenator3 1.1.4 reports the rendering pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified), with residual antialiasing coverage-rounding noise of at most 1/255 gray levels, stated in the conversion commit message.
+
 ## Initial state
 
 Google Fonts shipped Gudea (Regular, Italic, Bold) built from FontForge SFD sources at https://github.com/librefonts/gudea. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/habibi/METADATA.pb
+++ b/ofl/habibi/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/habibi"
-  commit: "dca56369c22e74471cceec90e257533271629472"
+  commit: "f84251c19559b3f2aae7053bb271ea0758b85c27"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/habibi/upstream_info.md
+++ b/ofl/habibi/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `f84251c19559`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Habibi (Regular) built from FontForge SFD sources at https://github.com/librefonts/habibi. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/hammersmithone/METADATA.pb
+++ b/ofl/hammersmithone/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/hammersmithone"
-  commit: "fa842a5d78963d24a139bb95c3b5d81d3a307c2b"
+  commit: "6459b0722c0ab3bdfb742cb5672dbaf572f4eca5"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/hammersmithone/upstream_info.md
+++ b/ofl/hammersmithone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `6459b0722c0a`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 The family shipped from FontForge `.sfd` sources with no gftools-builder configuration. The METADATA.pb source block pointed at the librefonts repository and a commit hash, but carried no config_yaml and no modern build recipe.

--- a/ofl/inder/METADATA.pb
+++ b/ofl/inder/METADATA.pb
@@ -17,7 +17,7 @@ subsets: "latin"
 subsets: "latin-ext"
 source {
   repository_url: "https://github.com/googlefonts/inder"
-  commit: "e4d4209a92fbe490892b0a6dbac6d61369f32f60"
+  commit: "0021128e5c59fff5b5df39abf96267d089922311"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/inder/upstream_info.md
+++ b/ofl/inder/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `0021128e5c59`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Inder (Regular) built from FontForge SFD sources at https://github.com/librefonts/inder. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/juliussansone/METADATA.pb
+++ b/ofl/juliussansone/METADATA.pb
@@ -19,7 +19,7 @@ stroke: "SANS_SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/juliussansone"
-  commit: "6e629197948d3aef530fba4cfa8f9e754b947cc1"
+  commit: "cc06b179d53ad0be099838f083c556b5d1415ca6"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/juliussansone/upstream_info.md
+++ b/ofl/juliussansone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `cc06b179d53a`; diffenator3 1.1.4 reports the rendering pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified), with residual antialiasing coverage-rounding noise of at most 0/255 gray levels, stated in the conversion commit message.
+
 ## Initial state
 
 Google Fonts shipped Julius Sans One (Regular) built from FontForge SFD sources at https://github.com/librefonts/juliussansone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/quando/METADATA.pb
+++ b/ofl/quando/METADATA.pb
@@ -19,7 +19,7 @@ stroke: "SERIF"
 classifications: "DISPLAY"
 source {
   repository_url: "https://github.com/googlefonts/quando"
-  commit: "bba03c60be43e46037df543ccce62fe7c7582b64"
+  commit: "097ef0d66cfa4118a3e05bc76d55ccf103129e82"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/quando/upstream_info.md
+++ b/ofl/quando/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources reconstructed 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary), and this family's committed `.sfd` did not exactly reproduce the shipped outlines. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, every deviation from the shipped binaries applied as its own documented commit, then the conversion to `.glyphs`. METADATA.pb references the binary-correspondence conversion commit `097ef0d66cfa`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Quando (Regular) built from FontForge SFD sources at https://github.com/librefonts/quando. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.


### PR DESCRIPTION
Follow-up to #10914, covering the 31 families whose committed FontForge .sfd did not exactly reproduce the shipped binaries (design drift between the committed source and the released build, or rasterizer-visible representation differences). Each upstream repository has since merged an explicit commit series (all merged, see each repo's "Rebuild the sources from the original .sfd" pull request): the .sfd restored byte-identical from that repository's own history, every deviation from the shipped binaries applied as its own documented commit (adopting released glyph revisions, normalizing outline representations, reproducing released metrics, kerning and composite placement), then the conversion to .glyphs. Git history is the documentation of what was done and why.

This PR updates, one commit per family, the METADATA.pb source commit to the binary-correspondence conversion commit of the merged series, and adds a dated note to each upstream_info.md. No binaries change and no other METADATA.pb fields change.

Verification, per family: builds with gftools-builder3 17b215c5 + fontc 3518040e (0.6.0); babelfont c368660; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the binaries currently shipped by Google Fonts on every style -- or, for 12 families, pixel-perfect within rasterizer rounding: the flagged glyphs are point-for-point identical to the shipped outlines (FreeType-verified) with residual antialiasing coverage-rounding noise of at most 8/255 gray levels, stated explicitly in that repository's conversion commit message.

One special case: Covered By Your Grace's repository .sfd was saved AFTER the shipped binary was generated, carrying post-release design work Google Fonts never shipped. Its METADATA.pb deliberately references the binary-correspondence commit, NOT the branch tip; the ten commits above it reintroduce the author's post-release design and await onboarder review as a future design update.

Families: Amarante, Antic Didone, Antic Slab, Average Sans, BenchNine, Bigshot One, Bilbo Swash Caps, Bowlby One, Bowlby One SC, Butcherman, Cantata One, Copse, Courgette, Covered By Your Grace, Crete Round, Doppio One, Dr Sugiyama, Duru Sans, Elsie, Elsie Swash Caps, Euphoria Script, Felipa, Flamenco, Gafata, Gochi Hand, Gudea, Habibi, Hammersmith One, Inder, Julius Sans One, Quando.