### PR TITLE
Update axisregistry to v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,62 +4,62 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cfg-if"
@@ -75,9 +75,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
@@ -97,18 +97,18 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fixedbitset"
@@ -118,42 +118,29 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "font-types"
-version = "0.9.0"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a596f5713680923a2080d86de50fe472fb290693cf0f701187a1c8b36996b7"
+checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
-name = "fontations"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce83f5942797f03c95b06864da889bc5a6acf543cd5bbf108ea114d898fc824"
-dependencies = [
- "font-types",
- "read-fonts",
- "skrifa",
- "write-fonts",
-]
-
-[[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
 ]
 
 [[package]]
 name = "gf-metadata"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6125c1c053786af0c39faebe483b519804f63a5bd4b2b092733686316db7bd0b"
+checksum = "b15e502d8366f08fe570c61b5c48871ee1700175b4202ef6be5aabfd685ee7b9"
 dependencies = [
  "google-fonts-languages",
  "protobuf",
@@ -163,16 +150,15 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "google-fonts-axisregistry"
-version = "0.4.19"
+version = "0.5.0"
 dependencies = [
  "bytes",
- "fontations",
  "gf-metadata",
  "glob",
  "indexmap",
@@ -183,18 +169,19 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "skrifa",
+ "syn 2.0.119",
+ "write-fonts",
 ]
 
 [[package]]
 name = "google-fonts-languages"
-version = "0.7.7"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe180b8735d2804f098df3fb976014f7578a65b72bcdca016273ed3194c7a41"
+checksum = "a8066b43e3021c9ba25242b7e2fa57a9f1d1f77fa8ae43936f6946512a3f2376"
 dependencies = [
- "bytes",
  "glob",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "prettyplease",
  "proc-macro2",
  "prost",
@@ -206,14 +193,14 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -232,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -260,26 +247,27 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kurbo"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
 dependencies = [
  "arrayvec",
  "euclid",
+ "polycool",
  "smallvec",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -289,21 +277,21 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "multimap"
@@ -322,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "petgraph"
@@ -334,6 +322,15 @@ checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -353,14 +350,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -391,7 +388,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -405,7 +402,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -519,34 +516,35 @@ checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "read-fonts"
-version = "0.31.3"
+version = "0.43.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8250b8f09ed4b9ba9271e06f10e7b1f03e8f8e3619e2368a991ecb25efa204"
+checksum = "005c8acf251756c478b0bf402885bfd88a1476020c4c7e6060edc1aa68da38ea"
 dependencies = [
  "bytemuck",
  "font-types",
+ "once_cell",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -556,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -567,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustix"
@@ -586,14 +584,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -608,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -618,29 +616,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -651,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "skrifa"
-version = "0.33.2"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc1f79e5624f166718224ef883095bea315801aca75b62c64f3937755a586d"
+checksum = "d4febebda507fb889c545a37a135517769d1391941013561292897961d1887d6"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -661,15 +659,26 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -678,14 +687,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -706,14 +715,14 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "walkdir"
@@ -723,15 +732,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
 ]
 
 [[package]]
@@ -844,16 +844,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-
-[[package]]
 name = "write-fonts"
-version = "0.39.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac89848aeba9b7e1877f1e89e3f9c95adb8771f640e1ef23c605aa734748c2b"
+checksum = "843cebb7bd36359861dbce43d54ac8b33dfdf7b80a95913adc1ef7c7bb881e62"
 dependencies = [
  "font-types",
  "indexmap",
@@ -870,6 +864,6 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-fonts-axisregistry"
-version = "0.4.19"
+version = "0.5.0"
 edition = "2021"
 description = "Google Fonts font axis support data"
 repository = "https://github.com/googlefonts/axisregistry"
@@ -8,13 +8,15 @@ license-file = "LICENSE.txt"
 
 [features]
 default = ["fontations"]
+fontations = ["dep:skrifa", "dep:write-fonts"]
 
 [dependencies]
 bytes = "1.11.1"
 gf-metadata = "0.2.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-fontations = { version = "0.3.0", optional = true }
+write-fonts = { version = "0.52.0", optional = true }
+skrifa = { version = "0.46.2", optional = true }
 indexmap = "2.7.0"
 
 [dev-dependencies]
@@ -28,3 +30,8 @@ proc-macro2 = "1.0"
 syn = "2.0"
 itertools = "0.13"
 gf-metadata = "0.2.4"
+serde_json = "1.0"
+
+[lints.clippy]
+unwrap_used = "deny"
+indexing_slicing = "deny"

--- a/Lib/axisregistry/data/spacing.textproto
+++ b/Lib/axisregistry/data/spacing.textproto
@@ -1,4 +1,4 @@
-# SPAC based on https://github.com/gferreira/roboto-flex-spac
+# SPAC based on https://fonts.google.com/specimen/Shantell+Sans and https://github.com/googlefonts/roboto-flex-spacing-axis-demo
 tag: "SPAC"
 display_name: "Spacing"
 min_value: -100.0

--- a/Lib/axisregistry/data/width.textproto
+++ b/Lib/axisregistry/data/width.textproto
@@ -2,7 +2,7 @@
 tag: "wdth"
 display_name: "Width"
 min_value: 25
-max_value: 200
+max_value: 300
 default_value: 100
 precision: -1
 # Instance values based on https://docs.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass

--- a/Lib/axisregistry/data/x_transparent.textproto
+++ b/Lib/axisregistry/data/x_transparent.textproto
@@ -2,7 +2,7 @@
 tag: "XTRA"
 display_name: "Counter Width"
 min_value: -1000
-max_value: 2000
+max_value: 3330
 default_value: 400
 precision: 0
 fallback {

--- a/build.rs
+++ b/build.rs
@@ -9,8 +9,9 @@ use std::{
 };
 
 fn main() {
-    let path = Path::new(&env::var("OUT_DIR").unwrap()).join("data.rs");
-    let mut file = BufWriter::new(File::create(path).unwrap());
+    let path =
+        Path::new(&env::var("OUT_DIR").expect("Couldn't find output directory")).join("data.rs");
+    let mut file = BufWriter::new(File::create(path).expect("Could not create output file"));
     let mut output = quote! { use std::collections::BTreeMap; use std::sync::LazyLock; };
 
     output.extend(serialize_a_structure(
@@ -31,7 +32,9 @@ fn serialize_a_structure(pathglob: &str, output_variable: &str) -> TokenStream {
         .expect("Failed to read glob pattern")
         .flatten()
         .collect();
-    let variable: TokenStream = output_variable.parse().unwrap();
+    let variable: TokenStream = output_variable
+        .parse()
+        .expect("Could not parse variable name");
     let mut gobbets = vec![];
     let mut names = vec![];
     let mut tags = vec![];
@@ -60,10 +63,13 @@ fn serialize_file(path: std::path::PathBuf) -> (TokenStream, TokenStream, String
         .unwrap_or_else(|_| panic!("Could not parse proto {}", path.display()));
     let name: TokenStream = format!("AXIS_{}", proto.tag().to_ascii_uppercase())
         .parse()
-        .unwrap();
+        .unwrap_or_else(|_| panic!("Could not parse variable name for {}", proto.tag()));
     // Resolve absolute path here
-    let path = std::fs::canonicalize(path).unwrap();
-    let path_as_string = path.to_str().unwrap();
+    let path = std::fs::canonicalize(path).expect("Could not canonicalize path");
+    let path_as_string = path
+        .to_str()
+        .expect("Could not convert path to string")
+        .to_string();
     let tag: String = proto.tag().to_string().parse().unwrap();
     let include_gobbet = quote! {
         const #name: &str = include_str!(#path_as_string);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,25 @@
+//! Rust port of the Google Fonts [Axis Registry](https://github.com/googlefonts/axisregistry).
+//!
+//! Provides a read-only view of every axis registered with Google Fonts, plus
+//! helpers for working with the axes implemented by a font. The registry data
+//! is compiled into the crate at build time from the
+//! `Lib/axisregistry/data/*.textproto` sources.
+//!
+//! With the `fontations` feature (enabled by default) it can also rebuild a
+//! font's `name`, `fvar` and `STAT` tables to conform to the Google Fonts
+//! naming and instance specifications.
+
 use gf_metadata::{AxisProto, FallbackProto};
 use std::{collections::HashSet, ops::Index};
 
-#[cfg(feature = "fontations")]
-pub use fontations::read::FontRef; // Re-export our types for users
-#[cfg(feature = "fontations")]
-use fontations::skrifa::string::StringId;
-#[cfg(feature = "fontations")]
-use fontations::{
-    read::{ReadError, TableProvider},
-    write::FontBuilder,
-};
 use indexmap::IndexMap;
+#[cfg(feature = "fontations")]
+use skrifa::string::StringId;
+#[cfg(feature = "fontations")]
+use skrifa::{
+    raw::FontRef,
+    raw::{ReadError, TableProvider},
+};
 
 include!(concat!(env!("OUT_DIR"), "/data.rs"));
 
@@ -57,44 +66,62 @@ const PROTECTED_IDS: [StringId; 9] = [
     StringId::VARIATIONS_POSTSCRIPT_NAME_PREFIX,
 ];
 
+/// The Google Fonts Axis Registry.
+///
+/// A read-only collection of every axis registered with Google Fonts, keyed by
+/// its four-character `tag`.
 pub struct AxisRegistry {
     axes: BTreeMap<String, Box<AxisProto>>,
 }
 
+/// A design axis as implemented by a font's `fvar` table.
 #[derive(Debug, Clone)]
 pub struct FontAxis {
+    /// The axis tag (e.g. `"wght"`).
     pub tag: String,
+    /// The minimum value of the axis.
     pub min: f32,
+    /// The maximum value of the axis.
     pub max: f32,
+    /// The default value of the axis.
     pub default: f32,
 }
 
+/// A named component used to compose axis-based style names.
 #[derive(Debug, Clone)]
 pub struct NameParticle {
+    /// The readable name, if one is known for this value.
     pub name: Option<String>,
+    /// The axis value this particle represents.
     pub value: f32,
+    /// Whether this particle is omitted from the composed name.
     pub elided: bool,
 }
 
 impl AxisRegistry {
+    /// Creates a registry containing all axes in the Google Fonts Axis Registry.
     pub fn new() -> Self {
         Self {
             axes: (*AXES).clone(),
         }
     }
 
+    /// Returns the registered axis for the given `tag`, if present.
     pub fn get(&self, tag: &str) -> Option<&AxisProto> {
         self.axes.get(tag).map(|v| &**v)
     }
 
+    /// Returns whether an axis with the given `tag` is registered.
     pub fn contains_key(&self, tag: &str) -> bool {
         self.axes.contains_key(tag)
     }
 
+    /// Iterates over all `(tag, axis)` pairs in the registry.
     pub fn iter(&self) -> impl Iterator<Item = (&String, &AxisProto)> {
         self.axes.iter().map(|(k, v)| (k, &**v))
     }
 
+    /// Returns the first fallback named `name`, as its `(axis tag, fallback)`.
     pub fn get_fallback<'a>(&'a self, name: &str) -> Option<(&'a str, &'a FallbackProto)> {
         self.axes
             .iter()
@@ -108,7 +135,11 @@ impl AxisRegistry {
             .next()
     }
 
-    // This is fallbacks_in_fvar, but without assuming any particular font representation
+    /// For each of the given font axes, yields its registered fallbacks whose
+    /// values fall within the axis' `min`..`max` range.
+    ///
+    /// This is `fallbacks_in_fvar` from the Python original, without assuming
+    /// any particular font representation.
     pub fn fallbacks<'a>(
         &'a self,
         font_axes: &'a [FontAxis],
@@ -128,7 +159,11 @@ impl AxisRegistry {
         })
     }
 
-    // This is fallbacks_in_name_table, but without assuming any particular font representation
+    /// Yields fallbacks whose names appear as tokens in the given family and
+    /// subfamily names, skipping any of the given font axes.
+    ///
+    /// This is `fallbacks_in_name_table` from the Python original, without
+    /// assuming any particular font representation.
     pub fn name_table_fallbacks<'a>(
         &'a self,
         family_name: &'a str,
@@ -145,6 +180,7 @@ impl AxisRegistry {
             .filter(move |(tag, _)| !axis_names.contains(tag))
     }
 
+    /// Returns the registered fallback with the given `value` on `axis_tag`, if any.
     pub fn fallback_for_value<'a>(
         &'a self,
         axis_tag: &str,
@@ -154,6 +190,8 @@ impl AxisRegistry {
             .and_then(|axis| axis.fallback.iter().find(|f| f.value == Some(value)))
     }
 
+    /// Returns axis tags in canonical Google Fonts order: custom axes
+    /// alphabetically, then `opsz`, `wdth`, `wght`, `ital`, `slnt`.
     pub fn axis_order(&self) -> Vec<&str> {
         let mut axis_tags: Vec<&str> = self
             .axes
@@ -166,7 +204,8 @@ impl AxisRegistry {
         axis_tags
     }
 
-    // This is the old "_fvar_dflts"
+    /// Builds a name particle for each of the given font axes from the axis'
+    /// default values (the former `_fvar_dflts` in the Python original).
     pub fn name_particles<'a>(&self, font_axes: &'a [FontAxis]) -> IndexMap<&'a str, NameParticle> {
         let mut particles = IndexMap::new();
         for axis in font_axes {
@@ -185,7 +224,8 @@ impl AxisRegistry {
                     NameParticle {
                         name: fallback.name.clone(),
                         value: axis.default,
-                        elided: (fallback.value() == self.get(&axis.tag).unwrap().default_value())
+                        elided: (Some(fallback.value())
+                            == self.get(&axis.tag).map(|axis| axis.default_value()))
                             && !(["Regular", "Italic", "14pt"].contains(&fallback.name())),
                     },
                 );
@@ -227,59 +267,74 @@ mod stat;
 #[cfg(feature = "fontations")]
 mod fontations_impl {
     use super::*;
-    use fontations::{
-        skrifa::{string::StringId, MetadataProvider, Tag},
-        write::{
-            from_obj::ToOwnedTable,
-            tables::{
-                fvar::{Fvar, InstanceRecord},
-                name::{Name, NameRecord},
-                os2::Os2,
-                stat::Stat,
-            },
-            types::Fixed,
-        },
-    };
     use monkeypatching::{AxisValueNameId, SetAxisValueNameId};
     use nametable::{
         add_name, best_familyname, best_subfamilyname, find_or_add_name, rewrite_or_insert,
     };
+    use skrifa::{string::StringId, MetadataProvider, Tag};
     use stat::{AxisLocation, AxisRecord, AxisValue, StatBuilder};
     use std::{cmp::Reverse, collections::HashMap};
+    use write_fonts::{
+        from_obj::ToOwnedTable,
+        tables::{
+            fvar::{Fvar, InstanceRecord},
+            name::{Name, NameRecord},
+            os2::Os2,
+            stat::Stat,
+        },
+        types::Fixed,
+        FontBuilder,
+    };
 
+    /// How aggressively an existing `name` table is rewritten.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
     pub enum RenameAggressiveness {
+        /// Replace the old family name in every record that mentions it.
         #[default]
         Aggressive,
+        /// Leave records this build does not explicitly set untouched.
         Conservative,
     }
 
+    /// Rewrites a font's `name` table (and OS/2 weight class) to conform to the
+    /// Google Fonts naming scheme, returning the updated font as bytes.
+    ///
+    /// Variable fonts derive their style name from the registry's fallback
+    /// names; static fonts use the version 1 (RIBBI) naming scheme. When
+    /// `family_name`/`style_name` are `None`, they are read from the font.
     pub fn build_name_table(
-        font: FontRef,
+        font: &[u8],
         family_name: Option<&str>,
         style_name: Option<&str>,
         siblings: &[FontRef],
         aggressive: Option<RenameAggressiveness>,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let fontref = FontRef::new(font)?;
         let mut new_font = FontBuilder::new();
         let family_name = family_name
             .map(|x| x.to_string())
-            .unwrap_or_else(|| best_familyname(&font).unwrap_or("Unknown".to_string()));
+            .unwrap_or_else(|| best_familyname(&fontref).unwrap_or("Unknown".to_string()));
         let style_name = style_name
             .map(|x| x.to_string())
-            .unwrap_or_else(|| best_subfamilyname(&font).unwrap_or("Regular".to_string()));
+            .unwrap_or_else(|| best_subfamilyname(&fontref).unwrap_or("Regular".to_string()));
 
-        let mut new_name = if font.table_data(Tag::new(b"fvar")).is_some() {
-            build_vf_name_table(&mut new_font, &font, &family_name, siblings, aggressive)?
+        let mut new_name = if fontref.table_data(Tag::new(b"fvar")).is_some() {
+            build_vf_name_table(&mut new_font, &fontref, &family_name, siblings, aggressive)?
         } else {
-            build_static_name_table_v1(&mut new_font, &font, &family_name, &style_name, aggressive)?
+            build_static_name_table_v1(
+                &mut new_font,
+                &fontref,
+                &family_name,
+                &style_name,
+                aggressive,
+            )?
         };
 
         let mut styles: Vec<_> = GF_STATIC_STYLES.iter().collect();
         styles.sort_by_key(|(name, _weight)| Reverse(name.len()));
         for (name, weight) in styles.iter() {
             if style_name.contains(name) {
-                let mut new_os2: Os2 = font.os2()?.to_owned_table();
+                let mut new_os2: Os2 = fontref.os2()?.to_owned_table();
                 new_os2.us_weight_class = *weight;
                 new_font.add_table(&new_os2)?;
                 break;
@@ -288,7 +343,7 @@ mod fontations_impl {
         // Set RIBBI bits
         new_name.name_record.sort();
         new_font.add_table(&new_name)?;
-        Ok(new_font.copy_missing_tables(font).build())
+        Ok(new_font.copy_missing_tables(fontref).build())
     }
 
     fn fvar_instance_collisions(font: &FontRef, siblings: &[FontRef]) -> bool {
@@ -438,6 +493,7 @@ mod fontations_impl {
                     && r.encoding_id == 1
                     && r.language_id == 0x409
             }) {
+                #[allow(clippy::indexing_slicing)] // We just found it, so it's safe to index
                 removed_names.insert(name_id, records[existing].string.to_string());
                 to_delete.push(existing);
             }
@@ -529,7 +585,7 @@ mod fontations_impl {
     }
 
     fn font_axes(font: &FontRef) -> Result<Vec<FontAxis>, ReadError> {
-        let fvar = font.fvar().unwrap();
+        let fvar = font.fvar()?;
         let mut axes = vec![];
         for axis in fvar.axes()? {
             let tag = axis.axis_tag().to_string();
@@ -578,15 +634,16 @@ mod fontations_impl {
     }
 
     /// Return a font with an fvar table which conforms to the Google Fonts instance spec:
-    /// https://github.com/googlefonts/gf-docs/tree/main/Spec#fvar-instances
+    /// <https://github.com/googlefonts/gf-docs/tree/main/Spec#fvar-instances>
     pub fn build_fvar_instances(
-        font: FontRef,
+        font: &[u8],
         axis_dflts: Option<HashMap<String, f32>>,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let font = FontRef::new(font)?;
         let axis_registry = AxisRegistry::new();
         let mut new_font = FontBuilder::new();
-        let mut fvar: Fvar = font.fvar().unwrap().to_owned_table();
-        let mut name_table: Name = font.name().unwrap().to_owned_table();
+        let mut fvar: Fvar = font.fvar()?.to_owned_table();
+        let mut name_table: Name = font.name()?.to_owned_table();
         let family_name = best_familyname(&font).unwrap_or("New Font".to_string());
         let style_name = best_subfamilyname(&font).unwrap_or("Regular".to_string());
         // Protect name IDs which are shared with the STAT table
@@ -638,6 +695,7 @@ mod fontations_impl {
         let mut fallbacks: HashMap<String, Vec<FallbackProto>> =
             axis_registry.fallbacks(&axes).collect();
         if !fvar_defaults.contains_key("wght") {
+            #[allow(clippy::unwrap_used)] // We know wght is in the registry
             fallbacks.insert(
                 "wght".to_string(),
                 axis_registry
@@ -673,14 +731,14 @@ mod fontations_impl {
         };
         for italic in do_italic.into_iter() {
             for fallback in wght_fallbacks.iter() {
-                let mut name = fallback.name.as_ref().unwrap().to_string();
+                let mut name = fallback.name().to_string();
                 if italic {
                     name += " Italic";
                 }
                 name = name.replace("Regular Italic", "Italic");
                 let mut coordinates = axis_dflts.clone();
                 if fvar_defaults.contains_key("wght") {
-                    coordinates.insert("wght".to_string(), fallback.value.unwrap());
+                    coordinates.insert("wght".to_string(), fallback.value());
                 }
                 if italic {
                     if let Some(min) = min_ital {
@@ -716,11 +774,20 @@ mod fontations_impl {
         Ok(new_font.copy_missing_tables(font).build())
     }
 
-    // All right, let's do it
+    /// Builds a Google Fonts-conformant `STAT` table for a variable font,
+    /// returning the updated font as bytes.
+    ///
+    /// Axis values come from the font's axes, its family/style names and its
+    /// `siblings`; the font's `name` table is updated to match.
     pub fn build_stat(
-        font: FontRef,
-        siblings: &[FontRef],
+        font: &[u8],
+        siblings: &[&[u8]],
     ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let font = FontRef::new(font)?;
+        let siblings = siblings
+            .iter()
+            .map(|s| FontRef::new(s))
+            .collect::<Result<Vec<_>, _>>()?;
         let mut new_font = FontBuilder::new();
         let axes = font_axes(&font)?;
         let axis_registry = AxisRegistry::new();
@@ -729,9 +796,9 @@ mod fontations_impl {
 
         let mut fallbacks_in_siblings: Vec<(String, FallbackProto)> = vec![];
         for fnt in siblings {
-            let family_name = best_familyname(fnt).unwrap_or("New Font".to_string());
-            let subfamily_name = best_subfamilyname(fnt).unwrap_or("Regular".to_string());
-            let font_axes = font_axes(fnt).unwrap_or_default();
+            let family_name = best_familyname(&fnt).unwrap_or("New Font".to_string());
+            let subfamily_name = best_subfamilyname(&fnt).unwrap_or("Regular".to_string());
+            let font_axes = font_axes(&fnt).unwrap_or_default();
             fallbacks_in_siblings.extend(
                 axis_registry
                     .name_table_fallbacks(&family_name, &subfamily_name, &font_axes)
@@ -744,8 +811,8 @@ mod fontations_impl {
         let fallbacks_in_names =
             axis_registry.name_table_fallbacks(&family_name, &subfamily_name, &axes);
 
-        let fvar: Fvar = font.fvar().unwrap().to_owned_table();
-        let mut name: Name = font.name().unwrap().to_owned_table();
+        let fvar: Fvar = font.fvar()?.to_owned_table();
+        let mut name: Name = font.name()?.to_owned_table();
         let fvar_name_ids: HashSet<StringId> = fvar
             .axis_instance_arrays
             .instances
@@ -799,6 +866,8 @@ mod fontations_impl {
             }
         }
 
+        #[allow(clippy::indexing_slicing, clippy::unwrap_used)]
+        // We know the fallback axis is in the registry so it's correct
         for (axis, fallbacks) in fallbacks_in_fvar.iter() {
             let tag = Tag::new_checked(&axis.as_bytes()[0..4])?;
             let ar_axis = axis_registry.get(axis).unwrap();
@@ -827,6 +896,7 @@ mod fontations_impl {
             }
         }
 
+        #[allow(clippy::indexing_slicing, clippy::unwrap_used)]
         for (axis, fallback) in fallbacks_in_names {
             let tag = Tag::new_checked(&axis.as_bytes()[0..4])?;
             if seen_axes.contains(&tag) {
@@ -852,6 +922,7 @@ mod fontations_impl {
             });
         }
 
+        #[allow(clippy::indexing_slicing, clippy::unwrap_used)]
         for (axis, _fallback) in fallbacks_in_siblings {
             let tag = Tag::new_checked(&axis.as_bytes()[0..4])?;
             if seen_axes.contains(&tag) {
@@ -890,7 +961,13 @@ mod fontations_impl {
         Ok(new_font.copy_missing_tables(font).build())
     }
 
-    pub fn build_filename(font: FontRef, extension: &str) -> String {
+    /// Returns the Google Fonts filename for a font, e.g.
+    /// `"RobotoFlex[GRAD,opsz,wdth,wght].ttf"`.
+    pub fn build_filename(
+        font: &[u8],
+        extension: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let font = FontRef::new(font)?;
         let family_name = best_familyname(&font)
             .unwrap_or("New Font".to_string())
             .replace(" ", "");
@@ -905,34 +982,33 @@ mod fontations_impl {
                 .collect::<Vec<_>>();
             axes.sort();
             let axes = axes.join(",");
-            return format!(
+            return Ok(format!(
                 "{}{}[{}].{}",
                 family_name,
                 if is_italic { "-Italic" } else { "" },
                 axes,
                 extension
-            );
+            ));
         }
-        format!("{family_name}-{style_name}.{extension}").replace(" ", "")
+        Ok(format!("{family_name}-{style_name}.{extension}").replace(" ", ""))
     }
 }
 
 #[cfg(feature = "fontations")]
 pub use fontations_impl::*;
 
+#[allow(clippy::indexing_slicing, clippy::unwrap_used)] // It's a test, knock yourself out
 #[cfg(test)]
 mod tests {
-    use fontations::{
-        skrifa::{string::StringId, MetadataProvider, Tag},
-        write::{
-            from_obj::ToOwnedTable,
-            tables::{
-                name::Name,
-                stat::{AxisValue, Stat},
-            },
+    use pretty_assertions::assert_eq;
+    use skrifa::{string::StringId, MetadataProvider, Tag};
+    use write_fonts::{
+        from_obj::ToOwnedTable,
+        tables::{
+            name::Name,
+            stat::{AxisValue, Stat},
         },
     };
-    use pretty_assertions::assert_eq;
 
     use super::*;
 
@@ -1277,14 +1353,13 @@ mod tests {
 
     fn run_name_table_tests(cases: &[NameTableTestCase], aggression: Option<RenameAggressiveness>) {
         for (ix, case) in cases.iter().enumerate() {
-            let font = FontRef::new(case.binary).expect("Failed to read font");
             let siblings: Vec<FontRef> = case
                 .siblings
                 .iter()
                 .map(|b| FontRef::new(b).unwrap())
                 .collect();
             let result = build_name_table(
-                font,
+                case.binary,
                 Some(case.family_name),
                 case.subfamily_name,
                 &siblings,
@@ -1403,11 +1478,11 @@ mod tests {
     #[test]
     fn test_build_stat() {
         let font_data = build_stat(
-            FontRef::new(OPEN_SANS).unwrap(),
+            OPEN_SANS,
             &[
-                FontRef::new(OPEN_SANS_ITALIC).unwrap(),
-                FontRef::new(OPEN_SANS_CONDENSED).unwrap(),
-                FontRef::new(OPEN_SANS_CONDENSED_ITALIC).unwrap(),
+                OPEN_SANS_ITALIC,
+                OPEN_SANS_CONDENSED,
+                OPEN_SANS_CONDENSED_ITALIC,
             ],
         )
         .unwrap();
@@ -1443,12 +1518,8 @@ mod tests {
     #[test]
     fn test_build_stat2() {
         let font_data = build_stat(
-            FontRef::new(OPEN_SANS_ITALIC).unwrap(),
-            &[
-                FontRef::new(OPEN_SANS).unwrap(),
-                FontRef::new(OPEN_SANS_CONDENSED).unwrap(),
-                FontRef::new(OPEN_SANS_CONDENSED_ITALIC).unwrap(),
-            ],
+            OPEN_SANS_ITALIC,
+            &[OPEN_SANS, OPEN_SANS_CONDENSED, OPEN_SANS_CONDENSED_ITALIC],
         )
         .unwrap();
         let new_font = FontRef::new(&font_data).unwrap();
@@ -1482,30 +1553,39 @@ mod tests {
 
     #[test]
     fn test_build_filename() {
-        let maven_pro = FontRef::new(MAVEN_PRO).unwrap();
-        assert_eq!(build_filename(maven_pro, "ttf"), "MavenPro-Regular.ttf");
-        let open_sans = FontRef::new(OPEN_SANS).unwrap();
-        assert_eq!(build_filename(open_sans, "ttf"), "OpenSans[wdth,wght].ttf");
-        let open_sans_italic = FontRef::new(OPEN_SANS_ITALIC).unwrap();
+        let maven_pro = MAVEN_PRO;
         assert_eq!(
-            build_filename(open_sans_italic, "ttf"),
+            build_filename(maven_pro, "ttf").unwrap(),
+            "MavenPro-Regular.ttf"
+        );
+        let open_sans = OPEN_SANS;
+        assert_eq!(
+            build_filename(open_sans, "ttf").unwrap(),
+            "OpenSans[wdth,wght].ttf"
+        );
+        let open_sans_italic = OPEN_SANS_ITALIC;
+        assert_eq!(
+            build_filename(open_sans_italic, "ttf").unwrap(),
             "OpenSans-Italic[wdth,wght].ttf"
         );
-        let open_sans_condensed = FontRef::new(OPEN_SANS_CONDENSED).unwrap();
+        let open_sans_condensed = OPEN_SANS_CONDENSED;
         assert_eq!(
-            build_filename(open_sans_condensed, "ttf"),
+            build_filename(open_sans_condensed, "ttf").unwrap(),
             "OpenSansCondensed[wght].ttf"
         );
-        let open_sans_condensed_italic = FontRef::new(OPEN_SANS_CONDENSED_ITALIC).unwrap();
+        let open_sans_condensed_italic = OPEN_SANS_CONDENSED_ITALIC;
         assert_eq!(
-            build_filename(open_sans_condensed_italic, "ttf"),
+            build_filename(open_sans_condensed_italic, "ttf").unwrap(),
             "OpenSansCondensed-Italic[wght].ttf"
         );
-        let wonky = FontRef::new(WONKY).unwrap();
-        assert_eq!(build_filename(wonky, "ttf"), "Wonky[wdth,wght].ttf");
-        let playfair = FontRef::new(PLAYFAIR).unwrap();
+        let wonky = WONKY;
         assert_eq!(
-            build_filename(playfair, "ttf"),
+            build_filename(wonky, "ttf").unwrap(),
+            "Wonky[wdth,wght].ttf"
+        );
+        let playfair = PLAYFAIR;
+        assert_eq!(
+            build_filename(playfair, "ttf").unwrap(),
             "Playfair[opsz,wdth,wght].ttf"
         );
     }

--- a/src/monkeypatching.rs
+++ b/src/monkeypatching.rs
@@ -1,7 +1,7 @@
 // STAT tables are *horrible*.
 
-use fontations::skrifa::string::StringId;
-use fontations::write::tables::stat::AxisValue as WriteAxisValue;
+use skrifa::string::StringId;
+use write_fonts::tables::stat::AxisValue as WriteAxisValue;
 
 pub(crate) trait AxisValueNameId {
     fn value_name_id(&self) -> Option<StringId>;

--- a/src/nametable.rs
+++ b/src/nametable.rs
@@ -1,8 +1,8 @@
 /// Utility functions for name table handling.
 use std::collections::HashSet;
 
-use fontations::skrifa::{string::StringId, FontRef, MetadataProvider};
-use fontations::write::tables::name::NameRecord;
+use skrifa::{string::StringId, FontRef, MetadataProvider};
+use write_fonts::tables::name::NameRecord;
 
 pub(crate) fn get_best_name(font: &FontRef, ids: &[StringId]) -> Option<String> {
     for id in ids {

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -4,11 +4,14 @@
 // We're uninterested in anything other than 3/1/0x409, so we use Strings instead
 // of the more correct NameSpec.
 
-use fontations::write::{
-    tables::{name::NameRecord, stat as write_stat},
+use std::collections::HashMap;
+use write_fonts::{
+    tables::{
+        name::NameRecord,
+        stat::{self as write_stat},
+    },
     types::{Fixed, NameId, Tag},
 };
-use std::collections::HashMap;
 
 use crate::nametable::find_or_add_name;
 
@@ -97,7 +100,8 @@ impl StatBuilder {
                 .iter()
                 .flat_map(|x| x.iter())
             {
-                let flags = write_stat::AxisValueTableFlags::from_bits(axis_value.flags).unwrap();
+                let flags = write_stat::AxisValueTableFlags::from_bits(axis_value.flags)
+                    .unwrap_or_default();
                 let name_id = find_or_add_name(name_records, &axis_value.name);
 
                 let value = match &axis_value.location {
@@ -127,7 +131,8 @@ impl StatBuilder {
             .unwrap_or_default()
             .into_iter()
             .map(|format4| {
-                let flags = write_stat::AxisValueTableFlags::from_bits(format4.flags).unwrap();
+                let flags =
+                    write_stat::AxisValueTableFlags::from_bits(format4.flags).unwrap_or_default();
                 let name_id = find_or_add_name(name_records, &format4.name);
 
                 let AxisLocation::Four(values) = &format4.location else {


### PR DESCRIPTION
This PR updates the `axisregistry` subtree with the latest release (v0.5.0) from [googlefonts/axisregistry](https://github.com/googlefonts/axisregistry). **Important:** When merging, use the **"Create a merge commit"** button, **not** "Squash and merge", to preserve subtree history and avoid future merge conflicts.