### PR TITLE
Reference the rebuilt-from-.sfd sources for 26 SFD-modernized families

### DIFF
--- a/ofl/abel/METADATA.pb
+++ b/ofl/abel/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2011-08-03"
 source {
   repository_url: "https://github.com/googlefonts/abel"
-  commit: "a68e5cfb801dfe266cdd8f5651e977f330757df2"
+  commit: "287af627694c877eed0e2fe6d375378e7d00720d"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/abel/upstream_info.md
+++ b/ofl/abel/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `287af627694c`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Abel (Regular) built from FontForge SFD sources at https://github.com/librefonts/abel. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/acme/METADATA.pb
+++ b/ofl/acme/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2011-12-19"
 source {
   repository_url: "https://github.com/googlefonts/acme"
-  commit: "d78cd61343e6d3bb3d00d8836d727fa1b7ac02fa"
+  commit: "33ccde2d61442c1f6c09125ba26fe4ff0ccee834"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/acme/upstream_info.md
+++ b/ofl/acme/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `33ccde2d6144`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 The upstream repository shipped only a FontForge source (`src/Acme-Regular-TTF.sfd`) and legacy build cruft. There was no Glyphs source and no gftools-builder configuration, so the family could not be built with the current Google Fonts Rust pipeline.

--- a/ofl/almendra/METADATA.pb
+++ b/ofl/almendra/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2011-12-19"
 source {
   repository_url: "https://github.com/googlefonts/almendra"
-  commit: "988cfa73bbc740e8a263da7a9c94c405d1436530"
+  commit: "8a710d34448831809bac6591af29d173da92e98a"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/almendra/upstream_info.md
+++ b/ofl/almendra/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `8a710d344488`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Almendra (Regular, Italic, Bold, Bold Italic) built from FontForge SFD sources at https://github.com/librefonts/almendra. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/almendradisplay/METADATA.pb
+++ b/ofl/almendradisplay/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2012-11-12"
 source {
   repository_url: "https://github.com/googlefonts/almendradisplay"
-  commit: "d0f84bf66891b9e398cec31f5f7314897f897ee2"
+  commit: "6a40f5fc91d58ab9cbd9a92e1a037dc9d71fa1aa"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/almendradisplay/upstream_info.md
+++ b/ofl/almendradisplay/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `6a40f5fc91d5`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Almendra Display (Regular) built from FontForge SFD sources at https://github.com/librefonts/almendradisplay. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/almendrasc/METADATA.pb
+++ b/ofl/almendrasc/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2011-12-19"
 source {
   repository_url: "https://github.com/googlefonts/almendrasc"
-  commit: "e4303f5636ecd733268fc4ae29dd16d2c894cc3d"
+  commit: "1b444171b7021e5d011427d7404387cf31bd88fc"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/almendrasc/upstream_info.md
+++ b/ofl/almendrasc/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `1b444171b702`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Almendra SC (Regular) built from FontForge SFD sources at https://github.com/librefonts/almendrasc. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/arbutus/METADATA.pb
+++ b/ofl/arbutus/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2011-12-07"
 source {
   repository_url: "https://github.com/googlefonts/arbutus"
-  commit: "1da75e32e2a7adc3225e7e88f7963ed2e84f48cb"
+  commit: "78eedc266b98dd8cca93c888354c49574811ae3f"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/arbutus/upstream_info.md
+++ b/ofl/arbutus/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `78eedc266b98`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Arbutus (Regular) built from FontForge SFD sources at https://github.com/librefonts/arbutus. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/arbutusslab/METADATA.pb
+++ b/ofl/arbutusslab/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2012-09-18"
 source {
   repository_url: "https://github.com/googlefonts/arbutusslab"
-  commit: "9188ac0bb9ae152e9c4e6ee8c726f4636babb86f"
+  commit: "17c26d3b3abd75c24119a0fc87dd491ece7c2af5"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/arbutusslab/upstream_info.md
+++ b/ofl/arbutusslab/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `17c26d3b3abd`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 The upstream repository shipped only FontForge `.sfd` sources (`src/ArbutusSlab-Regular.ttf.sfd`) with no gftools-builder configuration. METADATA.pb recorded the repository and onboarding commit but no `config_yaml`, so the family could not be rebuilt with the current Rust pipeline.

--- a/ofl/architectsdaughter/METADATA.pb
+++ b/ofl/architectsdaughter/METADATA.pb
@@ -5,7 +5,7 @@ category: "HANDWRITING"
 date_added: "2011-03-09"
 source {
   repository_url: "https://github.com/googlefonts/architectsdaughter"
-  commit: "0912d302495d684898c33d02a4a0f24f32ec3da3"
+  commit: "55246f9edaf98669853e024e60e0575bd9d52ada"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/architectsdaughter/upstream_info.md
+++ b/ofl/architectsdaughter/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `55246f9edaf9`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 The upstream repository at librefonts/architectsdaughter shipped only FontForge sources. METADATA.pb recorded the repository and onboarding commit but no config.yaml, so the family could not be rebuilt with the current Rust toolchain.

--- a/ofl/armata/METADATA.pb
+++ b/ofl/armata/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2011-12-19"
 source {
   repository_url: "https://github.com/googlefonts/armata"
-  commit: "acd66b422a3b61baae8fee57c197e9f782b87f57"
+  commit: "8594fe9afcf0f561d1150067067ddca7e44e91c9"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/armata/upstream_info.md
+++ b/ofl/armata/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `8594fe9afcf0`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 The upstream repository at librefonts/armata shipped only FontForge sources (`src/Armata-Regular-TTF.sfd`) and had no config.yaml or Glyphs sources, so it could not build with the current Google Fonts pipeline. METADATA.pb recorded the repository and onboarding commit but no build configuration.

--- a/ofl/astloch/METADATA.pb
+++ b/ofl/astloch/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-02-16"
 source {
   repository_url: "https://github.com/googlefonts/astloch"
-  commit: "48ba7212e16d35d8f5991fac7f46c8c134106d30"
+  commit: "e6ac0a83f48c458c055180c7fb695732d6b5559a"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/astloch/upstream_info.md
+++ b/ofl/astloch/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `e6ac0a83f48c`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Astloch (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/astloch. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/asul/METADATA.pb
+++ b/ofl/asul/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2011-12-19"
 source {
   repository_url: "https://github.com/googlefonts/asul"
-  commit: "d3179dc9cff2434b299a698af0183d191e31e925"
+  commit: "bdc50bf9e7acedd365c0e33e84a5ae7f5c09a5c9"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/asul/upstream_info.md
+++ b/ofl/asul/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `bdc50bf9e7ac`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Asul (Regular and Bold) built from FontForge SFD sources at https://github.com/librefonts/asul. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/autourone/METADATA.pb
+++ b/ofl/autourone/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2012-05-15"
 source {
   repository_url: "https://github.com/googlefonts/autourone"
-  commit: "11d97fbce17c2eb0a2eb88eb560c4ecf8e7645ac"
+  commit: "2773d8996d23617e284fcad81a8b396f2f098696"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/autourone/upstream_info.md
+++ b/ofl/autourone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `2773d8996d23`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Autour One (Regular) built from FontForge SFD sources at https://github.com/librefonts/autourone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/belgrano/METADATA.pb
+++ b/ofl/belgrano/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2011-12-19"
 source {
   repository_url: "https://github.com/googlefonts/belgrano"
-  commit: "e79e00337ef13f738009b16d2909cc2dd17af344"
+  commit: "e302859418e7d9bde89fa08de47658bab32d6559"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/belgrano/upstream_info.md
+++ b/ofl/belgrano/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `e302859418e7`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 The upstream repository shipped only a FontForge source (`src/Belgrano-Regular-TTF.sfd`) with no gftools-builder configuration, so the family could not be built with the current Google Fonts Rust pipeline. METADATA.pb recorded the librefonts repository and onboarding commit but no `config_yaml`.

--- a/ofl/boogaloo/METADATA.pb
+++ b/ofl/boogaloo/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-12-19"
 source {
   repository_url: "https://github.com/googlefonts/boogaloo"
-  commit: "254753cf202453c11d1aa39066b9ca5294d2dc5f"
+  commit: "c06afd6c55940a7cb72a434450a77575142f0249"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/boogaloo/upstream_info.md
+++ b/ofl/boogaloo/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `c06afd6c5594`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Boogaloo (Regular) built from FontForge SFD sources at https://github.com/librefonts/boogaloo. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/breeserif/METADATA.pb
+++ b/ofl/breeserif/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2011-12-19"
 source {
   repository_url: "https://github.com/googlefonts/breeserif"
-  commit: "80b004f6325a65a90f50de70facec1c98d36ff9d"
+  commit: "31562b2b04ee21afb0c750ca2343fb761ae36dfb"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/breeserif/upstream_info.md
+++ b/ofl/breeserif/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `31562b2b04ee`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 The family shipped from a FontForge `.sfd` source (`src/BreeSerif-Regular-TTF.sfd`) with no gftools-builder configuration. The METADATA.pb source block pointed at the librefonts repository but carried no `config_yaml`, so the family could not be rebuilt with the current pipeline.

--- a/ofl/bubblerone/METADATA.pb
+++ b/ofl/bubblerone/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2012-05-09"
 source {
   repository_url: "https://github.com/googlefonts/bubblerone"
-  commit: "110b02cb1d151f5c8288d01c98121bab0094da19"
+  commit: "340ec8e1db5757ed5255633684a491769e8025de"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/bubblerone/upstream_info.md
+++ b/ofl/bubblerone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `340ec8e1db57`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Bubbler One (Regular) built from FontForge SFD sources at https://github.com/librefonts/bubblerone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/cambo/METADATA.pb
+++ b/ofl/cambo/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2011-12-19"
 source {
   repository_url: "https://github.com/googlefonts/cambo"
-  commit: "a2c35dbad5014c97b1ca438b895d95c7411e0e04"
+  commit: "b011c20463fc7ab1930253d978d6504da299e848"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/cambo/upstream_info.md
+++ b/ofl/cambo/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `b011c20463fc`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Cambo (Regular) built from FontForge SFD sources at https://github.com/librefonts/cambo. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/candal/METADATA.pb
+++ b/ofl/candal/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2011-03-09"
 source {
   repository_url: "https://github.com/googlefonts/candal"
-  commit: "ed7ac22d003047196e34bcf6465f2ad5871493e8"
+  commit: "bfbce57a92b0b258efd685880d366d2c81e85777"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/candal/upstream_info.md
+++ b/ofl/candal/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `bfbce57a92b0`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Candal (Regular) built from FontForge SFD sources at https://github.com/librefonts/candal. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/chauphilomeneone/METADATA.pb
+++ b/ofl/chauphilomeneone/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2012-04-04"
 source {
   repository_url: "https://github.com/googlefonts/chauphilomeneone"
-  commit: "d7246600bbdfd898596bb8ebab13c484e5b21a55"
+  commit: "a1f00e1a92747fb44b1120ddaa31d3421e31ed69"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/chauphilomeneone/upstream_info.md
+++ b/ofl/chauphilomeneone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `a1f00e1a9274`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Chau Philomene One (Regular and Italic) built from FontForge SFD sources at https://github.com/librefonts/chauphilomeneone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/concertone/METADATA.pb
+++ b/ofl/concertone/METADATA.pb
@@ -5,7 +5,7 @@ category: "DISPLAY"
 date_added: "2011-11-23"
 source {
   repository_url: "https://github.com/googlefonts/concertone"
-  commit: "b002b9370c7365b13d6a79e4718eb6aa8e3d0dc6"
+  commit: "d68fc365f489c262c4fb6c3d8488f06f6941c569"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/concertone/upstream_info.md
+++ b/ofl/concertone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `d68fc365f489`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Concert One (Regular) built from FontForge SFD sources at https://github.com/librefonts/concertone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/dawningofanewday/METADATA.pb
+++ b/ofl/dawningofanewday/METADATA.pb
@@ -5,7 +5,7 @@ category: "HANDWRITING"
 date_added: "2011-04-14"
 source {
   repository_url: "https://github.com/googlefonts/dawningofanewday"
-  commit: "a0c504721994bbcde597e453115c481419e7c43f"
+  commit: "7becafaca78e29d8545909eaaa059819bb5959ff"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/dawningofanewday/upstream_info.md
+++ b/ofl/dawningofanewday/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `7becafaca78e`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Dawning of a New Day (Regular) built from FontForge SFD sources at https://github.com/librefonts/dawningofanewday. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/daysone/METADATA.pb
+++ b/ofl/daysone/METADATA.pb
@@ -5,7 +5,7 @@ category: "SANS_SERIF"
 date_added: "2011-08-17"
 source {
   repository_url: "https://github.com/googlefonts/daysone"
-  commit: "5a4d7f229c497dd3f4cf1b8c23da954c3e45e2cf"
+  commit: "4a7c150f858a8de260b27e12d95902e4de213286"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/daysone/upstream_info.md
+++ b/ofl/daysone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `4a7c150f858a`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Days One (Regular) built from FontForge SFD sources at https://github.com/librefonts/daysone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/donegalone/METADATA.pb
+++ b/ofl/donegalone/METADATA.pb
@@ -5,7 +5,7 @@ category: "SERIF"
 date_added: "2012-11-26"
 source {
   repository_url: "https://github.com/googlefonts/donegalone"
-  commit: "3fccfd33ed0b9eefdb158aef321fc2e604127a2c"
+  commit: "1789bdc47a7611ddd5bff9216bfc12655a32ad27"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/donegalone/upstream_info.md
+++ b/ofl/donegalone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `1789bdc47a76`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Donegal One (Regular) built from FontForge SFD sources at https://github.com/librefonts/donegalone. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/fjordone/METADATA.pb
+++ b/ofl/fjordone/METADATA.pb
@@ -16,7 +16,7 @@ subsets: "menu"
 subsets: "latin"
 source {
   repository_url: "https://github.com/googlefonts/fjordone"
-  commit: "a6c1784e33666b26db68a0170055b9f41086240e"
+  commit: "2ca608793920a72b6d11a00ca83a2f04b15d89b8"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/fjordone/upstream_info.md
+++ b/ofl/fjordone/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `2ca608793920`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 The family shipped from the dormant librefonts repository, whose only sources were FontForge `.sfd` files under `src/`. METADATA.pb recorded that repository and commit but carried no `config_yaml`, and the sources could not be built by the current Rust pipeline.

--- a/ofl/giveyouglory/METADATA.pb
+++ b/ofl/giveyouglory/METADATA.pb
@@ -16,7 +16,7 @@ subsets: "menu"
 subsets: "latin"
 source {
   repository_url: "https://github.com/googlefonts/giveyouglory"
-  commit: "79ab8c04f2f381fa7439e09957fe3257ff113333"
+  commit: "3a257cd1804b255dc7caac164c6cd2965c0119fc"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/giveyouglory/upstream_info.md
+++ b/ofl/giveyouglory/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `3a257cd1804b`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Give You Glory (Regular) built from FontForge SFD sources at https://github.com/librefonts/giveyouglory. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.

--- a/ofl/marckscript/METADATA.pb
+++ b/ofl/marckscript/METADATA.pb
@@ -20,7 +20,7 @@ classifications: "DISPLAY"
 classifications: "HANDWRITING"
 source {
   repository_url: "https://github.com/googlefonts/marckscript"
-  commit: "b85fe9173d03ac8c339274ead43f34f0752c0819"
+  commit: "f4e66d73d1cc7190be547d491b99a0979c60fb10"
   files {
     source_file: "OFL.txt"
     dest_file: "OFL.txt"

--- a/ofl/marckscript/upstream_info.md
+++ b/ofl/marckscript/upstream_info.md
@@ -2,6 +2,8 @@
 
 Source modernized 2026-07: the FontForge `.sfd` sources were converted to Glyphs (`.glyphs`) and now build with the Google Fonts Rust pipeline (gftools-builder3 + fontc). The repository, commit and config are recorded in the `source { }` block of METADATA.pb and are not duplicated here.
 
+Sources rebuilt 2026-09: the 2026-07 conversion was back-fitted (post-conversion scripts copied values out of the shipped binary) and carried undocumented source edits. The upstream repository now carries an explicit commit series: the `.sfd` restored byte-identical from the repository's own history, each documented edit (version bump, metric or naming correction) as its own commit with its justification, then the conversion to `.glyphs`. METADATA.pb references the conversion commit `f4e66d73d1cc`; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the shipped binaries on every style.
+
 ## Initial state
 
 Google Fonts shipped Marck Script (Regular) built from FontForge SFD sources at https://github.com/librefonts/marckscript. There was no Glyphs (`.glyphs`) source, and no source that builds with fontc.


### PR DESCRIPTION
Follow-up to #10914 and #10924, covering the 26 families whose 2026-07 conversions carried documented source edits (version bumps, vertical-metric or naming corrections) alongside the back-fitting problem. Each upstream repository has since merged an explicit commit series (all merged, see each repo's "Rebuild the sources from the original .sfd" pull request): the .sfd restored byte-identical from that repository's own history, each documented edit as its own commit with its justification in the commit message, then the conversion to .glyphs. Git history is the documentation of what was done and why.

This PR updates, one commit per family, the METADATA.pb source commit to the conversion commit of the merged series, and adds a dated note to each upstream_info.md. No binaries change and no other METADATA.pb fields change.

Verification, per family: builds with gftools-builder3 17b215c5 + fontc 3518040e (0.6.0); babelfont c368660; diffenator3 1.1.4 reports zero glyph, word and pixel differences against the binaries currently shipped by Google Fonts, on every style.

Families: Abel, Acme, Almendra, Almendra Display, Almendra SC, Arbutus, Arbutus Slab, Architects Daughter, Armata, Astloch, Asul, Autour One, Belgrano, Boogaloo, Bree Serif, Bubbler One, Cambo, Candal, Chau Philomene One, Concert One, Dawning of a New Day, Days One, Donegal One, Fjord One, Give You Glory, Marck Script.

With this PR, 99 of the 100 SFD-modernized families reference clean, explicitly-documented sources; the one remaining family (Handlee) waits on a babelfont fix (simoncozens/babelfont-rs#85) before its rebuild can reproduce the shipped vertical metrics.